### PR TITLE
Encode subview parameters and calculate transformed layout

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -564,9 +564,9 @@ void MemRef::setWritable(bool writable) {
   m->setWritable(bid, writable);
 }
 
-MemRef MemRef::subview(const std::vector<z3::expr> &offsets,
-    const std::vector<z3::expr> &sizes,
-    const std::vector<z3::expr> &strides) {
+MemRef MemRef::subview(const vector<expr> &offsets,
+    const vector<expr> &sizes,
+    const vector<expr> &strides) {
   auto layout = createSubViewLayout(offsets, strides);
   auto memref = MemRef(m, bid, offset, sizes, layout, Float::sort());
   return memref;
@@ -604,14 +604,14 @@ expr MemRef::to1DIdxWithLayout(const vector<expr> &idxs) {
 }
 
 MemRef::Layout MemRef::createSubViewLayout(
-   const vector<z3::expr> &offsets,
-   const vector<z3::expr> &strides) {
+   const vector<expr> &offsets,
+   const vector<expr> &strides) {
    // Before : <(d0, d1) -> (d0 * s0 + d1)>,
    // After: <(d0, d1) -> ((d0 + offsets[0]) * strides[0] * s0 + (d1 + offsets[1]) * strides[1])>
    assert(layout.indVars.size() == offsets.size());
    assert(layout.indVars.size() == strides.size());
 
-   vector<z3::expr> idxs;
+   vector<expr> idxs;
    for (unsigned i = 0; i < layout.indVars.size(); i ++)
      idxs.push_back((layout.indVars[i] + offsets[i]) * strides[i]);
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -564,22 +564,13 @@ void MemRef::setWritable(bool writable) {
   m->setWritable(bid, writable);
 }
 
-MemRef::Layout MemRef::toSubViewLayout(
-   const vector<z3::expr> &offsets,
-   const vector<z3::expr> &strides) {
-   // Before : <(d0, d1) -> (d0 * s0 + d1)>,
-   // After: <(d0, d1) -> ((d0 + offsets[0]) * strides[0] * s0 + (d1 + offsets[1]) * strides[1])>
-   assert(layout.indVars.size() == offsets.size());
-   assert(layout.indVars.size() == strides.size());
-
-   vector<z3::expr> idxs;
-   for (unsigned i = 0; i < layout.indVars.size(); i ++)
-     idxs.push_back((layout.indVars[i] + offsets[i]) * strides[i]);
-
-   auto transformed = layout.expr
-     .substitute(toExprVector(layout.indVars), toExprVector(idxs));
-   return Layout(layout.indVars, transformed);
- }
+MemRef MemRef::subview(const std::vector<z3::expr> &offsets,
+    const std::vector<z3::expr> &sizes,
+    const std::vector<z3::expr> &strides) {
+  auto layout = createSubViewLayout(offsets, strides);
+  auto memref = MemRef(m, bid, offset, sizes, layout, Float::sort());
+  return memref;
+}
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const MemRef &m) {
   assert(m.dims.size() > 0);
@@ -611,3 +602,20 @@ MemRef MemRef::eval(z3::model m) const {
 expr MemRef::to1DIdxWithLayout(const vector<expr> &idxs) {
   return layout.expr.substitute(toExprVector(layout.indVars), toExprVector(idxs));
 }
+
+MemRef::Layout MemRef::createSubViewLayout(
+   const vector<z3::expr> &offsets,
+   const vector<z3::expr> &strides) {
+   // Before : <(d0, d1) -> (d0 * s0 + d1)>,
+   // After: <(d0, d1) -> ((d0 + offsets[0]) * strides[0] * s0 + (d1 + offsets[1]) * strides[1])>
+   assert(layout.indVars.size() == offsets.size());
+   assert(layout.indVars.size() == strides.size());
+
+   vector<z3::expr> idxs;
+   for (unsigned i = 0; i < layout.indVars.size(); i ++)
+     idxs.push_back((layout.indVars[i] + offsets[i]) * strides[i]);
+
+   auto transformed = layout.expr
+     .substitute(toExprVector(layout.indVars), toExprVector(idxs));
+   return Layout(layout.indVars, transformed);
+ }

--- a/src/value.h
+++ b/src/value.h
@@ -217,8 +217,10 @@ public:
   void setWritable(bool writable);
   void setMemory(Memory *m) { this->m = m; }
 
-  MemRef::Layout createSubViewLayout(const std::vector<z3::expr> &offsets,
-     const std::vector<z3::expr> &strides);
+  // Return a new memerf which is subview of source memref.
+  MemRef subview(const std::vector<z3::expr> &offsets,
+      const std::vector<z3::expr> &sizes,
+      const std::vector<z3::expr> &strides);
 
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, const MemRef &);
   std::pair<smt::expr, std::vector<smt::expr>> refines(
@@ -236,4 +238,7 @@ public:
       const std::vector<smt::expr> &offbegins,
       const std::vector<smt::expr> &sizes) const;
   smt::expr to1DIdxWithLayout(const std::vector<smt::expr> &idxs);
+
+  MemRef::Layout createSubViewLayout(const std::vector<z3::expr> &offsets,
+     const std::vector<z3::expr> &strides);
 };

--- a/src/value.h
+++ b/src/value.h
@@ -218,9 +218,9 @@ public:
   void setMemory(Memory *m) { this->m = m; }
 
   // Return a new memerf which is subview of source memref.
-  MemRef subview(const std::vector<z3::expr> &offsets,
-      const std::vector<z3::expr> &sizes,
-      const std::vector<z3::expr> &strides);
+  MemRef subview(const std::vector<smt::expr> &offsets,
+      const std::vector<smt::expr> &sizes,
+      const std::vector<smt::expr> &strides);
 
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, const MemRef &);
   std::pair<smt::expr, std::vector<smt::expr>> refines(
@@ -239,6 +239,6 @@ public:
       const std::vector<smt::expr> &sizes) const;
   smt::expr to1DIdxWithLayout(const std::vector<smt::expr> &idxs);
 
-  MemRef::Layout createSubViewLayout(const std::vector<z3::expr> &offsets,
-     const std::vector<z3::expr> &strides);
+  MemRef::Layout createSubViewLayout(const std::vector<smt::expr> &offsets,
+     const std::vector<smt::expr> &strides);
 };

