### PR TITLE
register StandardOpsDialect to the context

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@ int main(int argc, char* argv[]) {
   DialectRegistry registry;
   // NOTE: we cannot use mlir::registerAllDialects because IREE does not have
   // dependency on some of those dialects
+  registry.insert<StandardOpsDialect>();
   registry.insert<AffineDialect>();
   registry.insert<linalg::LinalgDialect>();
   registry.insert<memref::MemRefDialect>();


### PR DESCRIPTION
The op `constant` was part of the `std` dialect, but this dialect wasn't registered to the context, causing the parser to fail.
Registering `StandardOpsDialect` to the context seems to solve this issue.