### PR TITLE
Add linalg to llvm plan conv order example

### DIFF
--- a/examples/linalg_to_llvm_plan_conv/linalg_to_llvm_plan_conv.mlir
+++ b/examples/linalg_to_llvm_plan_conv/linalg_to_llvm_plan_conv.mlir
@@ -1,0 +1,6 @@
+// RUN: iree-opt -iree-codegen-linalg-to-llvm-plan-conv-loop-order %s | IreeFileCheck %s
+
+func @conv(%filter: memref<3x3x3x32xf32>, %input: memref<1x225x225x3xf32>, %output: memref<1x112x112x32xf32>) {
+  linalg.conv(%filter, %input, %output) {dilations = [1, 1], strides = [2, 2]} : memref<3x3x3x32xf32>, memref<1x225x225x3xf32>, memref<1x112x112x32xf32>
+  return
+}

--- a/examples/linalg_to_llvm_plan_conv/linalg_to_llvm_plan_conv_opt.mlir
+++ b/examples/linalg_to_llvm_plan_conv/linalg_to_llvm_plan_conv_opt.mlir
@@ -1,0 +1,14 @@
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 * 2 + d3, d2 * 2 + d4, d5)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d6)>
+module  {
+  func @conv(%arg0: memref<3x3x3x32xf32>, %arg1: memref<1x225x225x3xf32>, %arg2: memref<1x112x112x32xf32>) {
+    linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "window", "window", "reduction", "parallel"]} ins(%arg0, %arg1 : memref<3x3x3x32xf32>, memref<1x225x225x3xf32>) outs(%arg2 : memref<1x112x112x32xf32>) {
+    ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+      %0 = mulf %arg3, %arg4 : f32
+      %1 = addf %0, %arg5 : f32
+      linalg.yield %1 : f32
+    }
+    return
+  }
+}


### PR DESCRIPTION
This pass related with lowering Linalg convolution into CPU friendly iterator order.
The iteration order is specified using affine map with `linalg.generic`op.
```
def LinalgToLLVMPlanConvLoopOrder :
    Pass<"iree-codegen-linalg-to-llvm-plan-conv-loop-order", "FuncOp"> {
  let summary = "Convert linalg.conv to linalg.generic with a CPU-friendly iterator order";
  let constructor = "mlir::iree_compiler::createLinalgToLLVMPlanConvLoopOrderPass()";
}
```