### PR TITLE
Fix compile failures in latest c++ stdlibs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ link_directories(${MLIR_LIB_DIR})
 link_directories(${Z3_LIB_DIR})
 
 link_libraries(
-    MLIRViewLikeInterface MLIRInferTypeOpInterface
-    MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRViewLikeInterface MLIRAffine MLIRMemRef MLIRShape MLIRMath
-    MLIRControlFlowInterfaces MLIRStandard MLIRSideEffectInterfaces MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport
+    MLIRViewLikeInterface MLIRInferTypeOpInterface MLIRControlFlowInterfaces MLIRSideEffectInterfaces
+    MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRAffine MLIRMemRef MLIRShape MLIRMath
+    MLIRStandard MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport
     LLVMSupport LLVMDemangle z3 pthread m curses)
 
 add_executable(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ link_directories(${Z3_LIB_DIR})
 link_libraries(
     MLIRViewLikeInterface MLIRInferTypeOpInterface
     MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRViewLikeInterface MLIRAffine MLIRMemRef MLIRShape MLIRMath
-    MLIRControlFlowInterfaces MLIRStandard MLIRSideEffectInterfaces MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport MLIRInferTypeOpInterface
+    MLIRControlFlowInterfaces MLIRStandard MLIRSideEffectInterfaces MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport
     LLVMSupport LLVMDemangle z3 pthread m curses)
 
 add_executable(${PROJECT_NAME}

--- a/src/state.h
+++ b/src/state.h
@@ -5,6 +5,7 @@
 #include "value.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include <stack>
+#include <optional>
 #include <variant>
 #include "mlir/Support/LLVM.h"
 

--- a/src/value.h
+++ b/src/value.h
@@ -6,7 +6,6 @@
 #include <string>
 #include <optional>
 #include <vector>
-#include <concepts>
 
 class Memory;
 

--- a/src/value.h
+++ b/src/value.h
@@ -4,7 +4,9 @@
 #include "llvm/ADT/APFloat.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include <string>
+#include <optional>
 #include <vector>
+#include <concepts>
 
 class Memory;
 

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <variant>
 #include <vector>
+#include <optional>
 
 using namespace smt;
 using namespace std;


### PR DESCRIPTION
This PR fixes compile failures when using the latest stdlib (to be precise, libstdc++ 11.2)

Some files that use `std::optional<T>` were missing header `<optional>`. This still worked in the older stdlibs, but it seems the libraries have since been refactored and doesn't compile anymore.
Resolved this issue by simply adding headers in each file.

Also, the `MLIRInferTypeOpInterface` and `MLIRViewLikeInterface` library were written twice in CMakeLists. Deduped both libraries.