### PR TITLE
Refactoring MLIRTest to better support various test syntax

### DIFF
--- a/tests/lit/formats/mlirtest.py
+++ b/tests/lit/formats/mlirtest.py
@@ -33,9 +33,6 @@ class TestMetaData:
     def __init__(self) -> None:
         pass
 
-    def __repr__(self) -> str:
-        return ""
-
 class TestInfo:
     def __init__(self, keyword: TestKeyword, metadata: Optional[TestMetaData] = None) -> None:
         self.__keyword: TestKeyword = keyword
@@ -44,8 +41,8 @@ class TestInfo:
     def __eq__(self, other: TestKeyword) -> bool:
         return self.__keyword == other
 
-    def getData(self) -> str:
-        return f"{self.__metadata}"
+    def getData(self) -> Optional[TestMetaData]:
+        return self.__metadata
 
 def _includes_unsupported_message(errs: str) -> bool:
     keywords: list[str] = ["Unknown"]


### PR DESCRIPTION
This PR slightly refactors the internal structure of MLIRTest.

In order to support arbitrary data that the test syntax may provide, a separate class for metadata has been added. So from now on, any test syntax will now be parsed into two parts: a test keyword and (optional) metadata