### PR TITLE
Add link_directories in unittests CMakeLists.txt

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -13,6 +13,7 @@ link_libraries(gtest_main)
 include_directories(${PROJECT_SOURCE_DIR})
 
 link_directories(${IREE_BUILD_DIR}/third_party/llvm-project/llvm/lib)
+link_directories(${Z3_LIBRARY_DIR})
 link_libraries(
     MLIRStandard MLIRControlFlowInterfaces
     MLIRSideEffectInterfaces MLIRViewLikeInterface MLIRInferTypeOpInterface


### PR DESCRIPTION
![스크린샷 2021-07-06 오후 12 39 47](https://user-images.githubusercontent.com/15178067/124538913-6dc3c680-de57-11eb-8534-26ff42cb9ca1.png)

I have a problem when linking z3 library in unit tests directory.
I think in unittests directory there is no hint where z3 library exists, so I added `link_directory` z3 in CMakeLists.txt