### PR TITLE
Encode memref inbounds check for SubViewOp when load, store memory

### DIFF
--- a/src/value.h
+++ b/src/value.h
@@ -171,9 +171,12 @@ public:
   public:
     std::vector<smt::expr> indVars;
     smt::expr expr;
+    smt::expr inbounds;
 
-    Layout(const std::vector<smt::expr> &indVars, const smt::expr &expr):
-      indVars(indVars), expr(expr) {}
+    Layout(const std::vector<smt::expr> &indVars,
+      const smt::expr &expr,
+      const smt::expr &inbounds):
+      indVars(indVars), expr(expr), inbounds(inbounds) {}
   };
 
   MemRef(Memory *m);
@@ -237,7 +240,7 @@ public:
   smt::expr to1DArrayWithOfs(
       const std::vector<smt::expr> &offbegins,
       const std::vector<smt::expr> &sizes) const;
-  smt::expr to1DIdxWithLayout(const std::vector<smt::expr> &idxs);
+  std::pair<smt::expr, smt::expr> to1DIdxWithLayout(const std::vector<smt::expr> &idxs);
 
   MemRef::Layout createSubViewLayout(const std::vector<smt::expr> &offsets,
      const std::vector<smt::expr> &strides);

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -445,7 +445,7 @@ optional<string> encodeOp(State &st, mlir::memref::SubViewOp op) {
   auto src = st.regs.get<MemRef>(op.source());
   auto memref = src.subview(offsets, sizes, strides);
   st.regs.add(op.getResult(), move(memref));
-  return "Unsupported yet..";
+  return {};
 }
 
 template<>


### PR DESCRIPTION
In this PR, we added inbounds check for SubViewOp
In documents, there's comments about how memref bounds are defined.

```
// Note that the subview op does not guarantee that the result
// memref is "inbounds" w.r.t to base memref. It is upto the client
// to ensure that the subview is accessed in a manner that is
// in-bounds.
```

To carefully deal with this inbounds check, the every memref's Layout should carry this inbounds information.
Then result memref bounds are determined from the source's memref information. 

For example,

```C
%0: memref<2x3xf32>
// %0's Layout is defined..
// layout.indVars = d0, d1
// layout.expr = d0 * 3 + d1
// layout.inbounds = d0 < 2 && d1 < 3

%1 = memref.subview %0[0, 0][2, 2][2, 1] : 
    memref<2x3xf32> to memref<2x2xf32, affine_map<(d0, d1) -> (d0 * 3 * 2 + d1)>>
// %1's Layout is defined..
// layout.indVars = d0, d1
// layout.expr = d0 * 6 + d1
// layout.inbounds = d0 * 2 < 2 && d1 < 3

%2 = memref.load %1[1, 1] : memref<2x2xf32, affine_map<(d0, d1) -> (d0 * 3 * 2 + d1)>>
// The inbounds condition is calculated like this,
// %1.layout.inbounds.substitude(indVars, {1, 1}) = 1 * 2 < 2 && 1 < 3 = false
// So this load operation is not well defined. 
```

Here we assume `strides`, `offsets` operands are positive values.
There's no explicit descriptions in documents, we can find the motivation of strided memref in [Strided MemRef Proposal](https://groups.google.com/a/tensorflow.org/g/mlir/c/MaL8m2nXuio/).
```
...
A stride specification is a list of integer values that are either non-negative (static case) or `-1` (dynamic case).
Strides encode the distance in memory between successive entries along a particular dimension.
...
```
