### PR TITLE
Implemented EXPECT test keyword

### DIFF
--- a/tests/opts/README.md
+++ b/tests/opts/README.md
@@ -15,6 +15,7 @@ Use suffix `-bad` for `// VERIFY-INCORRECT` test cases
 `// VERIFY` : check if the transformation is correct  
 `// VERIFY-INCORRECT` : check if the transformation is indeed wrong
 `// UNSUPPORTED` : ignore test case that includes **yet** unimplemented dialects
+`// EXPECT "<message>"` : check if the stdout/stderr includes the provided message
 
 ## And some more
 Each `.src.mlir` file must include the command used to create the pair `.tgt.mlir` file. For now they are written in the first-line comment. The `iree-opt` flag sometimes isn't identical to the pass name, so reproducing the src-tgt pair becomes troublesome. Including the flag(command) will be very much appreciated for this reason ;)  


### PR DESCRIPTION
This PR implements a new test keyword EXPECT. In short, this keyword matches a string literal to outputs from iree-tv.

EXPECT keyword can be used like `// EXPECT "<message>"`. Then, the test will check if any of the stdout/stderr includes the `<message>`.
Note that exit codes are completely ignored in this process.