### PR TITLE
Partially implement smt-switch terms for value types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,32 @@ set (CMAKE_CXX_STANDARD 17)
 set(IREE_DIR "" CACHE STRING "IREE source top-level directory")
 set(IREE_BUILD_DIR "" CACHE STRING "IREE build top-level directory")
 set(Z3_DIR "" CACHE STRING "Z3 installation top-level directory")
+set(SMT_SWITCH_DIR "" CACHE STRING "smt-switch installation top-level directory")
 
 set(Z3_INC_DIR "${Z3_DIR}/include")
 set(Z3_LIB_DIR "${Z3_DIR}/lib")
+set(SMT_SWITCH_INC_DIR "${SMT_SWITCH_DIR}/include")
+set(SMT_SWITCH_LIB_DIR "${SMT_SWITCH_DIR}/lib")
+
+# Libraries can be found in IREE_BUILD_DIR/third_party/llvm-project/llvm/lib
+link_directories(${IREE_BUILD_DIR}/third_party/llvm-project/llvm/lib)
+link_directories(${Z3_LIB_DIR})
+link_directories(${SMT_SWITCH_LIB_DIR})
+link_libraries(
+    MLIRViewLikeInterface MLIRInferTypeOpInterface
+    MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRViewLikeInterface MLIRAffine MLIRMemRef MLIRShape MLIRMath
+    MLIRControlFlowInterfaces MLIRStandard MLIRSideEffectInterfaces MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport MLIRInferTypeOpInterface
+    LLVMSupport LLVMDemangle z3 smt-switch smt-switch-z3 smt-switch-cvc4 pthread m curses)
+
+# IREE include directories
+include_directories(${IREE_DIR}/third_party/llvm-project/llvm/include ${IREE_DIR}/third_party/llvm-project/mlir/include)
+include_directories(${IREE_BUILD_DIR}/third_party/llvm-project/llvm/include ${IREE_BUILD_DIR}/third_party/llvm-project/llvm/tools/mlir/include)
+
+# Z3 include directories
+include_directories(${Z3_INC_DIR})
+
+# smt-switch include 
+include_directories(${SMT_SWITCH_INC_DIR})
 
 add_executable(${PROJECT_NAME}
     src/main.cpp
@@ -18,23 +41,8 @@ add_executable(${PROJECT_NAME}
     src/value.cpp
     src/vcgen.cpp)
 
-# Libraries can be found in IREE_BUILD_DIR/third_party/llvm-project/llvm/lib
-target_link_libraries(${PROJECT_NAME}
-    MLIRViewLikeInterface MLIRInferTypeOpInterface
-    MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRViewLikeInterface MLIRAffine MLIRMemRef MLIRShape MLIRMath
-    MLIRControlFlowInterfaces MLIRStandard MLIRSideEffectInterfaces MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport MLIRInferTypeOpInterface
-    LLVMSupport LLVMDemangle z3 pthread m curses)
 target_link_options(${PROJECT_NAME} PUBLIC -fPIC)
 target_compile_options(${PROJECT_NAME} PUBLIC -fno-rtti)
-target_link_directories(${PROJECT_NAME} PUBLIC ${IREE_BUILD_DIR}/third_party/llvm-project/llvm/lib)
-target_link_directories(${PROJECT_NAME} PUBLIC ${Z3_LIB_DIR})
-
-# IREE include directories
-include_directories(${IREE_DIR}/third_party/llvm-project/llvm/include ${IREE_DIR}/third_party/llvm-project/mlir/include)
-include_directories(${IREE_BUILD_DIR}/third_party/llvm-project/llvm/include ${IREE_BUILD_DIR}/third_party/llvm-project/llvm/tools/mlir/include)
-
-# Z3 include directories
-include_directories(${Z3_INC_DIR})
 
 enable_testing()
 add_subdirectory(${PROJECT_SOURCE_DIR}/tests)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ We take the path of a user's local IREE repo to detect MLIR's src and build dire
 Prerequisites: [CMake](https://cmake.org/download/)(>=3.15),
 [IREE](https://github.com/google/iree),
 [Z3-solver](https://github.com/Z3Prover/z3),
+[smt-switch](https://github.com/makaimann/smt-switch),
 [Python3](https://www.python.org/downloads/)(>=3.9)
 
 ```bash
@@ -16,6 +17,7 @@ cd build
 cmake -DIREE_DIR=<dir/to/iree> \
       -DIREE_BUILD_DIR=<dir/to/iree-build> \
       -DZ3_DIR=<dir/to/z3-install> \
+      -DSMT_SWITCH_DIR=<dir/to/smt-switch/install> \
       ..
 cmake --build .
 ```

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -12,14 +12,6 @@ FetchContent_MakeAvailable(googletest)
 link_libraries(gtest_main)
 include_directories(${PROJECT_SOURCE_DIR})
 
-link_directories(${IREE_BUILD_DIR}/third_party/llvm-project/llvm/lib)
-link_directories(${Z3_LIB_DIR})
-link_libraries(
-    MLIRViewLikeInterface MLIRInferTypeOpInterface
-    MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRViewLikeInterface MLIRAffine MLIRMemRef MLIRShape
-    MLIRControlFlowInterfaces MLIRStandard MLIRSideEffectInterfaces MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport MLIRInferTypeOpInterface
-    LLVMSupport LLVMDemangle z3 pthread m curses)
-
 # Add each test file as executable
 add_executable(
   state_test


### PR DESCRIPTION
This PR implements smt-switch Terms (`smt::Term` below) for Index, Float, and Integer types.
Currently they are not actually used in verification: `smt::Term` should be implemented for more types in order to do so.

Each type holds a map of Terms, of which the key is `SolverName` enum. This is because we want to provide options for solvers at runtime, and therefore the number of terms a type should hold is not fixed.

Note that this PR includes some of the changes from https://github.com/aqjune/mlir-tv/pull/70. Library linking option must be synced between `mlir-tv` and unittests, and the previous PR included refactoring of CMakeLists to reduce that workload. (Yup I should have split them into separate PRs :( )