### PR TITLE
Implement memref.subview rank reduction cases

### DIFF
--- a/src/value.h
+++ b/src/value.h
@@ -223,7 +223,8 @@ public:
   // Return a new memerf which is subview of source memref.
   MemRef subview(const std::vector<smt::expr> &offsets,
       const std::vector<smt::expr> &sizes,
-      const std::vector<smt::expr> &strides);
+      const std::vector<smt::expr> &strides,
+      int rankDiff = 0);
 
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, const MemRef &);
   std::pair<smt::expr, std::vector<smt::expr>> refines(
@@ -242,6 +243,7 @@ public:
       const std::vector<smt::expr> &sizes) const;
   std::pair<smt::expr, smt::expr> to1DIdxWithLayout(const std::vector<smt::expr> &idxs);
 
-  MemRef::Layout createSubViewLayout(const std::vector<smt::expr> &offsets,
-     const std::vector<smt::expr> &strides);
+  MemRef::Layout createSubViewLayout(const std::vector<smt::expr> &indVars,
+      const std::vector<smt::expr> &offsets,
+      const std::vector<smt::expr> &strides);
 };

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -441,9 +441,10 @@ optional<string> encodeOp(State &st, mlir::memref::SubViewOp op) {
     ADD(strides, Stride);
 #undef ADD
   }
-
   auto src = st.regs.get<MemRef>(op.source());
-  auto memref = src.subview(offsets, sizes, strides);
+  int rankDiff = op.getSourceType().getRank() - op.getType().getRank();
+  assert(rankDiff >= 0); // only reducing rank is allowed
+  auto memref = src.subview(offsets, sizes, strides, rankDiff);
   st.regs.add(op.getResult(), move(memref));
   return {};
 }

--- a/tests/litmus/memref-ops/subview_reduce_rank.src.mlir
+++ b/tests/litmus/memref-ops/subview_reduce_rank.src.mlir
@@ -1,0 +1,8 @@
+// VERIFY
+
+ func @subview(%arg: memref<8x16x4xf32>) -> f32 {
+   %c0 = constant 0 : index
+   %c1 = constant 1 : index
+   %1 = memref.load %arg[%c0, %c1, %c1]: memref<8x16x4xf32>
+   return %1 : f32
+ }

--- a/tests/litmus/memref-ops/subview_reduce_rank.tgt.mlir
+++ b/tests/litmus/memref-ops/subview_reduce_rank.tgt.mlir
@@ -1,0 +1,6 @@
+func @subview(%arg: memref<8x16x4xf32>) -> f32 {
+   %c1 = constant 1 : index
+   %1 = memref.subview %arg[0, 0, 0][1, 16, 4][1, 1, 1] : memref<8x16x4xf32> to memref<16x4xf32>
+   %2 = memref.load %1[%c1, %c1]: memref<16x4xf32>
+   return %2 : f32
+ }


### PR DESCRIPTION

In this PR, we additionally encode rank reduced cases of subview operation.
In MLIR [documents](https://mlir.llvm.org/docs/Dialects/MemRef/#memrefsubview-mlirmemrefsubviewop), A subview operation may additionally reduce the rank of the resulting view by removing dimensions that are statically known to be of size 1.

So after comparing source and result memref's rank, we can remove dimension if its size is statically known to be 1.
This process should be done while traversing dimension in increasing order, as in SubViewOp in MLIR (see `Type SubViewOp::inferRankReducedResultType` in MemRefOps.cpp)
