### PR TITLE
Support symbol encoding in affine apply

### DIFF
--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -564,25 +564,18 @@ optional<string> encodeOp(State &st, mlir::AffineApplyOp op) {
   if (m.getNumResults() != 1)
     return "num results is larger than one";
 
-  // AffineMap map = op.getAffineMap();
-  // ValueRange dimOperands = op.getMapOperands().take_front(map.getNumDims());
-  // ValueRange symbolOperands =
-      // op.getMapOperands().take_back(map.getNumSymbols());
   auto dimOperands = op.mapOperands().take_front(m.getNumDims());
   auto symbolOperands = op.mapOperands().take_back(m.getNumSymbols());
 
-  vector<Index> indices;
-  for (auto arg: dimOperands) {
+  vector<Index> indices, symbols;
+  for (auto arg: dimOperands)
     indices.push_back(st.regs.get<Index>(arg));
-  }
-  vector<Index> symbols;
-  for (auto symbol: symbolOperands) {
+  for (auto symbol: symbolOperands)
     symbols.push_back(st.regs.get<Index>(symbol));
-  }
+
   auto res = encodeAffineExpr(m.getResult(0), indices, symbols);
   if (!res)
     return "unsupported affine expr";
-  llvm::outs() << "RES: " << *res << "\n";
   st.regs.add(op, Index(move(*res)));
   return {};
 }


### PR DESCRIPTION
Add support symbol encoding in Affine Apply Operation.
The indexing logic (SymbolOperands comes after DimOperands) is from `Dialect/Affine/IR/AffineOps.cpp/remainsLegalAfterInline` in MLIR

```
MLIR expression : %0 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%arg5)[%arg1]
Z3-expression : (bvadd arg5 arg1)
```