### PR TITLE
Improve buffer_cast encoding when memref has an identity map

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -104,7 +104,7 @@ expr SingleArrayMemory::storeArray(
   arrayMaps = z3::store(arrayMaps, bid, stored);
 
   return z3::ule(low, high) && // low <= high (to prevent overflow)
-    z3::ule(high, block.numelem) && // high <= block.numelem
+    z3::ult(high, block.numelem) && // high < block.numelem
     block.writable;
 }
 
@@ -217,7 +217,7 @@ expr MultipleArrayMemory::storeArray(
     });
 
   return z3::ult(low, high) && // low <= high (to prevent overflow)
-    z3::ule(high, getNumElementsOfMemBlock(bid)) && // high <= block.numelem
+    z3::ult(high, getNumElementsOfMemBlock(bid)) && // high < block.numelem
     getWritable(bid);
 }
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -103,7 +103,7 @@ expr SingleArrayMemory::storeArray(
   auto stored = z3::lambda(idx, z3::ite(cond, arrayVal, currentVal));
   arrayMaps = z3::store(arrayMaps, bid, stored);
 
-  return z3::ule(low, high) && // low <= high (to prevent overflow)
+  return z3::bvadd_no_overflow(offset, size - 1, false) && // to prevent overflow
     z3::ult(high, block.numelem) && // high < block.numelem
     block.writable;
 }
@@ -216,7 +216,7 @@ expr MultipleArrayMemory::storeArray(
       return z3::lambda(idx, z3::ite(cond, arrayVal, currentVal));
     });
 
-  return z3::ult(low, high) && // low <= high (to prevent overflow)
+  return z3::bvadd_no_overflow(offset, size - 1, false) && // to prevent overflow
     z3::ult(high, getNumElementsOfMemBlock(bid)) && // high < block.numelem
     getWritable(bid);
 }

--- a/src/memory.h
+++ b/src/memory.h
@@ -46,6 +46,9 @@ public:
   // Returns: store successful?
   virtual z3::expr store(
       const z3::expr &f32val, const z3::expr &bid, const z3::expr &idx) = 0;
+  // Returns: store successful?
+  virtual z3::expr storeArray(
+      const z3::expr &arr, const z3::expr &bid, const z3::expr &offset, const z3::expr &size) = 0;
   // Returns: (loaded value, load successful?)
   virtual std::pair<z3::expr, z3::expr> load(
       const z3::expr &bid, const z3::expr &idx) const = 0;
@@ -70,6 +73,9 @@ public:
   z3::expr getWritable(const z3::expr &bid) const override;
   z3::expr store(
       const z3::expr &f32val, const z3::expr &bid, const z3::expr &idx)
+      override;
+  z3::expr storeArray(
+      const z3::expr &arr, const z3::expr &bid, const z3::expr &offset, const z3::expr &size)
       override;
   std::pair<z3::expr, z3::expr> load(const z3::expr &bid, const z3::expr &idx)
       const override;
@@ -97,6 +103,9 @@ public:
 
   z3::expr store(
       const z3::expr &f32val, const z3::expr &bid, const z3::expr &idx)
+      override;
+  z3::expr storeArray(
+      const z3::expr &arr, const z3::expr &bid, const z3::expr &offset, const z3::expr &size)
       override;
   std::pair<z3::expr, z3::expr> load(const z3::expr &bid, const z3::expr &idx)
       const override;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -508,6 +508,12 @@ z3::expr MemRef::store(const z3::expr &value, const std::vector<z3::expr> &indic
   return m->store(value, bid, offset + idx);
 }
 
