### PR TITLE
Upload : loop-invariant-code-motion test cases (#29)

### DIFF
--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0000.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0000.src.mlir
@@ -1,0 +1,21 @@
+// VERIFY
+
+func @nested_loops_both_having_invariant_code() {
+  %m = memref.alloc() : memref<10xf32>
+  %cf7 = constant 7.0 : f32
+  %cf8 = constant 8.0 : f32
+
+  affine.for %arg0 = 0 to 10 {
+    %v0 = addf %cf7, %cf8 : f32
+    affine.for %arg1 = 0 to 10 {
+      %v1 = addf %v0, %cf8 : f32
+      affine.store %v0, %m[%arg0] : memref<10xf32>
+    }
+  }
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0000.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0000.tgt.mlir
@@ -1,0 +1,16 @@
+module  {
+  func @nested_loops_both_having_invariant_code() {
+    %0 = memref.alloc() : memref<10xf32>
+    %cst = constant 7.000000e+00 : f32
+    %cst_0 = constant 8.000000e+00 : f32
+    %1 = addf %cst, %cst_0 : f32
+    %2 = addf %1, %cst_0 : f32
+    affine.for %arg0 = 0 to 10 {
+      affine.for %arg1 = 0 to 10 {
+        affine.store %1, %0[%arg0] : memref<10xf32>
+      }
+    }
+    return
+  }
+}
+

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0001.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0001.src.mlir
@@ -1,0 +1,19 @@
+// VERIFY
+
+func @nested_loops_code_invariant_to_both() {
+  %m = memref.alloc() : memref<10xf32>
+  %cf7 = constant 7.0 : f32
+  %cf8 = constant 8.0 : f32
+
+  affine.for %arg0 = 0 to 10 {
+    affine.for %arg1 = 0 to 10 {
+      %v0 = addf %cf7, %cf8 : f32
+    }
+  }
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0001.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0001.tgt.mlir
@@ -1,0 +1,14 @@
+module  {
+  func @nested_loops_code_invariant_to_both() {
+    %0 = memref.alloc() : memref<10xf32>
+    %cst = constant 7.000000e+00 : f32
+    %cst_0 = constant 8.000000e+00 : f32
+    %1 = addf %cst, %cst_0 : f32
+    affine.for %arg0 = 0 to 10 {
+    }
+    affine.for %arg0 = 0 to 10 {
+    }
+    return
+  }
+}
+

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0002.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0002.src.mlir
@@ -1,0 +1,18 @@
+// VERIFY
+
+func @single_loop_nothing_invariant() {
+  %m1 = memref.alloc() : memref<10xf32>
+  %m2 = memref.alloc() : memref<10xf32>
+  affine.for %arg0 = 0 to 10 {
+    %v0 = affine.load %m1[%arg0] : memref<10xf32>
+    %v1 = affine.load %m2[%arg0] : memref<10xf32>
+    %v2 = addf %v0, %v1 : f32
+    affine.store %v2, %m1[%arg0] : memref<10xf32>
+  }
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0002.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0002.tgt.mlir
@@ -1,0 +1,14 @@
+module  {
+  func @single_loop_nothing_invariant() {
+    %0 = memref.alloc() : memref<10xf32>
+    %1 = memref.alloc() : memref<10xf32>
+    affine.for %arg0 = 0 to 10 {
+      %2 = affine.load %0[%arg0] : memref<10xf32>
+      %3 = affine.load %1[%arg0] : memref<10xf32>
+      %4 = addf %2, %3 : f32
+      affine.store %4, %0[%arg0] : memref<10xf32>
+    }
+    return
+  }
+}
+

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0003.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0003.src.mlir
@@ -1,0 +1,22 @@
+// VERIFY
+
+func @invariant_code_inside_affine_if() {
+  %m = memref.alloc() : memref<10xf32>
+  %cf8 = constant 8.0 : f32
+
+  affine.for %arg0 = 0 to 10 {
+    %t0 = affine.apply affine_map<(d1) -> (d1 + 1)>(%arg0)
+    affine.if affine_set<(d0, d1) : (d1 - d0 >= 0)> (%arg0, %t0) {
+        %cf9 = addf %cf8, %cf8 : f32
+        affine.store %cf9, %m[%arg0] : memref<10xf32>
+
+    }
+  }
+
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0003.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0003.tgt.mlir
@@ -1,0 +1,17 @@
+#map = affine_map<(d0) -> (d0 + 1)>
+#set = affine_set<(d0, d1) : (d1 - d0 >= 0)>
+module  {
+  func @invariant_code_inside_affine_if() {
+    %0 = memref.alloc() : memref<10xf32>
+    %cst = constant 8.000000e+00 : f32
+    affine.for %arg0 = 0 to 10 {
+      %1 = affine.apply #map(%arg0)
+      affine.if #set(%arg0, %1) {
+        %2 = addf %cst, %cst : f32
+        affine.store %2, %0[%arg0] : memref<10xf32>
+      }
+    }
+    return
+  }
+}
+

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0004.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0004.src.mlir
@@ -1,0 +1,19 @@
+// VERIFY
+
+func @invariant_affine_if() {
+  %m = memref.alloc() : memref<10xf32>
+  %cf8 = constant 8.0 : f32
+  affine.for %arg0 = 0 to 10 {
+    affine.for %arg1 = 0 to 10 {
+      affine.if affine_set<(d0, d1) : (d1 - d0 >= 0)> (%arg0, %arg0) {
+          %cf9 = addf %cf8, %cf8 : f32
+      }
+    }
+  }
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0004.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0004.tgt.mlir
@@ -1,0 +1,16 @@
+#set = affine_set<(d0, d1) : (d1 - d0 >= 0)>
+module  {
+  func @invariant_affine_if() {
+    %0 = memref.alloc() : memref<10xf32>
+    %cst = constant 8.000000e+00 : f32
+    affine.for %arg0 = 0 to 10 {
+    }
+    affine.for %arg0 = 0 to 10 {
+      affine.if #set(%arg0, %arg0) {
+        %1 = addf %cst, %cst : f32
+      }
+    }
+    return
+  }
+}
+

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0005.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0005.src.mlir
@@ -1,0 +1,20 @@
+// VERIFY
+
+func @invariant_affine_if2() {
+  %m = memref.alloc() : memref<10xf32>
+  %cf8 = constant 8.0 : f32
+  affine.for %arg0 = 0 to 10 {
+    affine.for %arg1 = 0 to 10 {
+      affine.if affine_set<(d0, d1) : (d1 - d0 >= 0)> (%arg0, %arg0) {
+          %cf9 = addf %cf8, %cf8 : f32
+          affine.store %cf9, %m[%arg1] : memref<10xf32>
+      }
+    }
+  }
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0005.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0005.tgt.mlir
@@ -1,0 +1,17 @@
+#set = affine_set<(d0, d1) : (d1 - d0 >= 0)>
+module  {
+  func @invariant_affine_if2() {
+    %0 = memref.alloc() : memref<10xf32>
+    %cst = constant 8.000000e+00 : f32
+    affine.for %arg0 = 0 to 10 {
+      affine.for %arg1 = 0 to 10 {
+        affine.if #set(%arg0, %arg0) {
+          %1 = addf %cst, %cst : f32
+          affine.store %1, %0[%arg1] : memref<10xf32>
+        }
+      }
+    }
+    return
+  }
+}
+

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0006.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0006.src.mlir
@@ -1,0 +1,23 @@
+// VERIFY
+
+func @invariant_affine_nested_if() {
+  %m = memref.alloc() : memref<10xf32>
+  %cf8 = constant 8.0 : f32
+  affine.for %arg0 = 0 to 10 {
+    affine.for %arg1 = 0 to 10 {
+      affine.if affine_set<(d0, d1) : (d1 - d0 >= 0)> (%arg0, %arg0) {
+          %cf9 = addf %cf8, %cf8 : f32
+          affine.if affine_set<(d0, d1) : (d1 - d0 >= 0)> (%arg0, %arg0) {
+            %cf10 = addf %cf9, %cf9 : f32
+          }
+      }
+    }
+  }
+
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0006.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0006.tgt.mlir
@@ -1,0 +1,19 @@
+#set = affine_set<(d0, d1) : (d1 - d0 >= 0)>
+module  {
+  func @invariant_affine_nested_if() {
+    %0 = memref.alloc() : memref<10xf32>
+    %cst = constant 8.000000e+00 : f32
+    affine.for %arg0 = 0 to 10 {
+      affine.for %arg1 = 0 to 10 {
+        affine.if #set(%arg0, %arg0) {
+          %1 = addf %cst, %cst : f32
+          affine.if #set(%arg0, %arg0) {
+            %2 = addf %1, %1 : f32
+          }
+        }
+      }
+    }
+    return
+  }
+}
+

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0007.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0007.src.mlir
@@ -1,0 +1,26 @@
+// VERIFY
+
+func @invariant_affine_nested_if_else() {
+  %m = memref.alloc() : memref<10xf32>
+  %cf8 = constant 8.0 : f32
+  affine.for %arg0 = 0 to 10 {
+    affine.for %arg1 = 0 to 10 {
+      affine.if affine_set<(d0, d1) : (d1 - d0 >= 0)> (%arg0, %arg0) {
+          %cf9 = addf %cf8, %cf8 : f32
+          affine.store %cf9, %m[%arg0] : memref<10xf32>
+          affine.if affine_set<(d0, d1) : (d1 - d0 >= 0)> (%arg0, %arg0) {
+            %cf10 = addf %cf9, %cf9 : f32
+          } else {
+            affine.store %cf9, %m[%arg1] : memref<10xf32>
+          }
+      }
+    }
+  }
+
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0007.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0007.tgt.mlir
@@ -1,0 +1,22 @@
+#set = affine_set<(d0, d1) : (d1 - d0 >= 0)>
+module  {
+  func @invariant_affine_nested_if_else() {
+    %0 = memref.alloc() : memref<10xf32>
+    %cst = constant 8.000000e+00 : f32
+    affine.for %arg0 = 0 to 10 {
+      affine.for %arg1 = 0 to 10 {
+        affine.if #set(%arg0, %arg0) {
+          %1 = addf %cst, %cst : f32
+          affine.store %1, %0[%arg0] : memref<10xf32>
+          affine.if #set(%arg0, %arg0) {
+            %2 = addf %1, %1 : f32
+          } else {
+            affine.store %1, %0[%arg1] : memref<10xf32>
+          }
+        }
+      }
+    }
+    return
+  }
+}
+

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0008.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0008.src.mlir
@@ -1,0 +1,21 @@
+// VERIFY
+
+func @invariant_loop_dialect() {
+  %ci0 = constant 0 : index
+  %ci10 = constant 10 : index
+  %ci1 = constant 1 : index
+  %m = memref.alloc() : memref<10xf32>
+  %cf7 = constant 7.0 : f32
+  %cf8 = constant 8.0 : f32
+  scf.for %arg0 = %ci0 to %ci10 step %ci1 {
+    scf.for %arg1 = %ci0 to %ci10 step %ci1 {
+      %v0 = addf %cf7, %cf8 : f32
+    }
+  }
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0008.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0008.tgt.mlir
@@ -1,0 +1,17 @@
+module  {
+  func @invariant_loop_dialect() {
+    %c0 = constant 0 : index
+    %c10 = constant 10 : index
+    %c1 = constant 1 : index
+    %0 = memref.alloc() : memref<10xf32>
+    %cst = constant 7.000000e+00 : f32
+    %cst_0 = constant 8.000000e+00 : f32
+    %1 = addf %cst, %cst_0 : f32
+    scf.for %arg0 = %c0 to %c10 step %c1 {
+    }
+    scf.for %arg0 = %c0 to %c10 step %c1 {
+    }
+    return
+  }
+}
+

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0009.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0009.src.mlir
@@ -1,0 +1,19 @@
+// VERIFY
+
+func @variant_loop_dialect() {
+  %ci0 = constant 0 : index
+  %ci10 = constant 10 : index
+  %ci1 = constant 1 : index
+  %m = memref.alloc() : memref<10xf32>
+  scf.for %arg0 = %ci0 to %ci10 step %ci1 {
+    scf.for %arg1 = %ci0 to %ci10 step %ci1 {
+      %v0 = addi %arg0, %arg1 : index
+    }
+  }
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0009.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0009.tgt.mlir
@@ -1,0 +1,15 @@
+module  {
+  func @variant_loop_dialect() {
+    %c0 = constant 0 : index
+    %c10 = constant 10 : index
+    %c1 = constant 1 : index
+    %0 = memref.alloc() : memref<10xf32>
+    scf.for %arg0 = %c0 to %c10 step %c1 {
+      scf.for %arg1 = %c0 to %c10 step %c1 {
+        %1 = addi %arg0, %arg1 : index
+      }
+    }
+    return
+  }
+}
+

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0010.src.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0010.src.mlir
@@ -1,0 +1,19 @@
+// VERIFY
+
+func @parallel_loop_with_invariant() {
+  %c0 = constant 0 : index
+  %c10 = constant 10 : index
+  %c1 = constant 1 : index
+  %c7 = constant 7 : i32
+  %c8 = constant 8 : i32
+  scf.parallel (%arg0, %arg1) = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
+      %v0 = addi %c7, %c8 : i32
+      %v3 = addi %arg0, %arg1 : index
+  }
+
+
+  return
+}
+
+// How to reproduce tgt:
+// mlir-opt -split-input-file -loop-invariant-code-motion <src>

--- a/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0010.tgt.mlir
+++ b/tests/cases/loop-invariant-code-motion/loop-invariant-code-motion_0010.tgt.mlir
@@ -1,0 +1,16 @@
+module  {
+  func @parallel_loop_with_invariant() {
+    %c0 = constant 0 : index
+    %c10 = constant 10 : index
+    %c1 = constant 1 : index
+    %c7_i32 = constant 7 : i32
+    %c8_i32 = constant 8 : i32
+    %0 = addi %c7_i32, %c8_i32 : i32
+    scf.parallel (%arg0, %arg1) = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
+      %1 = addi %arg0, %arg1 : index
+      scf.yield
+    }
+    return
+  }
+}
+


### PR DESCRIPTION
(#29) 

This case should be run with these arguments ```-split-input-file -loop-invariant-code-motion```  as flags 

Please check if naming convention is appropriate, I will continue to use like this.
```loop-invariant-code-motion_[<number>].(src|tgt).mlir```


test cases source:
https://github.com/llvm/llvm-project/blob/main/mlir/test/Transforms/loop-invariant-code-motion.mlir