### PR TITLE
Reconfigure CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 3.15.0)
 project(iree-tv VERSION 0.1.0)
 set (CMAKE_CXX_STANDARD 17)
 
-set(IREE_DIR "/opt/iree" CACHE STRING "IREE source top-level directory")
-set(IREE_BUILD_DIR "/opt/iree/build" CACHE STRING "IREE build top-level directory")
-set(Z3_DIR "/opt/z3" CACHE STRING "Z3 source top-level directory")
-set(Z3_BUILD_DIR "/opt/z3/build" CACHE STRING "Z3 build top-level directory")
+set(IREE_SRC_DIR "" CACHE STRING "IREE source top-level directory")
+set(IREE_INST_DIR "" CACHE STRING "IREE installation top-level directory")
+set(Z3_SRC_DIR "" CACHE STRING "Z3 source top-level directory")
+set(Z3_INST_DIR "" CACHE STRING "Z3 installation top-level directory")
 
-set(Z3_API_DIR "${Z3_DIR}/src/api")
+set(Z3_API_DIR "${Z3_SRC_DIR}/src/api")
 set(Z3_CPP_DIR "${Z3_API_DIR}/c++")
 
 add_executable(${PROJECT_NAME}
@@ -17,7 +17,6 @@ add_executable(${PROJECT_NAME}
     src/tensor.cpp
     src/smt.cpp)
 
-#target_link_options(${PROJECT_NAME} PUBLIC -lz3 -ltinfo -lLLVMSupport -lMLIRStandard -lMLIRControlFlowInterfaces -lMLIRSideEffectInterfaces -lMLIRViewLikeInterface -lMLIRInferTypeOpInterface -lMLIRIR -lMLIRDialect -lMLIRDialectUtils -lMLIRLinalg -lMLIRAffine -lMLIRMemRef -lMLIRMemRefUtils -lMLIRTensor -lMLIRParser -lMLIRSupport -lpthread -lm -fPIC)
 target_link_libraries(${PROJECT_NAME}
     MLIRStandard MLIRControlFlowInterfaces
     MLIRSideEffectInterfaces MLIRViewLikeInterface MLIRInferTypeOpInterface
@@ -26,12 +25,12 @@ target_link_libraries(${PROJECT_NAME}
     LLVMSupport LLVMDemangle z3 pthread m curses)
 target_link_options(${PROJECT_NAME} PUBLIC -fPIC)
 target_compile_options(${PROJECT_NAME} PUBLIC -fno-rtti)
-target_link_directories(${PROJECT_NAME} PUBLIC ${IREE_BUILD_DIR}/third_party/llvm-project/llvm/lib)
-target_link_directories(${PROJECT_NAME} PUBLIC ${Z3_BUILD_DIR})
+target_link_directories(${PROJECT_NAME} PUBLIC ${IREE_INST_DIR}/third_party/llvm-project/llvm/lib)
+target_link_directories(${PROJECT_NAME} PUBLIC ${Z3_INST_DIR})
 
 # IREE include directories
-include_directories(${IREE_DIR}/third_party/llvm-project/llvm/include ${IREE_DIR}/third_party/llvm-project/mlir/include)
-include_directories(${IREE_BUILD_DIR}/third_party/llvm-project/llvm/include ${IREE_BUILD_DIR}/third_party/llvm-project/llvm/tools/mlir/include)
+include_directories(${IREE_SRC_DIR}/third_party/llvm-project/llvm/include ${IREE_SRC_DIR}/third_party/llvm-project/mlir/include)
+include_directories(${IREE_INST_DIR}/third_party/llvm-project/llvm/include ${IREE_INST_DIR}/third_party/llvm-project/llvm/tools/mlir/include)
 
 # Z3 API directories
 include_directories(${Z3_API_DIR})

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Prerequisites: [CMake](https://cmake.org/download/)(>=3.15),
 mkdir build
 cd build
 # If you want to build a release version, please add -DCMAKE_BUILD_TYPE=RELEASE
-cmake -DIREE_DIR=<dir/to/iree> \
-      -DIREE_BUILD_DIR=<dir/to/iree-build> \
-      -DZ3_DIR=<dir/to/z3> \
-      -DZ3_BUILD_DIR=<dir/to/z3-build/> \
+cmake -DIREE_SRC_DIR=<dir/to/iree-src> \
+      -DIREE_INST_DIR=<dir/to/iree-installation> \
+      -DZ3_SRC_DIR=<dir/to/z3-src> \
+      -DZ3_INST_DIR=<dir/to/z3-installation> \
       ..
 cmake --build .
 ```
@@ -30,8 +30,8 @@ iree-tv <.mlir before opt> <.mlir after opt>`
 ## How to test IREE-TV
 ```bash
 cd build
+# A detailed log is written to build/Testing/Temporary/LastTest.log
 # If you want detailed output on the terminal, please add -V
 ctest -R Unit
-# A detailed log is written to build/Testing/Temporary/LastTest.log
 ctest -R Passes # Test IR transformation passes
 ```

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -12,8 +12,8 @@ FetchContent_MakeAvailable(googletest)
 link_libraries(gtest_main)
 include_directories(${PROJECT_SOURCE_DIR})
 
-link_directories(${IREE_BUILD_DIR}/third_party/llvm-project/llvm/lib)
-link_directories(${Z3_BUILD_DIR})
+link_directories(${IREE_INST_DIR}/third_party/llvm-project/llvm/lib)
+link_directories(${Z3_INST_DIR})
 link_libraries(
     MLIRStandard MLIRControlFlowInterfaces
     MLIRSideEffectInterfaces MLIRViewLikeInterface MLIRInferTypeOpInterface


### PR DESCRIPTION
This PR changes the configuration methods for CMake

- Changed CMake variables for configuring Z3 to use higher-directory paths
- Updated README