### PR TITLE
Add fold tensor extract op examples

### DIFF
--- a/examples/fold_tensor_extract_op/fold_tensor_extract_op.mlir
+++ b/examples/fold_tensor_extract_op/fold_tensor_extract_op.mlir
@@ -1,0 +1,10 @@
+// RUN: iree-opt -iree-codegen-fold-tensor-extract-op %s | IreeFileCheck %s
+
+func @fold_tensor_extract(%arg0 : memref<2x3xi32>) -> i32
+{
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  %0 = memref.tensor_load %arg0 : memref<2x3xi32>
+  %1 = tensor.extract %0[%c1, %c2] : tensor<2x3xi32>
+  return %1 : i32
+}

--- a/examples/fold_tensor_extract_op/fold_tensor_extract_op_opt.mlir
+++ b/examples/fold_tensor_extract_op/fold_tensor_extract_op_opt.mlir
@@ -1,0 +1,8 @@
+module  {
+  func @fold_tensor_extract(%arg0: memref<2x3xi32>) -> i32 {
+    %c1 = constant 1 : index
+    %c2 = constant 2 : index
+    %0 = memref.load %arg0[%c1, %c2] : memref<2x3xi32>
+    return %0 : i32
+  }
+}


### PR DESCRIPTION
This pass is specifically undoing the canonicalization by folding `(tensor_extract (tensor_load (get_global_memref:$value), $indices)` to `(load $value, $indices)`


```
def FoldTensorExtractOp :
  Pass<"iree-codegen-fold-tensor-extract-op", ""> {
  let summary = "Fold `tensor.extract` operations prior to lowering to LLVM";
  let constructor = "mlir::iree_compiler::createFoldTensorExtractOpPass()";
}
```