### PR TITLE
Implement local memory blocks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,8 +39,8 @@ llvm::cl::opt<bool> split_input_file("split-input-file",
   llvm::cl::init(false));
 
 llvm::cl::opt<unsigned int> num_memblocks("num-memory-blocks",
-  llvm::cl::desc("Number of memory blocks required to verify translation (default=16)"),
-  llvm::cl::init(16), llvm::cl::value_desc("number"));
+  llvm::cl::desc("Number of memory blocks required to verify translation (default=8)"),
+  llvm::cl::init(8), llvm::cl::value_desc("number"));
 
 llvm::cl::opt<MemEncoding> memory_encoding("memory-encoding",
   llvm::cl::desc("Type of memref memory model (default=MULTIPLE)"),

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -66,7 +66,7 @@ MemBlock SingleArrayMemory::getMemBlock(const expr &bid) const {
   return MemBlock(array, writable, numelem);
 }
 
-expr SingleArrayMemory::addLocalMemBlock(const expr &numelem) {
+expr SingleArrayMemory::addLocalBlock(const expr &numelem) {
   assert(numLocalBlocks <= maxLocalBlocks);
   auto bid = ctx.bv_val(numGlobalBlocks + numLocalBlocks, bidBits);
   numelemMaps = z3::store(numelemMaps, bid, numelem);
@@ -149,7 +149,7 @@ void MultipleArrayMemory::update(
   }
 }
 
-expr MultipleArrayMemory::addLocalMemBlock(const expr &numelem) {
+expr MultipleArrayMemory::addLocalBlock(const expr &numelem) {
   auto bid = numGlobalBlocks + numLocalBlocks;
   auto suffix = [&](const string &s) { return s + to_string(bid); };
   arrays.push_back(ctx.constant(suffix("array").c_str(),

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -67,11 +67,11 @@ MemBlock SingleArrayMemory::getMemBlock(const expr &bid) const {
 }
 
 expr SingleArrayMemory::addLocalBlock(const expr &numelem, const expr &writable) {
-  assert(numLocalBlocks <= maxLocalBlocks);
+  assert(numLocalBlocks < maxLocalBlocks);
+
   auto bid = ctx.bv_val(numGlobalBlocks + numLocalBlocks, bidBits);
   numelemMaps = z3::store(numelemMaps, bid, numelem);
   numLocalBlocks ++;
-
   return bid;
 }
 
@@ -150,6 +150,8 @@ void MultipleArrayMemory::update(
 }
 
 expr MultipleArrayMemory::addLocalBlock(const expr &numelem, const expr &writable) {
+  assert(numLocalBlocks < maxLocalBlocks);
+
   auto bid = numGlobalBlocks + numLocalBlocks;
   auto suffix = [&](const string &s) { return s + to_string(bid); };
   arrays.push_back(ctx.constant(suffix("array").c_str(),
@@ -157,7 +159,6 @@ expr MultipleArrayMemory::addLocalBlock(const expr &numelem, const expr &writabl
   writables.push_back(ctx.bool_const(suffix("writable").c_str()));
   numelems.push_back(numelem);
   numLocalBlocks ++;
-
   return ctx.bv_val(bid, bidBits);
 }
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -53,7 +53,7 @@ SingleArrayMemory::refines(const Memory &other) const {
 }
 
 SingleArrayMemory::SingleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks):
-  Memory(globalBlocks, localBlocks, ulog2(globalBlocks) + ulog2(localBlocks)),
+  Memory(globalBlocks, localBlocks, ulog2(globalBlocks + localBlocks)),
   arrayMaps(ctx.constant("arrayMaps",
     ctx.array_sort(ctx.bv_sort(bidBits), ctx.array_sort(Index::sort(), Float::sort())))),
   writableMaps(ctx.constant("writableMaps",
@@ -91,7 +91,7 @@ std::pair<expr, expr> SingleArrayMemory::load(
 
 
 MultipleArrayMemory::MultipleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks):
-    Memory(globalBlocks, localBlocks, ulog2(globalBlocks) + ulog2(localBlocks)) {
+    Memory(globalBlocks, localBlocks, ulog2(globalBlocks + localBlocks)) {
   for (unsigned i = 0; i < getNumBlocks(); ++i) {
     auto suffix = [&](const string &s) {
       return s + to_string(i);

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -66,7 +66,7 @@ MemBlock SingleArrayMemory::getMemBlock(const expr &bid) const {
   return MemBlock(array, writable, numelem);
 }
 
-expr SingleArrayMemory::addLocalBlock(const expr &numelem) {
+expr SingleArrayMemory::addLocalBlock(const expr &numelem, const expr &writable) {
   assert(numLocalBlocks <= maxLocalBlocks);
   auto bid = ctx.bv_val(numGlobalBlocks + numLocalBlocks, bidBits);
   numelemMaps = z3::store(numelemMaps, bid, numelem);
@@ -149,7 +149,7 @@ void MultipleArrayMemory::update(
   }
 }
 
-expr MultipleArrayMemory::addLocalBlock(const expr &numelem) {
+expr MultipleArrayMemory::addLocalBlock(const expr &numelem, const expr &writable) {
   auto bid = numGlobalBlocks + numLocalBlocks;
   auto suffix = [&](const string &s) { return s + to_string(bid); };
   arrays.push_back(ctx.constant(suffix("array").c_str(),

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -70,8 +70,11 @@ MemBlock SingleArrayMemory::getMemBlock(const expr &bid) const {
 }
 
 expr SingleArrayMemory::addLocalMemBlock(const expr &numelem) {
-  // TODO (seongwon)
-  return ctx;
+  auto bid = ctx.bv_val(numGlobalBlocks + currLocalBlocks, bidBits);
+  numelemMaps = z3::store(numelemMaps, bid, numelem);
+  currLocalBlocks ++;
+
+  return bid;
 }
 
 void SingleArrayMemory::setWritable(const expr &bid, bool writable) {

--- a/src/memory.h
+++ b/src/memory.h
@@ -44,8 +44,8 @@ public:
   unsigned int getBIDBits() const { return bidBits; }
   unsigned int getNumBlocks() const { return globalBlocks + localBlocks; }
 
-  smt::expr isLocalBlock(smt::expr &bid) const;
   smt::expr isGlobalBlock(smt::expr &bid) const;
+  smt::expr isLocalBlock(smt::expr &bid) const;
 
   virtual smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const = 0;
   // Mark memblock's writable flag to `writable`

--- a/src/memory.h
+++ b/src/memory.h
@@ -22,27 +22,29 @@ public:
 
 class Memory {
 protected:
-  const unsigned int globalBlocks;
-  const unsigned int localBlocks;
+  const unsigned int numGlobalBlocks;
+  const unsigned int numLocalBlocks;
   const unsigned int bidBits;
+  unsigned int currLocalBlocks;
 
 public:
   static Memory * create(
-      unsigned int globalBlocks, unsigned int localBlocks,
+      unsigned int numGlobalBlocks, unsigned int numLocalBlocks,
       MemEncoding encoding);
   // Here we would like to use lower half of the memory blocks as global MemBlock
   // and upper half of the memory blocks as local MemBlock.
   // Memory refinement is defined only using global MemBlocks.
-  Memory(unsigned int globalBlocks, unsigned int localBlocks, unsigned int bidBits):
-      globalBlocks(globalBlocks), localBlocks(localBlocks), bidBits(bidBits) {}
+  Memory(unsigned int numGlobalBlocks,
+      unsigned int numLocalBlocks,
+      unsigned int bidBits):
+    numGlobalBlocks(numGlobalBlocks),
+    numLocalBlocks(numLocalBlocks),
+    bidBits(bidBits),
+    currLocalBlocks(0) {}
   virtual ~Memory() {}
 
-  // Encode the refinement relation between src (other) and tgt (this) memory
-  virtual std::pair<smt::expr, std::vector<smt::expr>>
-    refines(const Memory &other) const = 0;
-
   unsigned int getBIDBits() const { return bidBits; }
-  unsigned int getNumBlocks() const { return globalBlocks + localBlocks; }
+  unsigned int getNumBlocks() const { return numGlobalBlocks + currLocalBlocks; }
 
   smt::expr isGlobalBlock(const smt::expr &bid) const;
   smt::expr isLocalBlock(const smt::expr &bid) const;
@@ -59,6 +61,10 @@ public:
   // Returns: (loaded value, load successful?)
   virtual std::pair<smt::expr, smt::expr> load(
       const smt::expr &bid, const smt::expr &idx) const = 0;
+
+  // Encode the refinement relation between src (other) and tgt (this) memory
+  virtual std::pair<smt::expr, std::vector<smt::expr>>
+    refines(const Memory &other) const = 0;
 };
 
 class SingleArrayMemory: public Memory {

--- a/src/memory.h
+++ b/src/memory.h
@@ -44,8 +44,8 @@ public:
   unsigned int getBIDBits() const { return bidBits; }
   unsigned int getNumBlocks() const { return globalBlocks + localBlocks; }
 
-  smt::expr isGlobalBlock(smt::expr &bid) const;
-  smt::expr isLocalBlock(smt::expr &bid) const;
+  smt::expr isGlobalBlock(const smt::expr &bid) const;
+  smt::expr isLocalBlock(const smt::expr &bid) const;
 
   virtual smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const = 0;
   // Mark memblock's writable flag to `writable`

--- a/src/memory.h
+++ b/src/memory.h
@@ -47,11 +47,11 @@ public:
   unsigned int getNumBlocks() const { return numGlobalBlocks + numLocalBlocks; }
 
   // Bids smaller than numGlobalBlocks are global (0 ~ numGlobalBlocks - 1)
-  virtual smt::expr isGlobalBlock(const smt::expr &bid) const = 0;
+  smt::expr isGlobalBlock(const smt::expr &bid) const;
   // Bids bigger than and equal to numGlobalBlocks are local blocks (numGlobalBlocks ~ numGlobalBlocks + numGlobalBlocks)
-  virtual smt::expr isLocalBlock(const smt::expr &bid) const = 0;
+  smt::expr isLocalBlock(const smt::expr &bid) const;
 
-  // Returns: (newly issued block id)
+  // Returns: (newly created block id)
   virtual smt::expr addLocalMemBlock(const smt::expr &numelem) = 0;
 
   virtual smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const = 0;
@@ -76,7 +76,6 @@ class SingleArrayMemory: public Memory {
   smt::expr arrayMaps; // bv(bits)::sort() -> (Index::sort() -> Float::sort())
   smt::expr writableMaps; // bv(bits)::sort() -> bool::sort()
   smt::expr numelemMaps; // bv(bits)::sort() -> Index::sort()
-  smt::expr isGlobalMaps; // bv(bits)::sort() -> bool::sort()
 
 private:
   MemBlock getMemBlock(const smt::expr &bid) const;
@@ -84,8 +83,6 @@ private:
 public:
   SingleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);
 
-  smt::expr isGlobalBlock(const smt::expr &bid) const override;
-  smt::expr isLocalBlock(const smt::expr &bid) const override;
   smt::expr addLocalMemBlock(const smt::expr &numelem) override;
 
   smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const override {
@@ -111,13 +108,10 @@ class MultipleArrayMemory: public Memory {
   std::vector<smt::expr> arrays;  // vector<(Index::sort() -> Float::sort())>
   std::vector<smt::expr> writables; // vector<Bool::sort()>
   std::vector<smt::expr> numelems;  // vector<Index::sort>
-  std::vector<smt::expr> isGlobals; // vector<Bool::sort()>
 
 public:
   MultipleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);
 
-  smt::expr isGlobalBlock(const smt::expr &bid) const override;
-  smt::expr isLocalBlock(const smt::expr &bid) const override;
   smt::expr addLocalMemBlock(const smt::expr &numelem) override;
 
   smt::expr getNumElementsOfMemBlock(unsigned ubid) const

--- a/src/memory.h
+++ b/src/memory.h
@@ -109,7 +109,7 @@ class MultipleArrayMemory: public Memory {
   std::vector<smt::expr> arrays;  // vector<(Index::sort() -> Float::sort())>
   std::vector<smt::expr> writables; // vector<Bool::sort()>
   std::vector<smt::expr> numelems;  // vector<Index::sort>
-  std::vector<smt::expr> isGlobals; // vector<Bool::sort()>
+  std::vector<smt::expr> isGlobals; // vector<Bool::sort()>, Bids smaller than numGlobalBlocks are global
 
 public:
   MultipleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);

--- a/src/memory.h
+++ b/src/memory.h
@@ -49,6 +49,9 @@ public:
   smt::expr isGlobalBlock(const smt::expr &bid) const;
   smt::expr isLocalBlock(const smt::expr &bid) const;
 
+  // Returns: (newly issued block id)
+  virtual smt::expr addLocalMemBlock(const smt::expr &numelem) = 0;
+
   virtual smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const = 0;
   // Mark memblock's writable flag to `writable`
   virtual void setWritable(const smt::expr &bid, bool writable) = 0;
@@ -78,6 +81,8 @@ private:
 public:
   SingleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);
 
+  smt::expr addLocalMemBlock(const smt::expr &numelem) override;
+
   smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const override {
     return getMemBlock(bid).numelem;
   }
@@ -104,6 +109,8 @@ class MultipleArrayMemory: public Memory {
 
 public:
   MultipleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);
+
+  smt::expr addLocalMemBlock(const smt::expr &numelem) override;
 
   smt::expr getNumElementsOfMemBlock(unsigned ubid) const
   { assert(ubid < getNumBlocks()); return numelems[ubid]; }

--- a/src/memory.h
+++ b/src/memory.h
@@ -46,8 +46,8 @@ public:
   unsigned int getBIDBits() const { return bidBits; }
   unsigned int getNumBlocks() const { return numGlobalBlocks + currLocalBlocks; }
 
-  smt::expr isGlobalBlock(const smt::expr &bid) const;
-  smt::expr isLocalBlock(const smt::expr &bid) const;
+  virtual smt::expr isGlobalBlock(const smt::expr &bid) const = 0;
+  virtual smt::expr isLocalBlock(const smt::expr &bid) const = 0;
 
   // Returns: (newly issued block id)
   virtual smt::expr addLocalMemBlock(const smt::expr &numelem) = 0;
@@ -74,6 +74,7 @@ class SingleArrayMemory: public Memory {
   smt::expr arrayMaps; // bv(bits)::sort() -> (Index::sort() -> Float::sort())
   smt::expr writableMaps; // bv(bits)::sort() -> bool::sort()
   smt::expr numelemMaps; // bv(bits)::sort() -> Index::sort()
+  smt::expr isGlobalMaps; // bv(bits)::sort() -> bool::sort()
 
 private:
   MemBlock getMemBlock(const smt::expr &bid) const;
@@ -81,6 +82,8 @@ private:
 public:
   SingleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);
 
+  smt::expr isGlobalBlock(const smt::expr &bid) const override;
+  smt::expr isLocalBlock(const smt::expr &bid) const override;
   smt::expr addLocalMemBlock(const smt::expr &numelem) override;
 
   smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const override {
@@ -106,10 +109,13 @@ class MultipleArrayMemory: public Memory {
   std::vector<smt::expr> arrays;  // vector<(Index::sort() -> Float::sort())>
   std::vector<smt::expr> writables; // vector<Bool::sort()>
   std::vector<smt::expr> numelems;  // vector<Index::sort>
+  std::vector<smt::expr> isGlobals; // vector<Bool::sort()>
 
 public:
   MultipleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);
 
+  smt::expr isGlobalBlock(const smt::expr &bid) const override;
+  smt::expr isLocalBlock(const smt::expr &bid) const override;
   smt::expr addLocalMemBlock(const smt::expr &numelem) override;
 
   smt::expr getNumElementsOfMemBlock(unsigned ubid) const

--- a/src/memory.h
+++ b/src/memory.h
@@ -23,28 +23,28 @@ public:
 class Memory {
 protected:
   const unsigned int numGlobalBlocks;
-  const unsigned int numLocalBlocks;
+  const unsigned int maxLocalBlocks;
   const unsigned int bidBits;
-  unsigned int currLocalBlocks;
+  unsigned int numLocalBlocks;
 
 public:
   static Memory * create(
-      unsigned int numGlobalBlocks, unsigned int numLocalBlocks,
+      unsigned int numGlobalBlocks, unsigned int maxLocalBlocks,
       MemEncoding encoding);
   // Here we would like to use lower half of the memory blocks as global MemBlock
   // and upper half of the memory blocks as local MemBlock.
   // Memory refinement is defined only using global MemBlocks.
   Memory(unsigned int numGlobalBlocks,
-      unsigned int numLocalBlocks,
+      unsigned int maxLocalBlocks,
       unsigned int bidBits):
     numGlobalBlocks(numGlobalBlocks),
-    numLocalBlocks(numLocalBlocks),
+    maxLocalBlocks(maxLocalBlocks),
     bidBits(bidBits),
-    currLocalBlocks(0) {}
+    numLocalBlocks(0) {}
   virtual ~Memory() {}
 
   unsigned int getBIDBits() const { return bidBits; }
-  unsigned int getNumBlocks() const { return numGlobalBlocks + currLocalBlocks; }
+  unsigned int getNumBlocks() const { return numGlobalBlocks + numLocalBlocks; }
 
   virtual smt::expr isGlobalBlock(const smt::expr &bid) const = 0;
   virtual smt::expr isLocalBlock(const smt::expr &bid) const = 0;

--- a/src/memory.h
+++ b/src/memory.h
@@ -53,7 +53,7 @@ public:
   smt::expr isLocalBlock(const smt::expr &bid) const;
 
   // Returns: (newly created block id)
-  virtual smt::expr addLocalBlock(const smt::expr &numelem) = 0;
+  virtual smt::expr addLocalBlock(const smt::expr &numelem, const smt::expr &writable) = 0;
 
   virtual smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const = 0;
   // Mark memblock's writable flag to `writable`
@@ -84,7 +84,7 @@ private:
 public:
   SingleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);
 
-  smt::expr addLocalBlock(const smt::expr &numelem) override;
+  smt::expr addLocalBlock(const smt::expr &numelem, const smt::expr &writable) override;
 
   smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const override {
     return getMemBlock(bid).numelem;
@@ -113,7 +113,7 @@ class MultipleArrayMemory: public Memory {
 public:
   MultipleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);
 
-  smt::expr addLocalBlock(const smt::expr &numelem) override;
+  smt::expr addLocalBlock(const smt::expr &numelem, const smt::expr &writable) override;
 
   smt::expr getNumElementsOfMemBlock(unsigned ubid) const
   { assert(ubid < getNumBlocks()); return numelems[ubid]; }

--- a/src/memory.h
+++ b/src/memory.h
@@ -16,7 +16,8 @@ public:
   smt::expr writable; // bool::sort()
   smt::expr numelem;  // Index::sort()
 
-  MemBlock(const smt::expr &array, const smt::expr &writable, const smt::expr &numelem):
+  MemBlock(const smt::expr &array, const smt::expr &writable,
+           const smt::expr &numelem):
     array(array), writable(writable), numelem(numelem) {}
 };
 
@@ -52,7 +53,7 @@ public:
   smt::expr isLocalBlock(const smt::expr &bid) const;
 
   // Returns: (newly created block id)
-  virtual smt::expr addLocalMemBlock(const smt::expr &numelem) = 0;
+  virtual smt::expr addLocalBlock(const smt::expr &numelem) = 0;
 
   virtual smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const = 0;
   // Mark memblock's writable flag to `writable`
@@ -83,7 +84,7 @@ private:
 public:
   SingleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);
 
-  smt::expr addLocalMemBlock(const smt::expr &numelem) override;
+  smt::expr addLocalBlock(const smt::expr &numelem) override;
 
   smt::expr getNumElementsOfMemBlock(const smt::expr &bid) const override {
     return getMemBlock(bid).numelem;
@@ -112,7 +113,7 @@ class MultipleArrayMemory: public Memory {
 public:
   MultipleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);
 
-  smt::expr addLocalMemBlock(const smt::expr &numelem) override;
+  smt::expr addLocalBlock(const smt::expr &numelem) override;
 
   smt::expr getNumElementsOfMemBlock(unsigned ubid) const
   { assert(ubid < getNumBlocks()); return numelems[ubid]; }

--- a/src/memory.h
+++ b/src/memory.h
@@ -46,7 +46,9 @@ public:
   unsigned int getBIDBits() const { return bidBits; }
   unsigned int getNumBlocks() const { return numGlobalBlocks + numLocalBlocks; }
 
+  // Bids smaller than numGlobalBlocks are global (0 ~ numGlobalBlocks - 1)
   virtual smt::expr isGlobalBlock(const smt::expr &bid) const = 0;
+  // Bids bigger than and equal to numGlobalBlocks are local blocks (numGlobalBlocks ~ numGlobalBlocks + numGlobalBlocks)
   virtual smt::expr isLocalBlock(const smt::expr &bid) const = 0;
 
   // Returns: (newly issued block id)
@@ -109,7 +111,7 @@ class MultipleArrayMemory: public Memory {
   std::vector<smt::expr> arrays;  // vector<(Index::sort() -> Float::sort())>
   std::vector<smt::expr> writables; // vector<Bool::sort()>
   std::vector<smt::expr> numelems;  // vector<Index::sort>
-  std::vector<smt::expr> isGlobals; // vector<Bool::sort()>, Bids smaller than numGlobalBlocks are global
+  std::vector<smt::expr> isGlobals; // vector<Bool::sort()>
 
 public:
   MultipleArrayMemory(unsigned int globalBlocks, unsigned int localBlocks);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -76,4 +76,4 @@ State::LinalgGenericScope::LinalgGenericScope(
 State::State(unsigned int numBlocks, MemEncoding encoding):
   hasQuantifier(false),
   isWellDefined(ctx),
-  m(Memory::create(numBlocks, encoding)) {}
+  m(Memory::create(numBlocks, numBlocks, encoding)) {}

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -455,7 +455,7 @@ MemRef::MemRef(Memory *m,
     const z3::sort &elemty,
     bool freshBlock): m(m), bid(ctx), offset(ctx), dims(dims), layout(layout) {
   if (freshBlock) {
-    bid = m->addLocalMemBlock(get1DSize());
+    bid = m->addLocalBlock(get1DSize());
     offset = Index::zero();
   } else {
     static int count = 0;
@@ -477,7 +477,7 @@ MemRef::MemRef(Memory *m,
     dims(dims),
     layout(layout) {
   if (freshBlock) {
-    bid = m->addLocalMemBlock(get1DSize());
+    bid = m->addLocalBlock(get1DSize());
     offset = Index::zero();
   }
 }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -466,7 +466,7 @@ MemRef::MemRef(Memory *m,
     dims(dims),
     layout(layout) {
   if (freshBlock) {
-    bid = m->addLocalBlock(get1DSize());
+    bid = m->addLocalBlock(get1DSize(), ctx.bool_val(false));
     offset = Index::zero();
   }
 }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -478,16 +478,15 @@ MemRef::MemRef(Memory *m,
     bool freshBlock) : MemRef(m, freshName("memref"), dims, layout, elemty, freshBlock) {}
 
 expr MemRef::getWellDefined() const {
-  expr wellDefined = z3::ult(bid, m->getNumBlocks()); // memref points currently issued memblock.
   expr size = get1DSize();
   if (size.is_numeral())
-    return wellDefined;
-  wellDefined = wellDefined && z3::ule(size, MAX_MEMREF_SIZE);
+    return ctx.bool_val(true);
+  auto expr = z3::ule(size, MAX_MEMREF_SIZE);
   for (auto dim: dims) {
     if (dim.is_numeral()) continue;
-    wellDefined = wellDefined && z3::ule(dim, MAX_DIM_SIZE);
+    expr = expr && z3::ule(dim, MAX_DIM_SIZE);
   }
-  return wellDefined.simplify();
+  return expr.simplify();
 }
 
 optional<tuple<vector<expr>, MemRef::Layout, z3::sort>>

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -483,15 +483,16 @@ MemRef::MemRef(Memory *m,
 }
 
 expr MemRef::getWellDefined() const {
+  expr wellDefined = z3::ult(bid, m->getNumBlocks()); // memref points currently issued memblock.
   expr size = get1DSize();
   if (size.is_numeral())
-    return ctx.bool_val(true);
-  auto expr = z3::ule(size, MAX_MEMREF_SIZE);
+    return wellDefined;
+  wellDefined = wellDefined && z3::ule(size, MAX_MEMREF_SIZE);
   for (auto dim: dims) {
     if (dim.is_numeral()) continue;
-    expr = expr && z3::ule(dim, MAX_DIM_SIZE);
+    wellDefined = wellDefined && z3::ule(dim, MAX_DIM_SIZE);
   }
-  return expr.simplify();
+  return wellDefined.simplify();
 }
 
 optional<tuple<vector<expr>, MemRef::Layout, z3::sort>>

--- a/src/value.h
+++ b/src/value.h
@@ -177,12 +177,12 @@ public:
 
   MemRef(Memory *m);
   MemRef(Memory *m,
+    const std::string &name,
     const std::vector<smt::expr> &dims,
     const Layout &layout,
     const z3::sort &elemty,
     bool freshBlock = false);
   MemRef(Memory *m,
-    const std::string &name,
     const std::vector<smt::expr> &dims,
     const Layout &layout,
     const z3::sort &elemty,

--- a/src/value.h
+++ b/src/value.h
@@ -177,10 +177,16 @@ public:
 
   MemRef(Memory *m);
   MemRef(Memory *m,
+    const std::vector<smt::expr> &dims,
+    const Layout &layout,
+    const z3::sort &elemty,
+    bool freshBlock = false);
+  MemRef(Memory *m,
     const std::string &name,
     const std::vector<smt::expr> &dims,
     const Layout &layout,
-    const z3::sort &elemty);
+    const z3::sort &elemty,
+    bool freshBlock = false);
 
   operator smt::expr() const { return bid && offset; }
 
@@ -195,6 +201,8 @@ public:
   smt::expr store(
       const smt::expr &value, const std::vector<smt::expr> &indices);
   smt::expr isInBounds() const;
+  smt::expr isGlobalBlock() const;
+  smt::expr isLocalBlock() const;
   smt::expr getBID() const { return bid; }
   Index getOffset() const { return offset; }
   smt::expr get1DSize() const { return smt::get1DSize(dims); }

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -444,7 +444,7 @@ optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
   auto [mVal, success] = memref.load(idxs);
   memref.setWritable(false);
 
-  st.wellDefined(z3::forall(toExprVector(idxs), mVal == tVal));
+  st.wellDefined(z3::forall(toExprVector(idxs), z3::implies(success, mVal == tVal)));
   st.hasQuantifier = true;
   st.regs.add(op.memref(), move(memref));
   return {};


### PR DESCRIPTION
To solve memory mismatch issue in `buffer_cast` operations, we introduce a new concept of memory block. 
That is "local memory block" which can exist only in that block scope.
So there blocks published dynamically at runtime and block size is determined at that time.
For simplicity, local memory blocks are not considered when showing refinement between memory for now.