### PR TITLE
Use UFBV logic when expression has Quantifier

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -73,5 +73,6 @@ State::LinalgGenericScope::LinalgGenericScope(
 }
 
 State::State(unsigned int numBlocks, MemEncoding encoding):
+  hasQuantifier(false),
   isWellDefined(ctx),
   m(Memory::create(numBlocks, encoding)) {}

--- a/src/state.h
+++ b/src/state.h
@@ -68,12 +68,16 @@ public:
   // We'll need to implement our own version of peephole optimizations on Z3
   // expr some day (or simply use Alive2's one), and this form will be helpful
   // then.
+  bool hasQuantifier;
   z3::expr isWellDefined;
   std::shared_ptr<Memory> m;
 
   State(unsigned int numBlocks, MemEncoding encoding);
 
-  void wellDefined(const z3::expr &e) { isWellDefined = isWellDefined && e; };
+  void wellDefined(const z3::expr &e) {
+    isWellDefined = isWellDefined && e;
+    hasQuantifier = hasQuantifier || e.is_quantifier();
+  };
 
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, State &);
 };

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -1269,9 +1269,10 @@ static Results checkRefinement(
       llvm_unreachable("unexpected result");
     }
   };
+  auto logic = (st_src.hasQuantifier || st_src.hasQuantifier) ? "UFBV" : "QF_UFBV";
 
   { // 1. Check UB
-    auto s = z3::solver(ctx, "QF_UFBV");
+    auto s = z3::solver(ctx, logic);
     auto not_refines =
         (st_src.isWellDefined && !st_tgt.isWellDefined).simplify();
     auto res = solve(s, not_refines, vinput.dumpSMTPath, fnname + ".1.ub");
@@ -1283,7 +1284,7 @@ static Results checkRefinement(
   }
 
   { // 2. Check whether src is always UB
-    auto s = z3::solver(ctx, "QF_UFBV");
+    auto s = z3::solver(ctx, logic);
     auto not_ub = st_src.isWellDefined.simplify();
     auto res = solve(s, not_ub, vinput.dumpSMTPath, fnname + ".2.notub");
     elapsedMillisec += res.second;
@@ -1294,7 +1295,7 @@ static Results checkRefinement(
   }
 
   if (st_src.retValue) { // 3. Check the return values
-    auto s = z3::solver(ctx, "QF_UFBV");
+    auto s = z3::solver(ctx, logic);
 
     z3::expr refines(ctx);
     vector<z3::expr> params;
@@ -1315,7 +1316,7 @@ static Results checkRefinement(
 
   if (st_src.m->getNumBlocks() > 0 ||
       st_tgt.m->getNumBlocks() > 0) { // 4. Check memory refinement
-    auto s = z3::solver(ctx, "QF_UFBV");
+    auto s = z3::solver(ctx, logic);
     auto [refines, params] = st_src.m->refines(*st_tgt.m);
     auto not_refines =
       (st_src.isWellDefined && st_tgt.isWellDefined && !refines).simplify();

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -436,11 +436,7 @@ optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
   auto [mVal, success] = memref.load(idxs);
   memref.setWritable(false); // mutating result memref is undefined behavior
 
-  z3::expr_vector xs(ctx);
-  for (auto idx: idxs)
-    xs.push_back(idx);
-
-  st.wellDefined(z3::forall(xs, mVal == tVal));
+  st.wellDefined(z3::forall(toExprVector(idxs), mVal == tVal));
   st.regs.add(op.memref(), move(memref));
   return {};
 }

--- a/tests/litmus/memref-ops/buffer_cast.src.mlir
+++ b/tests/litmus/memref-ops/buffer_cast.src.mlir
@@ -1,3 +1,5 @@
+// VERIFY
+
 func @buffer_cast(%arg : tensor<2x3xf32>) -> f32
 {
   %c0 = constant 0 : index


### PR DESCRIPTION
QF_UFBV(Unquantified formulas over bitvectors with uninterpreted sort function and symbols) logic fails when expression has  quantifier.
So we select z3 solver logic dynamically based on expression.
`forall` quantifier could be introduced when encoding `memref::buffer_cast` operation.