### PR TITLE
Fix tinfo linking issue in MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(${PROJECT_NAME}
     MLIRSideEffectInterfaces MLIRViewLikeInterface MLIRInferTypeOpInterface
     MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRAffine MLIRMemRef
     MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport MLIRInferTypeOpInterface
-    LLVMSupport z3 pthread m tinfo)
+    LLVMSupport LLVMDemangle z3 pthread m curses)
 target_link_options(${PROJECT_NAME} PUBLIC -fPIC)
 target_compile_options(${PROJECT_NAME} PUBLIC -fno-rtti)
 target_link_directories(${PROJECT_NAME} PUBLIC ${IREE_BUILD_DIR}/third_party/llvm-project/llvm/lib)


### PR DESCRIPTION
Fix below issue

```
Undefined symbols for architecture arm64:
  "llvm::itaniumDemangle(char const*, char*, unsigned long*, int*)", referenced from:
      llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) in libLLVMSupport.a(Signals.cpp.o)
  "_del_curterm", referenced from:
      llvm::sys::Process::FileDescriptorHasColors(int) in libLLVMSupport.a(Process.cpp.o)
  "_set_curterm", referenced from:
      llvm::sys::Process::FileDescriptorHasColors(int) in libLLVMSupport.a(Process.cpp.o)
  "_setupterm", referenced from:
      llvm::sys::Process::FileDescriptorHasColors(int) in libLLVMSupport.a(Process.cpp.o)
  "_tigetnum", referenced from:
      llvm::sys::Process::FileDescriptorHasColors(int) in libLLVMSupport.a(Process.cpp.o)
ld: symbol(s) not found for architecture arm64
```