### PR TITLE
Update CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set (CMAKE_CXX_STANDARD 17)
 set(MLIR_DIR "")
 set(Z3_DIR "")
 set(CVC5_DIR "")
-set(USE_LIBC ON)
+set(USE_LIBC OFF)
 
 set(MLIR_INC_DIR "${MLIR_DIR}/include")
 set(MLIR_LIB_DIR "${MLIR_DIR}/lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,25 +2,21 @@ cmake_minimum_required(VERSION 3.15.0)
 project(mlir-tv VERSION 0.1.0)
 set (CMAKE_CXX_STANDARD 17)
 
-set(MLIR_DIR "" CACHE STRING "MLIR installation top-level directory")
-set(Z3_DIR "" CACHE STRING "Z3 installation top-level directory")
+set(MLIR_DIR "")
+set(Z3_DIR "")
+set(CVC5_DIR "")
+set(USE_LIBC ON)
 
 set(MLIR_INC_DIR "${MLIR_DIR}/include")
 set(MLIR_LIB_DIR "${MLIR_DIR}/lib")
 set(Z3_INC_DIR "${Z3_DIR}/include")
 set(Z3_LIB_DIR "${Z3_DIR}/lib")
+set(CVC5_INC_DIR "${CVC5_DIR}/include")
+set(CVC5_LIB_DIR "${CVC5_DIR}/lib")
 
-link_directories(${MLIR_LIB_DIR})
-link_directories(${Z3_LIB_DIR})
-
-link_libraries(
-    MLIRViewLikeInterface MLIRInferTypeOpInterface MLIRControlFlowInterfaces MLIRSideEffectInterfaces
-    MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRAffine MLIRMemRef MLIRShape MLIRMath
-    MLIRStandard MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport
-    LLVMSupport LLVMDemangle z3 pthread m curses)
-
-add_executable(${PROJECT_NAME}
-    src/main.cpp
+# Build library first
+set(PROJECT_LIB "mlirtv")
+add_library(${PROJECT_LIB} STATIC
     src/abstractops.cpp
     src/memory.cpp
     src/smt.cpp
@@ -28,11 +24,59 @@ add_executable(${PROJECT_NAME}
     src/value.cpp
     src/vcgen.cpp)
 
-target_link_options(${PROJECT_NAME} PUBLIC -fPIC)
-target_compile_options(${PROJECT_NAME} PUBLIC -fno-rtti)
+# Check for MLIR installation
+if(NOT MLIR_DIR)
+    message(FATAL_ERROR "path to MLIR must be provided!")
+elseif(NOT EXISTS ${MLIR_INC_DIR} OR NOT EXISTS ${MLIR_LIB_DIR})
+    message(FATAL_ERROR "the provided path doesn't seem to be a valid MLIR directory")
+else()
+    target_include_directories(${PROJECT_LIB} PUBLIC ${MLIR_INC_DIR})
+    target_link_directories(${PROJECT_LIB} PUBLIC ${MLIR_LIB_DIR})
+    target_link_libraries(${PROJECT_LIB} PUBLIC
+        MLIRViewLikeInterface MLIRInferTypeOpInterface MLIRControlFlowInterfaces MLIRSideEffectInterfaces
+        MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRAffine MLIRMemRef MLIRShape MLIRMath
+        MLIRStandard MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport
+        LLVMSupport LLVMDemangle pthread m curses)
+endif()
 
-include_directories(${MLIR_INC_DIR})
-include_directories(${Z3_INC_DIR})
+# Check if at least one solver is available
+if(NOT Z3_DIR AND NOT CVC5_DIR)
+    message(FATAL_ERROR "path to at least one of the solvers must be provided!")
+endif()
+
+# Check for Z3 installation
+if(Z3_DIR)
+    if(NOT EXISTS ${Z3_INC_DIR} OR NOT EXISTS ${Z3_LIB_DIR})
+        message(FATAL_ERROR "the provided path doesn't seem to be a valid Z3 directory")
+    else()
+        target_include_directories(${PROJECT_LIB} PUBLIC ${Z3_INC_DIR})
+        target_link_directories(${PROJECT_LIB} PUBLIC ${Z3_LIB_DIR})
+        target_link_libraries(${PROJECT_LIB} PUBLIC z3)
+    endif()
+endif()
+
+# Check for CVC5 installation
+if(CVC5_DIR)
+    if(NOT EXISTS ${CVC5_INC_DIR} OR NOT EXISTS ${CVC5_LIB_DIR})
+        message(FATAL_ERROR "the provided path doesn't seem to be a valid CVC5 directory")
+    else()
+        target_include_directories(${PROJECT_LIB} PUBLIC ${CVC5_INC_DIR})
+        target_link_directories(${PROJECT_LIB} PUBLIC ${CVC5_LIB_DIR})
+        target_link_libraries(${PROJECT_LIB} PUBLIC cvc5 cvc5parser)
+    endif()
+endif()
+
+# Try using libc if possible
+if(USE_LIBC)
+    target_compile_options(${PROJECT_LIB} PUBLIC -stdlib=libc++)
+    target_link_options(${PROJECT_LIB} PUBLIC -stdlib=libc++)
+endif()
+
+# Build executable
+add_executable(${PROJECT_NAME} src/main.cpp)
+add_dependencies(${PROJECT_NAME} ${PROJECT_LIB})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_LIB})
+target_compile_options(${PROJECT_NAME} PRIVATE -fno-rtti)
 
 enable_testing()
 add_subdirectory(${PROJECT_SOURCE_DIR}/tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,11 @@ set (CMAKE_CXX_STANDARD 17)
 
 set(MLIR_DIR "")
 set(Z3_DIR "")
-set(CVC5_DIR "")
-set(USE_LIBC OFF)
 
 set(MLIR_INC_DIR "${MLIR_DIR}/include")
 set(MLIR_LIB_DIR "${MLIR_DIR}/lib")
 set(Z3_INC_DIR "${Z3_DIR}/include")
 set(Z3_LIB_DIR "${Z3_DIR}/lib")
-set(CVC5_INC_DIR "${CVC5_DIR}/include")
-set(CVC5_LIB_DIR "${CVC5_DIR}/lib")
 
 # Build library first
 set(PROJECT_LIB "mlirtv")
@@ -40,7 +36,7 @@ else()
 endif()
 
 # Check if at least one solver is available
-if(NOT Z3_DIR AND NOT CVC5_DIR)
+if(NOT Z3_DIR)
     message(FATAL_ERROR "path to at least one of the solvers must be provided!")
 endif()
 
@@ -52,17 +48,6 @@ if(Z3_DIR)
         target_include_directories(${PROJECT_LIB} PUBLIC ${Z3_INC_DIR})
         target_link_directories(${PROJECT_LIB} PUBLIC ${Z3_LIB_DIR})
         target_link_libraries(${PROJECT_LIB} PUBLIC z3)
-    endif()
-endif()
-
-# Check for CVC5 installation
-if(CVC5_DIR)
-    if(NOT EXISTS ${CVC5_INC_DIR} OR NOT EXISTS ${CVC5_LIB_DIR})
-        message(FATAL_ERROR "the provided path doesn't seem to be a valid CVC5 directory")
-    else()
-        target_include_directories(${PROJECT_LIB} PUBLIC ${CVC5_INC_DIR})
-        target_link_directories(${PROJECT_LIB} PUBLIC ${CVC5_LIB_DIR})
-        target_link_libraries(${PROJECT_LIB} PUBLIC cvc5 cvc5parser)
     endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,22 @@ Currently this is in an experimental stage.
 
 Prerequisites: [CMake](https://cmake.org/download/)(>=3.15),
 [MLIR](https://github.com/llvm/llvm-project),
-[Z3-solver](https://github.com/Z3Prover/z3),
-[Python3](https://www.python.org/downloads/)(>=3.9)
+[Python3](https://www.python.org/downloads/)(>=3.9)  
+Solvers (at least one of them must be used): [Z3-solver](https://github.com/Z3Prover/z3),
+[CVC5](https://github.com/cvc5/cvc5)
 
 - Installation of MLIR: please follow [this instruction](https://llvm.org/docs/GettingStarted.html#getting-the-source-code-and-building-llvm) & run `cmake --build . --target install`
 
 ```bash
 mkdir build
 cd build
-# If you want to build a release version, please add -DCMAKE_BUILD_TYPE=RELEASE
+# At least one of -DZ3_DIR and -DCVC5_DIR must be provided
+# -DUSE_LIBC is OFF by default. Set it to ON iff the MLIR is built using libc++
 cmake -DMLIR_DIR=<dir/to/mlir-install> \
-      -DZ3_DIR=<dir/to/z3-install> \
+      [-DZ3_DIR=<dir/to/z3-install>] \
+      [-DCVC5_DIR=<dir/to/cvc5-install>] \
+      [-DUSE_LIBC=ON|OFF] \
+      [-DCMAKE_BUILD_TYPE=DEBUG|RELEASE] \
       ..
 cmake --build .
 ```

--- a/README.md
+++ b/README.md
@@ -8,19 +8,16 @@ Currently this is in an experimental stage.
 Prerequisites: [CMake](https://cmake.org/download/)(>=3.15),
 [MLIR](https://github.com/llvm/llvm-project),
 [Python3](https://www.python.org/downloads/)(>=3.9)  
-Solvers (at least one of them must be used): [Z3-solver](https://github.com/Z3Prover/z3),
-[CVC5](https://github.com/cvc5/cvc5)
+Solvers (at least one of them must be used): [Z3-solver](https://github.com/Z3Prover/z3)
 
 - Installation of MLIR: please follow [this instruction](https://llvm.org/docs/GettingStarted.html#getting-the-source-code-and-building-llvm) & run `cmake --build . --target install`
 
 ```bash
 mkdir build
 cd build
-# At least one of -DZ3_DIR and -DCVC5_DIR must be provided
 # -DUSE_LIBC is OFF by default. Set it to ON iff the MLIR is built using libc++
 cmake -DMLIR_DIR=<dir/to/mlir-install> \
-      [-DZ3_DIR=<dir/to/z3-install>] \
-      [-DCVC5_DIR=<dir/to/cvc5-install>] \
+      -DZ3_DIR=<dir/to/z3-install> \
       [-DUSE_LIBC=ON|OFF] \
       [-DCMAKE_BUILD_TYPE=DEBUG|RELEASE] \
       ..

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,16 +1,20 @@
 cmake_minimum_required(VERSION 3.15.0)
 
+# Try using libc when building googletest if possible
+if(USE_LIBC)
+    add_compile_options(-stdlib=libc++)
+    add_link_options(-stdlib=libc++)
+endif()
+
 include(FetchContent)
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
 )
+
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
-
-link_libraries(gtest_main)
-include_directories(${PROJECT_SOURCE_DIR})
 
 # Add each test file as executable
 add_executable(
@@ -22,6 +26,10 @@ add_executable(
   ../src/abstractops.cpp
   ../src/memory.cpp
 )
+add_dependencies(state_test ${PROJECT_LIB})
+target_include_directories(state_test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(state_test PRIVATE gtest_main ${PROJECT_LIB})
+
 add_executable(
   value_test
   value_test.cpp
@@ -30,8 +38,11 @@ add_executable(
   ../src/abstractops.cpp
   ../src/memory.cpp
 )
+add_dependencies(value_test ${PROJECT_LIB})
+target_include_directories(value_test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(value_test PRIVATE gtest_main ${PROJECT_LIB})
+
 include(GoogleTest)
 # Add each executable to gtest
-
 gtest_discover_tests(state_test)
 gtest_discover_tests(value_test)


### PR DESCRIPTION
This PR makes a lot of changes in CMakeLists to prevent possible misconfigurations and support more diverse environments.
It is also a prelude for supporting multiple smt solvers.

- Refactored global functions into target-specific functions
- Added options for using libc++
- cmake now fails if one or more necessary arguments aren't provided
- Removed CACHE STRING
- Removed redundant -fPIC option
- Updated README accordingly