### PR TITLE
Detach freshBlock parameter in MemRef 

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -452,30 +452,30 @@ expr Tensor::to1DArrayWithOfs(
         aop::mkZeroElemFromArr(arr)));
 }
 
-MemRef::MemRef(Memory *m): m(m), bid(ctx), offset(ctx), layout(Layout({}, ctx)) {}
+MemRef::MemRef(Memory *m) : m(m), bid(ctx), offset(ctx), layout(Layout({}, ctx)) {}
+
+MemRef::MemRef(Memory *m,
+  const smt::expr &bid,
+  const smt::expr &offset,
+  const std::vector<smt::expr> &dims,
+  const Layout &layout,
+  const z3::sort &elemty) : m(m), bid(bid), offset(offset), dims(dims), layout(layout) {}
 
 MemRef::MemRef(Memory *m,
   const std::string &name,
   const std::vector<expr> &dims,
   const Layout &layout,
-  const z3::sort &elemty,
-  bool freshBlock):
+  const z3::sort &elemty):
     m(m),
     bid(ctx.bv_const((name + "_bid").c_str(), m->getBIDBits())),
     offset(Index((name + "_offset").c_str())),
     dims(dims),
-    layout(layout) {
-  if (freshBlock) {
-    bid = m->addLocalBlock(get1DSize(), ctx.bool_val(false));
-    offset = Index::zero();
-  }
-}
+    layout(layout) {}
 
 MemRef::MemRef(Memory *m,
     const std::vector<expr> &dims,
     const Layout &layout,
-    const z3::sort &elemty,
-    bool freshBlock) : MemRef(m, freshName("memref"), dims, layout, elemty, freshBlock) {}
+    const z3::sort &elemty) : MemRef(m, freshName("memref"), dims, layout, elemty) {}
 
 expr MemRef::getWellDefined() const {
   expr size = get1DSize();

--- a/src/value.h
+++ b/src/value.h
@@ -178,16 +178,20 @@ public:
 
   MemRef(Memory *m);
   MemRef(Memory *m,
+    const smt::expr &bid,
+    const smt::expr &offset,
+    const std::vector<smt::expr> &dims,
+    const Layout &layout,
+    const z3::sort &elemty);
+  MemRef(Memory *m,
     const std::string &name,
     const std::vector<smt::expr> &dims,
     const Layout &layout,
-    const z3::sort &elemty,
-    bool freshBlock = false);
+    const z3::sort &elemty);
   MemRef(Memory *m,
     const std::vector<smt::expr> &dims,
     const Layout &layout,
-    const z3::sort &elemty,
-    bool freshBlock = false);
+    const z3::sort &elemty);
 
   operator smt::expr() const { return bid && offset; }
 

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -436,10 +436,14 @@ optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
   if (!dimsAndLayoutAndElemTy)
     return "unsupported type";
 
-  auto memref = MemRef(st.m.get(),
-      get<0>(*dimsAndLayoutAndElemTy),
-      get<1>(*dimsAndLayoutAndElemTy),
-      get<2>(*dimsAndLayoutAndElemTy));
+  auto dims = get<0>(*dimsAndLayoutAndElemTy);
+  auto layout = get<1>(*dimsAndLayoutAndElemTy);
+  auto elemty = get<2>(*dimsAndLayoutAndElemTy);
+  // Add new local block
+  auto bid = st.m->addLocalBlock(smt::get1DSize(dims), ctx.bool_val(false));
+  auto offset = Index::zero();
+  // Create MemRef which points newly created block id
+  auto memref = MemRef(st.m.get(), bid, offset, dims, layout, elemty);
 
   if (memrefTy.getAffineMaps().empty()) {
     // memref with identity map

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -439,8 +439,7 @@ optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
   auto memref = MemRef(st.m.get(),
       get<0>(*dimsAndLayoutAndElemTy),
       get<1>(*dimsAndLayoutAndElemTy),
-      get<2>(*dimsAndLayoutAndElemTy),
-      true);
+      get<2>(*dimsAndLayoutAndElemTy));
 
   if (memrefTy.getAffineMaps().empty()) {
     // memref with identity map


### PR DESCRIPTION
To make it clear that `BufferCastOp` creates a new local memory block, we remove freshBlock parameters.
And we explicitly call `addLocalBlock` to memory when encoding BufferCastOp.
In this way, we keep the consistency that the memref points a already existing block id. 