+z3::expr MemRef::storeArray(const z3::expr &array,
+  const z3::expr &startOffset,
+  const z3::expr &size) {
+  return m->storeArray(array, bid, offset + startOffset, size);
+}
+
 z3::expr MemRef::isInBounds() const {
   auto numelem = m->getNumElementsOfMemBlock(bid);
   auto memrefSize = get1DSize();

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -520,7 +520,7 @@ pair<expr, expr> MemRef::load(const vector<expr> &indices) {
   expr idx = to1DIdxWithLayout(indices);
   auto [expr, success] = m->load(bid, offset + idx);
 
-  // check whether indices are  inbound.
+  // check whether indices are inbound.
   for (int i = 0; i < indices.size(); i ++)
     success = success && z3::ult(indices[i], getDim(i));
 
@@ -531,7 +531,7 @@ expr MemRef::store(const expr &value, const std::vector<expr> &indices) {
   expr idx = to1DIdxWithLayout(indices);
   auto success = m->store(value, bid, offset + idx);
 
-  // check whether indices are  inbound.
+  // check whether indices are inbound.
   for (int i = 0; i < indices.size(); i ++)
     success = success && z3::ult(indices[i], getDim(i));
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -473,7 +473,9 @@ z3::expr MemRef::getWellDefined() const {
 
 optional<tuple<vector<z3::expr>, MemRef::Layout, z3::sort>>
 MemRef::getDimsAndLayoutAndElemTy(
-    mlir::MemRefType memRefTy, bool freshVarForUnknownSize) {
+    mlir::MemRefType memRefTy,
+    optional<vector<z3::expr>> predefinedDims,
+    bool freshVarForUnknownSize) {
   // Step1. check element type
   auto elemty = memRefTy.getElementType();
   z3::sort elemty2(ctx);
@@ -487,7 +489,7 @@ MemRef::getDimsAndLayoutAndElemTy(
 
   // Step2. check affine map
   if (mlir::isStrided(memRefTy)) {
-    auto dims = ::getDims(memRefTy, freshVarForUnknownSize);
+    auto dims = predefinedDims.value_or(::getDims(memRefTy, freshVarForUnknownSize));
     auto layout = ::getLayout(memRefTy, dims);
     return {{dims, layout, elemty2}};
   } else {

--- a/src/value.h
+++ b/src/value.h
@@ -185,8 +185,9 @@ public:
 
   // If memRefTy is unsupported, return nullopt
   static std::optional<std::tuple<std::vector<z3::expr>, Layout, z3::sort>>
-      getDimsAndLayoutAndElemTy(mlir::MemRefType memRefTy,
-                       bool freshVarForUnknownSize = true);
+    getDimsAndLayoutAndElemTy(mlir::MemRefType memRefTy,
+      std::optional<std::vector<z3::expr>> predefinedDims = {},
+      bool freshVarForUnknownSize = true);
 
   std::pair<z3::expr, z3::expr> load(const std::vector<z3::expr> &indices);
   z3::expr store(const z3::expr &value, const std::vector<z3::expr> &indices);

--- a/src/value.h
+++ b/src/value.h
@@ -191,6 +191,7 @@ public:
 
   std::pair<z3::expr, z3::expr> load(const std::vector<z3::expr> &indices);
   z3::expr store(const z3::expr &value, const std::vector<z3::expr> &indices);
+  z3::expr storeArray(const z3::expr &array, const z3::expr &startOffset, const z3::expr &size);
   z3::expr isInBounds() const;
   z3::expr getBID() const { return bid; }
   Index getOffset() const { return offset; }

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -419,7 +419,9 @@ template<>
 optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
   auto tensor = st.regs.get<Tensor>(op.getOperand());
   auto memrefTy = op.memref().getType().cast<mlir::MemRefType>();
-  auto dimsAndLayoutAndElemTy = MemRef::getDimsAndLayoutAndElemTy(memrefTy);
+  auto predefinedDims = tensor.getDims();
+  auto dimsAndLayoutAndElemTy = MemRef::
+    getDimsAndLayoutAndElemTy(memrefTy, predefinedDims);
   if (!dimsAndLayoutAndElemTy)
     return "unsupported type";
 

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -434,23 +434,24 @@ optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
     auto success = memref.storeArray(tensor.asArray(), Index::zero(), tensor.get1DSize());
     st.wellDefined(success);
     st.regs.add(op.memref(), move(memref));
-  } else {
-    // memref with affine maps
-    vector<z3::expr> idxs;
-    for (int i = 0; i < memrefTy.getRank(); i ++)
-      idxs.push_back(Index("Index", true));
-
-    auto tVal = tensor.get(idxs);
-    auto [mVal, success] = memref.load(idxs);
-    memref.setWritable(false); // mutating result memref is undefined behavior
-
-    z3::expr_vector xs(ctx);
-    for (auto idx: idxs)
-      xs.push_back(idx);
-
-    st.wellDefined(z3::forall(xs, mVal == tVal));
-    st.regs.add(op.memref(), move(memref));
+    return {};
   }
+
+  // memref with affine maps
+  vector<z3::expr> idxs;
+  for (int i = 0; i < memrefTy.getRank(); i ++)
+    idxs.push_back(Index("Index", true));
+
+  auto tVal = tensor.get(idxs);
+  auto [mVal, success] = memref.load(idxs);
+  memref.setWritable(false); // mutating result memref is undefined behavior
+
+  z3::expr_vector xs(ctx);
+  for (auto idx: idxs)
+    xs.push_back(idx);
+
+  st.wellDefined(z3::forall(xs, mVal == tVal));
+  st.regs.add(op.memref(), move(memref));
   return {};
 }
 

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -435,11 +435,12 @@ optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
     getDimsAndLayoutAndElemTy(memrefTy, predefinedDims);
   if (!dimsAndLayoutAndElemTy)
     return "unsupported type";
+
   auto memref = MemRef(st.m.get(),
-    get<0>(*dimsAndLayoutAndElemTy),
-    get<1>(*dimsAndLayoutAndElemTy),
-    get<2>(*dimsAndLayoutAndElemTy),
-    true);
+      get<0>(*dimsAndLayoutAndElemTy),
+      get<1>(*dimsAndLayoutAndElemTy),
+      get<2>(*dimsAndLayoutAndElemTy),
+      true);
 
   if (memrefTy.getAffineMaps().empty()) {
     // memref with identity map

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -432,7 +432,7 @@ optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
   auto memrefTy = op.memref().getType().cast<mlir::MemRefType>();
   auto predefinedDims = tensor.getDims();
   auto dimsAndLayoutAndElemTy = MemRef::
-    getDimsAndLayoutAndElemTy(memrefTy, predefinedDims);
+    getDimsAndLayoutAndElemTy(memrefTy, move(predefinedDims));
   if (!dimsAndLayoutAndElemTy)
     return "unsupported type";
 

--- a/tests/litmus/memref-ops/buffer_cast.src.mlir
+++ b/tests/litmus/memref-ops/buffer_cast.src.mlir
@@ -1,7 +1,4 @@
-// EXPECT: "Memory mismatch"
-
-// Although this conversion is correct, currently we don't fully support local block memory refinement.
-// So this test just checks whether return value mismatch.
+// VERIFY
 
 func @buffer_cast(%arg : tensor<2x3xf32>) -> f32
 {

--- a/tests/litmus/memref-ops/buffer_cast.src.mlir
+++ b/tests/litmus/memref-ops/buffer_cast.src.mlir
@@ -1,4 +1,7 @@
-// VERIFY
+// EXPECT: "Memory mismatch"
+
+// Although this conversion is correct, currently we don't fully support local block memory refinement.
+// So this test just checks whether return value mismatch.
 
 func @buffer_cast(%arg : tensor<2x3xf32>) -> f32
 {

--- a/tests/litmus/memref-ops/var_buffer_cast.src.mlir
+++ b/tests/litmus/memref-ops/var_buffer_cast.src.mlir
@@ -1,0 +1,8 @@
+func @var_buffer_cast(%arg : tensor<?x?xf32>) -> f32
+{
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %0 = memref.buffer_cast %arg : memref<?x?xf32>
+  %1 = memref.load %0[%c0, %c1] : memref<?x?xf32>
+  return %1 : f32
+}

--- a/tests/litmus/memref-ops/var_buffer_cast.src.mlir
+++ b/tests/litmus/memref-ops/var_buffer_cast.src.mlir
@@ -1,3 +1,8 @@
+// EXPECT: "Memory mismatch"
+
+// Although this conversion is correct, currently we don't fully support local block memory refinement.
+// So this test just checks whether return value mismatch.
+
 func @var_buffer_cast(%arg : tensor<?x?xf32>) -> f32
 {
   %c0 = constant 0 : index

--- a/tests/litmus/memref-ops/var_buffer_cast.src.mlir
+++ b/tests/litmus/memref-ops/var_buffer_cast.src.mlir
@@ -1,7 +1,4 @@
-// EXPECT: "Memory mismatch"
-
-// Although this conversion is correct, currently we don't fully support local block memory refinement.
-// So this test just checks whether return value mismatch.
+// VERIFY
 
 func @var_buffer_cast(%arg : tensor<?x?xf32>) -> f32
 {

--- a/tests/litmus/memref-ops/var_buffer_cast.tgt.mlir
+++ b/tests/litmus/memref-ops/var_buffer_cast.tgt.mlir
@@ -1,0 +1,7 @@
+func @var_buffer_cast(%arg : tensor<?x?xf32>) -> f32
+{
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %0 = tensor.extract %arg[%c0, %c1] : tensor<?x?xf32>
+  return %0 : f32
+}


### PR DESCRIPTION
In the previous PR (https://github.com/aqjune/mlir-tv/pull/66), we encoded buffer_cast ops using a forall quantifier.
However, using a forall quantifier is expensive in SMT.
But, in many cases, we can find a cheaper encoding for buffer_cast.
If the origin memref is identity-mapped, it can be encoded more efficiently using `z3::lambda`.
Memref with an identity map means its layout is same as that of the origin tensor.

By using lambda, transformations containing complex buffer_cast operations (variable sized tensor, multi-dimension..) are verified much faster than before.
In the previous encoding, even verifying very small memrefs like `memref<3x4xf32>` failed.