### PR TITLE
Fix redundant memref writable encoding

### DIFF
--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -294,8 +294,6 @@ optional<string> encodeOp(State &st, mlir::memref::TensorLoadOp op) {
   auto memBlock = st.m.getMemBlock(m.getBID());
   memBlock.writable = ctx.bool_val(false);
 
-  st.m.getMemBlock(m.getBID()).writable = ctx.bool_val(false);
-
   // step2. create new Tensor that alias origin memref using Tensor::mkLambda
   auto dims = m.getDims();
   auto memrefSize = get1DSize(dims);


### PR DESCRIPTION
I missed to remove original line of writable encoding (same encoding is done right above line 😅)