--- a/src/value.h
+++ b/src/value.h
@@ -217,6 +217,9 @@ public:
   void setWritable(bool writable);
   void setMemory(Memory *m) { this->m = m; }
 
+  MemRef::Layout toSubViewLayout(const std::vector<z3::expr> &offsets,
+     const std::vector<z3::expr> &strides);
+
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, const MemRef &);
   std::pair<smt::expr, std::vector<smt::expr>> refines(
       const MemRef &other) const;

--- a/src/value.h
+++ b/src/value.h
@@ -217,7 +217,7 @@ public:
   void setWritable(bool writable);
   void setMemory(Memory *m) { this->m = m; }
 
-  MemRef::Layout toSubViewLayout(const std::vector<z3::expr> &offsets,
+  MemRef::Layout createSubViewLayout(const std::vector<z3::expr> &offsets,
      const std::vector<z3::expr> &strides);
 
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, const MemRef &);

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -436,16 +436,14 @@ optional<string> encodeOp(State &st, mlir::memref::SubViewOp op) {
       st.regs.get<Index>(op.getDynamic ## ee(i)) : \
       Index(op.getStatic ## ee(i))); \
 }
-    ADD(sizes, Size);
     ADD(offsets, Offset);
+    ADD(sizes, Size);
     ADD(strides, Stride);
 #undef ADD
   }
 
   auto src = st.regs.get<MemRef>(op.source());
-  auto layout = src.createSubViewLayout(offsets, strides);
-
-  auto memref = MemRef(st.m.get(), src.getBID(), src.getOffset(),  sizes, layout, Float::sort());
+  auto memref = src.subview(offsets, sizes, strides);
   st.regs.add(op.getResult(), move(memref));
   return "Unsupported yet..";
 }

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -443,7 +443,7 @@ optional<string> encodeOp(State &st, mlir::memref::SubViewOp op) {
   }
 
   auto src = st.regs.get<MemRef>(op.source());
