### PR TITLE
Use z3::ugt rather than z3::sgt

### DIFF
--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -771,7 +771,7 @@ encodeUBForTensorShapeMatch(State &st, mlir::linalg::GenericOp op,
       return "unsupported affine expr";
 
     z3::expr size = (z3::expr)viewSizes[idx];
-    z3::expr inbounds = z3::implies(size > 0, z3::ult(*ae, size));
+    z3::expr inbounds = z3::implies(z3::ugt(size, 0), z3::ult(*ae, size));
     st.wellDefined(inbounds);
   }
 


### PR DESCRIPTION
By default, `size > 0` is encoded into `bvsgt` (which means signed-greater-than).
So we explicitly encode using `z3::ugt`when check size inbounds.

### Before
```
(=> (bvsgt dim.3 #x00000000) (bvult (bvadd dim.3 #xffffffff) dim.3))
(=> (bvsgt dim.4 #x00000000) (bvult (bvadd dim.3 #xffffffff) dim.4))
```

### After


```
(=> (bvugt dim.3 #x00000000) (bvult (bvadd dim.3 #xffffffff) dim.3))
(=> (bvugt dim.4 #x00000000) (bvult (bvadd dim.3 #xffffffff) dim.4))
```