### PR TITLE
Implemented VERIFY-INCORRECT testing

### DIFF
--- a/tests/lit/formats/mlirtest.py
+++ b/tests/lit/formats/mlirtest.py
@@ -1,3 +1,5 @@
+from abc import abstractmethod
+from enum import Enum, auto
 from lit.formats.base import TestFormat
 import lit
 from lit.Test import *
@@ -23,13 +25,36 @@ def _executeCommand(command: List[str]):
 
     return out, err, exitCode
 
+class TestKeyword(Enum):
+    NOTEST = auto()
+    VERIFY = auto()
+    VERIFY_INCORRECT = auto()
+
+def _check_exit_code(keyword: TestKeyword, outs: str, errs: str, exit_code: int):
+    if keyword == TestKeyword.VERIFY:
+        if exit_code == 0:
+            return lit.Test.PASS, ""
+        elif exit_code == 1:
+            return lit.Test.TIMEOUT, ""
+        else:
+            return lit.Test.FAIL, outs + errs
+    
+    elif keyword == TestKeyword.VERIFY_INCORRECT:
+        if exit_code == 0:
+            return lit.Test.FAIL, "This test must fail!"
+        elif exit_code == 1:
+            return lit.Test.TIMEOUT, ""
+        else:
+            return lit.Test.PASS, ""
+
 class MLIRTest(TestFormat):
+    __suffix_src: str = ".src.mlir"
+    __suffix_tgt: str = ".tgt.mlir"
+    __verify_regex = re.compile(r"^// ?VERIFY$")
+    __verify_incorrect_regex = re.compile(r"^// ?VERIFY-INCORRECT$")
+
+    @abstractmethod
     def __init__(self, dir_tv: str) -> None:
-        self.__regex_verify = re.compile(r"^// ?VERIFY")
-        self.__regex_src = re.compile(r".+\.src\.mlir$")
-        self.__regex_tgt = re.compile(r".+\.tgt\.mlir$")
-        self.__suffix_src: str = ".src.mlir"
-        self.__suffix_tgt: str = ".tgt.mlir"
         self.__dir_tv: str = dir_tv
 
     def getTestsInDirectory(self, testSuite, path_in_suite, litConfig, localConfig):
@@ -39,35 +64,33 @@ class MLIRTest(TestFormat):
                 , os.listdir(source_path)):
             pass_path: str = os.path.join(source_path, pass_name)
             for case_src_name in filter(lambda name: (os.path.isfile(os.path.join(pass_path, name)) \
-                        and self.__regex_src.match(name) \
+                        and name.endswith(MLIRTest.__suffix_src)
                         and not _starts_with_dot(name))
                     , os.listdir(pass_path)):
-                case_src_file_name: str = os.path.join(pass_path, case_src_name)
-                with open(case_src_file_name, 'r') as case_src_file:
-                    has_verify: bool = False
-                    for line in case_src_file.readlines():
-                        if self.__regex_verify.match(line):
-                            has_verify = True
-                            break
-                if has_verify:
-                    case_name: str = case_src_name.removesuffix(self.__suffix_src)
-                    yield lit.Test.Test(testSuite, path_in_suite + (os.path.join(pass_name, case_name),), localConfig)
+                case_name: str = case_src_name.removesuffix(MLIRTest.__suffix_src)
+                yield lit.Test.Test(testSuite, path_in_suite + (os.path.join(pass_name, case_name),), localConfig)
 
-    def execute(self, test, litConfig):
+    def execute(self, test, litConfig) -> lit.Test:
         test = test.getSourcePath()
-        tc_src = test + self.__suffix_src
-        tc_tgt = test + self.__suffix_tgt
+        tc_src = test + MLIRTest.__suffix_src
+        tc_tgt = test + MLIRTest.__suffix_tgt
         if not (os.path.isfile(tc_src) and os.path.isfile(tc_tgt)):
             # src or tgt mlir file is missing
             return lit.Test.SKIPPED
 
-        cmd = [self.__dir_tv, "-smt-to=10000", tc_src, tc_tgt]
-        outs, errs, exit_code = _executeCommand(cmd)
-        output = outs + errs
+        test_keyword = TestKeyword.NOTEST
+        with open(tc_src, 'r') as src_file:
+            for line in src_file.readlines():
+                if MLIRTest.__verify_regex.match(line):
+                    test_keyword = TestKeyword.VERIFY
+                    break
+                elif MLIRTest.__verify_incorrect_regex.match(line):
+                    test_keyword = TestKeyword.VERIFY_INCORRECT
+                    break
 
-        if exit_code == 0:
-            return lit.Test.PASS, ''
-        elif exit_code == 1:
-            return lit.Test.TIMEOUT, ""
+        if test_keyword == TestKeyword.NOTEST:
+            # file does not include test keyword
+            return lit.Test.SKIPPED
         else:
-            return lit.Test.FAIL, output
+            cmd = [self.__dir_tv, "-smt-to=10000", tc_src, tc_tgt]
+            return _check_exit_code(test_keyword, *_executeCommand(cmd))


### PR DESCRIPTION
This PR implements execution of 'negative tests' as intended.

`Passes` test now distinguishes `// VERIFY` and `// VERIFY-INCORRECT`.
- `// VERIFY` -> Maps `iree-tv`'s correct to PASS, mismatch to FAIL
- `// VERIFY-INCORRECT` -> Maps `iree-tv`'s correct to FAIL, mismatch to PASS