### PR TITLE
Print counter example instruction in pretty format

### DIFF
--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -1162,17 +1162,23 @@ static void printCounterEx(
   }
 
   llvm::outs() << "\n<Source's instructions>\n";
-  for (auto &[v, e]: st_src.regs) {
-    if (args_src.contains(v))
-      continue;
-    llvm::outs() << "\t'" << v << "'\n\t\tValue: " << e << "\n";
+  for (auto &op: src.getRegion().front()) {
+    if (op.getNumResults() > 0 && st_src.regs.contains(op.getResult(0))) {
+      auto value =  st_src.regs.findOrCrash(op.getResult(0));
+      llvm::outs() << "\t'" << op.getResult(0) << "'\n\t\tValue: " << value << "\n";
+    } else {
+      llvm::outs() << "\t" << op << "\n";
+    }
   }
 
   llvm::outs() << "\n<Target's instructions>\n";
-  for (auto &[v, e]: st_tgt.regs) {
-    if (args_tgt.contains(v))
-      continue;
-    llvm::outs() << "\t'" << v << "'\n\t\tValue: " << e << "\n";
+  for (auto &op: tgt.getRegion().front()) {
+    if (op.getNumResults() > 0 && st_tgt.regs.contains(op.getResult(0))) {
+      auto value =  st_tgt.regs.findOrCrash(op.getResult(0));
+      llvm::outs() << "\t'" << op.getResult(0) << "'\n\t\tValue: " << value << "\n";
+    } else {
+      llvm::outs() << "\t" << op << "\n";
+    }
   }
 
   if (st_src.retValue && step == VerificationStep::RetValue) {


### PR DESCRIPTION
The output instruction is not ordered, so it's hard to understand what it actually means.
So in this PR, we update the ordering of instruction based on input MLIR code.

## Input
```
func @fold_tensor_extract(%arg0 : memref<2x3xf32>) -> f32
{
  %c1 = constant 1 : index
  %c2 = constant 2 : index
  %0 = memref.tensor_load %arg0 : memref<2x3xf32>
  %1 = tensor.extract %0[%c1, %c2] : tensor<2x3xf32>
  return %1 : f32
}
```

## Before
```
Function fold_tensor_extract

<src>
  %c1 = constant 1 : index
  %c1_0 = constant 1 : index
  %0 = memref.tensor_load %arg0 : memref<2x3xf32>
  %1 = tensor.extract %0[%c1, %c1_0] : tensor<2x3xf32>
  return %1 : f32

<tgt>
  %c1 = constant 1 : index
  %c2 = constant 2 : index
  %0 = memref.load %arg0[%c1, %c2] : memref<2x3xf32>
  return %0 : f32

== Result: Return value mismatch
<Inputs>
        arg0: (bid: arg0_bid, offset: arg0_offset, dim: #x00000002, #x00000003)

<Source's instructions>
        '%1 = tensor.extract %0[%c1, %c1_0] : tensor<2x3xf32>'
                Value: (omitted)
        '%c1 = constant 1 : index'
                Value: #x00000001
        '%0 = memref.tensor_load %arg0 : memref<2x3xf32>'
                Value: (dim :#x00000002, #x00000003) (omitted)
        '%c1_0 = constant 1 : index'
                Value: #x00000001

<Target's instructions>
        '%0 = memref.load %arg0[%c1, %c2] : memref<2x3xf32>'
                Value: (omitted)
        '%c2 = constant 2 : index'
                Value: #x00000002
        '%c1 = constant 1 : index'
                Value: #x00000001

<Returned value>
        Src: #x0
        Tgt: #xf
solver's running time: 96 msec.
```

## After
```
Function fold_tensor_extract

<src>
  %c1 = constant 1 : index
  %c1_0 = constant 1 : index
  %0 = memref.tensor_load %arg0 : memref<2x3xf32>
  %1 = tensor.extract %0[%c1, %c1_0] : tensor<2x3xf32>
  return %1 : f32

<tgt>
  %c1 = constant 1 : index
  %c2 = constant 2 : index
  %0 = memref.load %arg0[%c1, %c2] : memref<2x3xf32>
  return %0 : f32

== Result: Return value mismatch
<Inputs>
        arg0: (bid: arg0_bid, offset: arg0_offset, dim: #x00000002, #x00000003)

<Source's instructions>
        '%c1 = constant 1 : index'
                Value: #x00000001
        '%c1_0 = constant 1 : index'
                Value: #x00000001
        '%0 = memref.tensor_load %arg0 : memref<2x3xf32>'
                Value: (dim :#x00000002, #x00000003) (omitted)
        '%1 = tensor.extract %0[%c1, %c1_0] : tensor<2x3xf32>'
                Value: (omitted)
        return %1 : f32

<Target's instructions>
        '%c1 = constant 1 : index'
                Value: #x00000001
        '%c2 = constant 2 : index'
                Value: #x00000002
        '%0 = memref.load %arg0[%c1, %c2] : memref<2x3xf32>'
                Value: (omitted)
        return %0 : f32

<Returned value>
        Src: #x0
        Tgt: #xf
solver's running time: 102 msec.
```