### PR TITLE
Fix linalg.generic encoding when zero sized tensor.

### DIFF
--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -770,7 +770,8 @@ encodeUBForTensorShapeMatch(State &st, mlir::linalg::GenericOp op,
     if (!ae)
       return "unsupported affine expr";
 
-    z3::expr inbounds = z3::ult(*ae, (z3::expr)viewSizes[idx]);
+    z3::expr size = (z3::expr)viewSizes[idx];
+    z3::expr inbounds = z3::implies(size > 0, z3::ult(*ae, size));
     st.wellDefined(inbounds);
   }
 


### PR DESCRIPTION
According to https://llvm.discourse.group/t/what-is-the-semantics-of-memref-0xf32-and-tensor-0xf32/3557/12 this discussion, zero sized tensor is allowed.
If we interpret LinAlg.dot operation as loop over input tensors, then zero sized tensor input means no-op in output tensor.
Similarly, we can interpret linalg.generic loops as no-op when input tensor is zero sized.
So in `encodeUBForTensorShapeMatch`, inbounds check should be encoded only when size is bigger than zero (i.e only when it's not a no-op)

Issue https://github.com/aqjune/iree-tv/issues/60 will be resolved by this PR :) 