-  auto layout = src.toSubViewLayout(offsets, strides);
+  auto layout = src.createSubViewLayout(offsets, strides);
 
   auto memref = MemRef(st.m.get(), src.getBID(), src.getOffset(),  sizes, layout, Float::sort());
   st.regs.add(op.getResult(), move(memref));

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -426,6 +426,55 @@ optional<string> encodeOp(State &st, mlir::memref::StoreOp op) {
   return {};
 }
 
+vector<z3::expr> getSizes(const State &st, mlir::memref::SubViewOp op) {
+   vector<z3::expr> sizes;
+   for (unsigned i = 0; i < op.getSourceType().getRank(); i ++) {
+     if (op.isDynamicSize(i)) {
+       sizes.push_back(st.regs.get<Index>(op.getDynamicSize(i)));
+     } else {
+       sizes.push_back(Index(op.getStaticSize(i)));
+     }
+   }
+   return sizes;
+ }
+
+ vector<z3::expr> getOffsets(const State &st, mlir::memref::SubViewOp op) {
+   vector<z3::expr> offsets;
+   for (unsigned i = 0; i < op.getSourceType().getRank(); i ++) {
+     if (op.isDynamicOffset(i)) {
+       offsets.push_back(st.regs.get<Index>(op.getDynamicOffset(i)));
+     } else {
+       offsets.push_back(Index(op.getStaticOffset(i)));
+     }
+   }
+   return offsets;
+ }
+
+ vector<z3::expr> getStrides(const State &st, mlir::memref::SubViewOp op) {
+   vector<z3::expr> strides;
+   for (unsigned i = 0; i < op.getSourceType().getRank(); i ++) {
+     if (op.isDynamicStride(i)) {
+       strides.push_back(st.regs.get<Index>(op.getDynamicStride(i)));
+     } else {
+       strides.push_back(Index(op.getStaticStride(i)));
+     }
+   }
+   return strides;
+ }
+
+template<>
+optional<string> encodeOp(State &st, mlir::memref::SubViewOp op) {
+  auto sizes = getSizes(st, op);
+  auto offsets = getOffsets(st, op);
+  auto strides = getStrides(st, op);
+  auto src = st.regs.get<MemRef>(op.source());
+  auto layout = src.toSubViewLayout(offsets, strides);
+
+  auto memref = MemRef(st.m.get(), src.getBID(), src.getOffset(),  sizes, layout, Float::sort());
+  st.regs.add(op.getResult(), move(memref));
+  return "Unsupported yet..";
+}
+
 template<>
 optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
   auto tensor = st.regs.get<Tensor>(op.getOperand());
@@ -1105,6 +1154,7 @@ static optional<string> encodeRegion(
 
     ENCODE(st, op, mlir::memref::LoadOp);
     ENCODE(st, op, mlir::memref::StoreOp);
+    ENCODE(st, op, mlir::memref::SubViewOp);
     ENCODE(st, op, mlir::memref::BufferCastOp);
     ENCODE(st, op, mlir::memref::TensorLoadOp);
 


### PR DESCRIPTION
In this PR, we support memref.subview encoding.
Memref subview operation makes an alias object of original memref with different offset, sizes, strides.

The detailed subview behavior can be found in [documents](https://mlir.llvm.org/docs/Dialects/MemRef/#memrefsubview-mlirmemrefsubviewop).

The basic calculation logic is like this. (offsets, sizes, strides are parameters of subview operation)
```
// Before : <(d0, d1) -> (d0 * s0 + d1)>,
// After: <(d0, d1) -> ((d0 + offsets[0]) * strides[0] * s0 + (d1 + offsets[1]) * strides[1])>
```

The result memref layout information are also doubly checked by MLIR verifier whether it matches with expected value.
(see `Type SubViewOp::inferResultType` in MLIR code)
