### PR TITLE
Renamed to mlir-tv in tests, comments, and READMEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15.0)
-project(iree-tv VERSION 0.1.0)
+project(mlir-tv VERSION 0.1.0)
 set (CMAKE_CXX_STANDARD 17)
 
 set(IREE_DIR "" CACHE STRING "IREE source top-level directory")

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ cmake --build .
 ```
 
 ## How to run MLIR-TV
-Run the built `iree-tv` executable as following:
+Run the built `mlir-tv` executable as following:
 ```bash
-iree-tv <.mlir before opt> <.mlir after opt>`
-# ex: ./build/iree-tv \
+mlir-tv <.mlir before opt> <.mlir after opt>`
+# ex: ./build/mlir-tv \
 #        tests/opts/conv2d_to_img2col/nhwc_filter.src.mlir \
 #        tests/opts/conv2d_to_img2col/nhwc_filter.tgt.mlir -smt-to=5000
 ```

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -1,12 +1,12 @@
 import os
 import lit.formats
 
-# iree-tv directory
-iree_tv: str = os.path.join(config.my_obj_root, "iree-tv")
+# mlir-tv directory
+mlir_tv: str = os.path.join(config.my_obj_root, "mlir-tv")
 root_name: str = lit_config.params["root"]
 pass_name: str = lit_config.params["pass"]
 
 config.name = 'MLIR'
 config.test_source_root = os.path.join(config.my_src_root, f"tests/{root_name}")
 config.test_exec_root = os.path.join(config.my_obj_root, "tests")
-config.test_format = lit.formats.SrcTgtPairTest(iree_tv, pass_name)
+config.test_format = lit.formats.SrcTgtPairTest(mlir_tv, pass_name)

--- a/tests/lit/formats/__init__.py
+++ b/tests/lit/formats/__init__.py
@@ -7,4 +7,4 @@ from lit.formats.base import (  # noqa: F401
 
 from lit.formats.googletest import GoogleTest  # noqa: F401
 from lit.formats.shtest import ShTest  # noqa: F401
-from lit.formats.mlirtest import SrcTgtPairTest # added by iree-tv
+from lit.formats.mlirtest import SrcTgtPairTest # added by mlir-tv

--- a/tests/lit/formats/mlirtest.py
+++ b/tests/lit/formats/mlirtest.py
@@ -60,7 +60,7 @@ class ExitCodeDependentTestBase(TestBase):
             # exit code 80~89: parsing related errors
             return lit.Test.UNRESOLVED, ""
         elif int(exit_code / 10) == 9:
-            # exit code 90~99: iree-tv related errors
+            # exit code 90~99: mlir-tv related errors
             return lit.Test.UNRESOLVED, ""
         elif exit_code == 101:
             # timeout

--- a/tests/opts/README.md
+++ b/tests/opts/README.md
@@ -29,4 +29,4 @@ Each `.src.mlir` file must include the command used to create the pair `.tgt.mli
 When implementing a negative test case by modifying valid `tgt.mlir`, the diff must be annotated with comments.
 
 ## Reference
-https://github.com/aqjune/iree-tv/issues/13
+https://github.com/aqjune/mlir-tv/issues/13


### PR DESCRIPTION
This PR applies the changed project name to binary name and documentations.
- All `iree-tv`s are now renamed into `mlir-tv`s.