### PR TITLE
Fix value refinement using == operator

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -32,7 +32,7 @@ SingleArrayMemory::refines(const Memory &other) const {
   auto tgtWritable = other.getWritable(bid);
   // define memory refinement using writable refinement and value refinement
   auto wRefinement = z3::implies(srcWritable, tgtWritable);
-  auto vRefinement = z3::eq(tgtValue, srcValue);
+  auto vRefinement = (tgtValue == srcValue);
   auto refinement = z3::implies(tgtSuccess, srcSuccess && wRefinement && vRefinement);
   return {refinement, {bid, offset}};
 }
@@ -186,7 +186,7 @@ MultipleArrayMemory::refines(const Memory &other0) const {
     auto tgtWritable = other.getWritable(ubid);
 
     auto wRefinement = z3::implies(srcWritable, tgtWritable);
-    auto vRefinement = z3::eq(tgtValue, srcValue);
+    auto vRefinement = (tgtValue == srcValue);
     return z3::implies(tgtSuccess, srcSuccess && wRefinement && vRefinement);
   };
 


### PR DESCRIPTION
`z3::eq` checks two expression is exactly same and return just boolean value.
But what we want to check is two expression evaluated to same value for every valid input data.
To do this rather than use `z3::eq` operation, we use == operation which returns z3::expr.