### PR TITLE
Update CMakeLists to change dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,22 @@ cmake_minimum_required(VERSION 3.15.0)
 project(mlir-tv VERSION 0.1.0)
 set (CMAKE_CXX_STANDARD 17)
 
-set(IREE_DIR "" CACHE STRING "IREE source top-level directory")
-set(IREE_BUILD_DIR "" CACHE STRING "IREE build top-level directory")
+set(MLIR_DIR "" CACHE STRING "MLIR installation top-level directory")
 set(Z3_DIR "" CACHE STRING "Z3 installation top-level directory")
 
+set(MLIR_INC_DIR "${MLIR_DIR}/include")
+set(MLIR_LIB_DIR "${MLIR_DIR}/lib")
 set(Z3_INC_DIR "${Z3_DIR}/include")
 set(Z3_LIB_DIR "${Z3_DIR}/lib")
+
+link_directories(${MLIR_LIB_DIR})
+link_directories(${Z3_LIB_DIR})
+
+link_libraries(
+    MLIRViewLikeInterface MLIRInferTypeOpInterface
+    MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRViewLikeInterface MLIRAffine MLIRMemRef MLIRShape MLIRMath
+    MLIRControlFlowInterfaces MLIRStandard MLIRSideEffectInterfaces MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport MLIRInferTypeOpInterface
+    LLVMSupport LLVMDemangle z3 pthread m curses)
 
 add_executable(${PROJECT_NAME}
     src/main.cpp
@@ -18,22 +28,10 @@ add_executable(${PROJECT_NAME}
     src/value.cpp
     src/vcgen.cpp)
 
-# Libraries can be found in IREE_BUILD_DIR/third_party/llvm-project/llvm/lib
-target_link_libraries(${PROJECT_NAME}
-    MLIRViewLikeInterface MLIRInferTypeOpInterface
-    MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRViewLikeInterface MLIRAffine MLIRMemRef MLIRShape MLIRMath
-    MLIRControlFlowInterfaces MLIRStandard MLIRSideEffectInterfaces MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport MLIRInferTypeOpInterface
-    LLVMSupport LLVMDemangle z3 pthread m curses)
 target_link_options(${PROJECT_NAME} PUBLIC -fPIC)
 target_compile_options(${PROJECT_NAME} PUBLIC -fno-rtti)
-target_link_directories(${PROJECT_NAME} PUBLIC ${IREE_BUILD_DIR}/third_party/llvm-project/llvm/lib)
-target_link_directories(${PROJECT_NAME} PUBLIC ${Z3_LIB_DIR})
 
-# IREE include directories
-include_directories(${IREE_DIR}/third_party/llvm-project/llvm/include ${IREE_DIR}/third_party/llvm-project/mlir/include)
-include_directories(${IREE_BUILD_DIR}/third_party/llvm-project/llvm/include ${IREE_BUILD_DIR}/third_party/llvm-project/llvm/tools/mlir/include)
-
-# Z3 include directories
+include_directories(${MLIR_INC_DIR})
 include_directories(${Z3_INC_DIR})
 
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 ## How to build MLIR-TV
 
-We take the path of a user's local IREE repo to detect MLIR's src and build directory.
-
 Prerequisites: [CMake](https://cmake.org/download/)(>=3.15),
-[IREE](https://github.com/google/iree),
+[MLIR](https://github.com/llvm/llvm-project),
 [Z3-solver](https://github.com/Z3Prover/z3),
 [Python3](https://www.python.org/downloads/)(>=3.9)
 
@@ -13,8 +11,7 @@ Prerequisites: [CMake](https://cmake.org/download/)(>=3.15),
 mkdir build
 cd build
 # If you want to build a release version, please add -DCMAKE_BUILD_TYPE=RELEASE
-cmake -DIREE_DIR=<dir/to/iree> \
-      -DIREE_BUILD_DIR=<dir/to/iree-build> \
+cmake -DMLIR_DIR=<dir/to/mlir-install> \
       -DZ3_DIR=<dir/to/z3-install> \
       ..
 cmake --build .

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -12,14 +12,6 @@ FetchContent_MakeAvailable(googletest)
 link_libraries(gtest_main)
 include_directories(${PROJECT_SOURCE_DIR})
 
-link_directories(${IREE_BUILD_DIR}/third_party/llvm-project/llvm/lib)
-link_directories(${Z3_LIB_DIR})
-link_libraries(
-    MLIRViewLikeInterface MLIRInferTypeOpInterface
-    MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRViewLikeInterface MLIRAffine MLIRMemRef MLIRShape
-    MLIRControlFlowInterfaces MLIRStandard MLIRSideEffectInterfaces MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport MLIRInferTypeOpInterface
-    LLVMSupport LLVMDemangle z3 pthread m curses)
-
 # Add each test file as executable
 add_executable(
   state_test


### PR DESCRIPTION
This PR changes the CMake configuration to change dependency of `mlir-tv` from IREE to MLIR.

- Now accepts `MLIR_DIR` instead of `IREE_DIR` and `IREE_BUILD_DIR`
- unittests CMakeLists now derive include and lib directories from iree-tv CMakeLists
- Updated README