### PR TITLE
Implement prototype smt::Expr

### DIFF
--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -138,16 +138,15 @@ std::vector<Expr> Expr::toElements(const std::vector<Expr>& dims) const {
   std::vector<Expr> exprs;
   exprs.reserve(dims.size());
 
-  auto acc = std::accumulate(dims.crbegin(), dims.crend(), 
+  auto expanded_exprs = std::accumulate(dims.crbegin(), dims.crend(), 
     std::make_pair(this->clone(), std::move(exprs)),
     [](std::pair<Expr, std::vector<Expr>>& acc, const Expr& dim) {
       auto [idx_1d, expanded_exprs] = std::move(acc);
       expanded_exprs.push_back(urem(idx_1d, dim));
       idx_1d = udiv(idx_1d, dim);
       return std::make_pair(std::move(idx_1d), std::move(expanded_exprs));
-    });
-  
-  auto expanded_exprs = std::move(acc.second);
+    })
+    .second;
   std::reverse(expanded_exprs.begin(), expanded_exprs.end());
   return expanded_exprs;
 }

--- a/src/smt.h
+++ b/src/smt.h
@@ -28,40 +28,15 @@ std::string or_omit(const expr &e);
 
 class Expr {
 private:
-    std::optional<z3::expr> z3_expr;
+  std::optional<z3::expr> z3_expr;
 
-    bool checkZ3(const Expr& arg0) {
-        return arg0.z3_expr.has_value();
-    }
-
-    template<typename... Es>
-    bool checkZ3(const Expr& arg0, const Es&... args) {
-        return arg0.z3_expr.has_value() && checkZ3(args...);
-    }
-
-    template<typename F, typename... Ts>
-    void applyZ3Op(F&& op, const Expr& arg0, const Ts... args) {
-        if (checkZ3(arg0, args...)) {
-            this->replaceExpr(op(arg0.z3_expr.value(), args.z3_expr.value()...));
-        }
-    }
+  Expr(std::optional<z3::expr> z3_expr): z3_expr(z3_expr) {}
 
 public:
-    Expr() = default;
-    Expr(const Expr& from) = default;
-    Expr(Expr&& from) = default;
-    Expr& operator=(const Expr& from) = default;
-    Expr& operator=(Expr&& from) = default;
-    // simplify expressions
-    Expr simplify() const;
-    // equivalent to from1DIdx
-    std::vector<Expr> toElements(const std::vector<Expr>& dims) const;
+  Expr simplify() const;
 
-    // update internal z3::expr and get previous z3::expr
-    std::optional<z3::expr> replaceExpr(z3::expr&& z3_expr);
-
-    Expr urem(const Expr& rhs) const;
-    Expr udiv(const Expr& rhs) const;
+  Expr urem(const Expr &rhs) const;
+  Expr udiv(const Expr &rhs) const;
 };
 } // namespace smt
 

--- a/src/smt.h
+++ b/src/smt.h
@@ -38,7 +38,7 @@ public:
   Expr urem(const Expr &rhs) const;
   Expr udiv(const Expr &rhs) const;
 };
-} // namespace smt
+};
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const smt::expr &e);
 llvm::raw_ostream& operator<<(

--- a/src/smt.h
+++ b/src/smt.h
@@ -3,6 +3,8 @@
 #include "llvm/Support/raw_ostream.h"
 #include "z3++.h"
 #include <vector>
+#include <functional>
+#include <optional>
 
 namespace smt {
 using expr = z3::expr;
@@ -15,13 +17,42 @@ std::vector<expr> from1DIdx(
 std::vector<expr> simplifyList(const std::vector<expr> &exprs);
 
 expr to1DIdx(const std::vector<expr> &idxs,
-                 const std::vector<expr> &dims);
+                const std::vector<expr> &dims);
 expr to1DIdxWithLayout(const std::vector<expr> &idxs, expr layout);
 expr fitsInDims(const std::vector<expr> &idxs,
-                    const std::vector<expr> &sizes);
+                const std::vector<expr> &sizes);
 z3::expr_vector toExprVector(const std::vector<expr> &vec);
 std::string or_omit(const expr &e);
+
+class Expr {
+private:
+    std::optional<z3::expr> z3_expr;
+    Expr(const Expr& from);
+
+    void applyZ3Operation(std::function<z3::expr(z3::expr const&)>&& op, const Expr& arg0);
+    void applyZ3Operation(std::function<z3::expr(z3::expr const&, z3::expr const&)>&& op, const Expr& arg0, const Expr& arg1);
+
+public:
+    // default constructor
+    Expr();
+    // move constructor
+    Expr(Expr&& from);
+    // explicit copy 
+    Expr clone() const;
+    // move assignment operator
+    Expr& operator=(Expr&& from);
+    // simplify expressions
+    Expr simplify() const;
+    // equivalent to from1DIdx
+    std::vector<Expr> toElements(const std::vector<Expr>& dims) const;
+
+    // update internal z3::expr and get previous z3::expr
+    std::optional<z3::expr> replaceExpr(z3::expr&& z3_expr);
+
+    friend Expr urem(const Expr& lhs, const Expr& rhs);
+    friend Expr udiv(const Expr& lhs, const Expr& rhs);
 };
+} // namespace smt
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const smt::expr &e);
 llvm::raw_ostream& operator<<(


### PR DESCRIPTION
This PR presents a proof-of-concept expr wrapper class, `smt::Expr`.

This class has three major goals as of now:
- Hide away solver-specific interface as much as possible
- Prevent potential performance degradation while dealing with many expressions
- Reduce the complexity of supporting new solvers

This class doesn't have enough methods to be fully functional, so it hasn't replaced any `z3::expr`s yet. 