### PR TITLE
Specify exit codes for various iree-tv exit conditions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,14 +60,14 @@ static unsigned validateBuffer(unique_ptr<llvm::MemoryBuffer> srcBuffer,
 
   auto ir_before = parseSourceFile(src_sourceMgr, context);
   if (!ir_before) {
-    llvm::errs() << "Cannot read source file\n";
-    return 65;
+    llvm::errs() << "Cannot parse source file\n";
+    return 81;
   }
 
   auto ir_after = parseSourceFile(tgt_sourceMgr, context);
   if (!ir_after) {
-    llvm::errs() << "Cannot read target file\n";
-    return 66;
+    llvm::errs() << "Cannot parse target file\n";
+    return 82;
   }
 
   return validate(ir_before, ir_after,
@@ -86,7 +86,7 @@ static unsigned splitAndValidateBuffer(unique_ptr<llvm::MemoryBuffer> srcBuffer,
   tgtMemBuffer->getBuffer().split(targetBuffers, splitMarker);
 
   if (sourceBuffers.size() != targetBuffers.size()) {
-    return 64;
+    return 65;
   }
 
   unsigned retcode = 0;
@@ -128,13 +128,13 @@ int main(int argc, char* argv[]) {
   auto src_file = openInputFile(filename_src, &errorMessage);
   if (!src_file) {
     llvm::errs() << errorMessage << "\n";
-    return 67;
+    return 66;
   }
 
   auto tgt_file = openInputFile(filename_tgt, &errorMessage);
   if (!tgt_file) {
     llvm::errs() << errorMessage << "\n";
-    return 68;
+    return 66;
   }
 
   unsigned verificationResult;

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -1304,7 +1304,7 @@ static Results tryValidation(
   auto src = vinput.src, tgt = vinput.tgt;
   auto raiseUnsupported = [](const string &msg) {
     llvm::errs() << msg << "\n";
-    exit(1);
+    exit(91);
   };
 
   if (auto errmsg = checkFunctionSignatures(src, tgt))

--- a/src/vcgen.h
+++ b/src/vcgen.h
@@ -8,7 +8,10 @@
 class Results {
 public:
   enum Code {
-    SUCCESS = 0, TIMEOUT, RETVALUE, UB
+    SUCCESS = 0,
+    TIMEOUT = 101,
+    RETVALUE = 102,
+    UB = 103,
   };
 
   // Returns true if the value equals zero.


### PR DESCRIPTION
This PR introduces new exit codes to `iree-tv`, in order to better represent the reason of termination.
See [here](https://github.com/aqjune/iree-tv/issues/63) for details.

Also, MLIRTest uses the new exit codes for more precise analysis.