### PR TITLE
Optimized vector insertions

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -305,9 +305,9 @@ vector<z3::expr> Tensor::getDims(mlir::TensorType tensorTy) {
     if (sz == (uint64_t)-1ull)
       // TODO: this requires encoding of well-formedness of input tensors.
       // dims.emplace_back(Index("dim" + to_string(dim_var++)));
-      dims.push_back(std::move(Index(100)));
+      dims.push_back(Index(100));
     else
-      dims.push_back(std::move(Index(sz)));
+      dims.push_back(Index(sz));
   }
 
   return dims;


### PR DESCRIPTION
This PR optimizes some vector insertions.

Most of the changes are replacing `emplace_back()` with `push_back()` (with`std::move()` if possible).
Because using `emplace_back()` on `std::vector` calls copy constructor, the current code induces both copy and construction overhead. In most of the uses the objects are already constructed, so we don't have to use `emplace_back()`. Then I `move`d the temporary objects if they are made only for insertion.

Also, I added some `reserve()` if we can predict the number of insertions in advance.