### PR TITLE
Implement more solver-independent wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.15.0)
 project(mlir-tv VERSION 0.1.0)
 set (CMAKE_CXX_STANDARD 17)
 
-set(MLIR_DIR "")
-set(Z3_DIR "")
+set(MLIR_DIR CACHE PATH "MLIR installation top-level directory")
+set(Z3_DIR CACHE PATH "Z3 installation top-level directory")
+option(USE_LIBC "Use libc++ in case the MLIR is linked against libc++")
 
 set(MLIR_INC_DIR "${MLIR_DIR}/include")
 set(MLIR_LIB_DIR "${MLIR_DIR}/lib")

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -297,14 +297,6 @@ Expr ExprVec::fitsInDims(const ExprVec &sizes) const {
 }
 } // namespace smt
 
-
-void test() {
-  auto ct = smt::ContextBuilder().useZ3().build().value();
-  auto e1 = ct.bvVal(32, 32);
-  auto e2 = ct.bvVal(32, 32);
-  e1.add(e2);
-}
-
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const smt::expr &e) {
   std::stringstream ss;
   ss << e;

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -14,7 +14,7 @@ template<class T, class Fn>
 optional<T> fmap(const optional<T> &x, Fn &&fn) {
   if (!x)
     return std::nullopt;
-  return {fn(*x)};
+  return std::make_optional(fn(*x));
 }
 
 template<class Fn>

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -277,7 +277,7 @@ Expr operator|(const Expr &lhs, const Expr &rhs) {
   return Expr(move(z3_expr));
 }
 
-Expr Expr::mkBV(const uint32_t val, const size_t sz) {
+Expr Expr::mkBV(const uint64_t val, const size_t sz) {
   auto z3_expr = fupdate(sctx.z3_ctx, [val, sz](auto &ctx){ return ctx.bv_val(val, sz); });
 
   return Expr(move(z3_expr));

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -207,11 +207,11 @@ Expr Expr::simplify() const {
   return Expr(std::move(z3_expr));
 }
 
-ExprVec Expr::toNDIndices(const ExprVec &dims) const {
+std::vector<Expr> Expr::toNDIndices(const std::vector<Expr> &dims) const {
   assert(dims.size() > 0);
 
   auto idx_1d = *this;
-  ExprVec expanded_exprs;
+  std::vector<Expr> expanded_exprs;
   expanded_exprs.reserve(dims.size());
   std::for_each(dims.crbegin(), dims.crend(), 
     [&idx_1d, &expanded_exprs](const Expr& dim) {

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -15,26 +15,17 @@ z3::expr_vector toExprVector(const vector<smt::expr> &vec) {
 
 namespace smt {
 class Context {
-
 public:
-  std::optional<z3::context> z3_ctx;
+  optional<z3::context> z3_ctx;
 
   Context() {
-    this->z3_ctx = std::nullopt;
+    this->z3_ctx = nullopt;
   }
 
   Context(bool use_z3) {
     if (use_z3) {
       this->z3_ctx.emplace();
     }
-  }
-
-  template<class Fn>
-  auto z3Map(Fn fn) {
-    auto &ctx = this->z3_ctx;
-    if (ctx)
-      return std::optional(fn(*ctx));
-    return std::optional<decltype(fn(*ctx))>();
   }
 };
 
@@ -71,7 +62,7 @@ vector<expr> simplifyList(const vector<expr> &exprs) {
   vector<expr> v;
   v.reserve(exprs.size());
   for (auto &e: exprs)
-    v.push_back(std::move(e.simplify()));
+    v.push_back(move(e.simplify()));
   return v;
 }
 
@@ -107,12 +98,12 @@ expr fitsInDims(
   return cond;
 }
 
-expr mkFreshVar(const sort &s, std::string &&prefix) {
+expr mkFreshVar(const sort &s, string &&prefix) {
   Z3_ast ast = Z3_mk_fresh_const(ctx, prefix.c_str(), s);
   return z3::expr(ctx, ast);
 }
 
-expr mkVar(const sort &s, std::string &&name) {
+expr mkVar(const sort &s, string &&name) {
   return ctx.constant(name.c_str(), s);
 }
 
@@ -124,14 +115,14 @@ expr mkBool(bool b) {
   return ctx.bool_val(b);
 }
 
-func_decl mkUF(const sort &domain, const sort &range, std::string &&name) {
+func_decl mkUF(const sort &domain, const sort &range, string &&name) {
   return ctx.function(move(name).c_str(), domain, range);
 }
 
 func_decl mkUF(
     const vector<sort> &domain,
     const sort &range,
-    std::string &&name) {
+    string &&name) {
   z3::sort_vector v(ctx);
   for (const auto &s: domain)
     v.push_back(s);
@@ -144,12 +135,12 @@ bool structurallyEq(const expr &e1, const expr &e2) {
 
 expr substitute(
     expr e,
-    const std::vector<expr> &vars,
-    const std::vector<expr> &values) {
+    const vector<expr> &vars,
+    const vector<expr> &values) {
   return e.substitute(toExprVector(vars), toExprVector(values));
 }
 
-expr forall(const std::vector<expr> &vars, const expr &e) {
+expr forall(const vector<expr> &vars, const expr &e) {
   return z3::forall(toExprVector(vars), e);
 }
 
@@ -181,7 +172,7 @@ string or_omit(const expr &e) {
   return s;
 }
 
-string or_omit(const std::vector<expr> &evec) {
+string or_omit(const vector<expr> &evec) {
   string s;
   llvm::raw_string_ostream rso(s);
   rso << "(";
@@ -197,106 +188,116 @@ string or_omit(const std::vector<expr> &evec) {
   return s;
 }
 
-Expr::Expr(std::optional<z3::expr> &&z3_expr) {
-  this->z3_expr = std::move(z3_expr);
+Expr::Expr(optional<z3::expr> &&z3_expr) {
+  this->z3_expr = move(z3_expr);
 }
 
 Expr Expr::simplify() const {
   auto z3_expr = fmap(this->z3_expr, [](auto e) { return e.simplify(); });
 
-  return Expr(std::move(z3_expr));
+  return Expr(move(z3_expr));
 }
 
-std::vector<Expr> Expr::toNDIndices(const std::vector<Expr> &dims) const {
+vector<Expr> Expr::toNDIndices(const vector<Expr> &dims) const {
   assert(dims.size() > 0);
 
   auto idx_1d = *this;
-  std::vector<Expr> expanded_exprs;
+  vector<Expr> expanded_exprs;
   expanded_exprs.reserve(dims.size());
-  std::for_each(dims.crbegin(), dims.crend(), 
+  for_each(dims.crbegin(), dims.crend(), 
     [&idx_1d, &expanded_exprs](const Expr& dim) {
       expanded_exprs.push_back(idx_1d.urem(dim));
       idx_1d = idx_1d.udiv(dim);
     });
-  std::reverse(expanded_exprs.begin(), expanded_exprs.end());
+  reverse(expanded_exprs.begin(), expanded_exprs.end());
   return expanded_exprs;
 }
 
 Expr Expr::urem(const Expr &rhs) const {
   auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return z3::urem(e, *rhs.z3_expr); });
   
-  return Expr(std::move(z3_expr));
+  return Expr(move(z3_expr));
 }
 
 Expr Expr::udiv(const Expr& rhs) const {
   auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return z3::udiv(e, *rhs.z3_expr); });
   
-  return Expr(std::move(z3_expr));
-}
-
-Expr Expr::add(const Expr& rhs) const {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e + *rhs.z3_expr; });
-  
-  return Expr(std::move(z3_expr));
-}
-
-Expr Expr::sub(const Expr& rhs) const {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e - *rhs.z3_expr; });
-  
-  return Expr(std::move(z3_expr));
-}
-
-Expr Expr::mul(const Expr& rhs) const {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e * *rhs.z3_expr; });
-  
-  return Expr(std::move(z3_expr));
+  return Expr(move(z3_expr));
 }
 
 Expr Expr::ult(const Expr& rhs) const {
   auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return z3::ult(e, *rhs.z3_expr); });
   
-  return Expr(std::move(z3_expr));
+  return Expr(move(z3_expr));
 }
 
 Expr Expr::ugt(const Expr& rhs) const {
   auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return z3::ugt(e, *rhs.z3_expr); });
   
-  return Expr(std::move(z3_expr));
+  return Expr(move(z3_expr));
 }
 
-Expr Expr::boolAnd(const Expr& rhs) const {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e && *rhs.z3_expr; });
+Expr operator+(const Expr &lhs, const Expr &rhs) {
+  auto z3_expr = fmap(lhs.z3_expr, [&rhs](auto e) { return e + *rhs.z3_expr; });
   
-  return Expr(std::move(z3_expr));
+  return Expr(move(z3_expr));
 }
 
-Expr Expr::boolOr(const Expr& rhs) const {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e || *rhs.z3_expr; });
+Expr operator-(const Expr &lhs, const Expr &rhs) {
+  auto z3_expr = fmap(lhs.z3_expr, [&rhs](auto e) { return e - *rhs.z3_expr; });
   
-  return Expr(std::move(z3_expr));
+  return Expr(move(z3_expr));
 }
 
-Expr Expr::bvVal(const uint32_t val, const size_t sz) {
-  auto z3_expr = sctx.z3Map([val, sz](auto &ctx){ return ctx.bv_val(val, sz); });
-
-  return Expr(std::move(z3_expr));
+Expr operator*(const Expr &lhs, const Expr &rhs) {
+  auto z3_expr = fmap(lhs.z3_expr, [&rhs](auto e) { return e * *rhs.z3_expr; });
+  
+  return Expr(move(z3_expr));
 }
 
-Expr Expr::bvConst(char* const name, const size_t sz) {
-  auto z3_expr = sctx.z3Map([name, sz](auto &ctx){ return ctx.bv_const(name, sz); });
-
-  return Expr(std::move(z3_expr));
+Expr operator&(const Expr &lhs, const Expr &rhs) {
+  auto z3_expr = fmap(lhs.z3_expr, [&rhs](auto e) { 
+    if (e.is_bool()) 
+      return e && *rhs.z3_expr;
+    else
+      return e & *rhs.z3_expr;
+  });
+  
+  return Expr(move(z3_expr));
 }
 
-Expr Expr::boolVal(const bool val) {
-  auto z3_expr = sctx.z3Map([val](auto &ctx){ return ctx.bool_val(val); });
+Expr operator|(const Expr &lhs, const Expr &rhs) {
+  auto z3_expr = fmap(lhs.z3_expr, [&rhs](auto e) { 
+    if (e.is_bool()) 
+      return e || *rhs.z3_expr;
+    else
+      return e | *rhs.z3_expr;
+  });
+  
+  return Expr(move(z3_expr));
+}
 
-  return Expr(std::move(z3_expr));
+Expr Expr::mkBV(const uint32_t val, const size_t sz) {
+  auto z3_expr = fupdate(sctx.z3_ctx, [val, sz](auto &ctx){ return ctx.bv_val(val, sz); });
+
+  return Expr(move(z3_expr));
+}
+
+Expr Expr::mkVar(char* const name, const size_t sz) {
+  auto z3_expr = fupdate(sctx.z3_ctx, [name, sz](auto &ctx){ return ctx.bv_const(name, sz); });
+
+  return Expr(move(z3_expr));
+}
+
+Expr Expr::mkBool(const bool val) {
+  auto z3_expr = fupdate(sctx.z3_ctx, [val](auto &ctx){ return ctx.bool_val(val); });
+
+  return Expr(move(z3_expr));
 }
 } // namespace smt
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const smt::expr &e) {
-  std::stringstream ss;
+  stringstream ss;
   ss << e;
   os << ss.str();
   return os;
@@ -304,7 +305,7 @@ llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const smt::expr &e) {
 
 
 llvm::raw_ostream& operator<<(
-    llvm::raw_ostream& os, const std::vector<smt::expr> &es) {
+    llvm::raw_ostream& os, const vector<smt::expr> &es) {
   os << "(";
   if (es.size() != 0) {
     os << es[0];

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -276,7 +276,7 @@ ExprVec ExprVec::simplify() const {
   return simplified_exprs;
 }
 
-Expr ExprVec::to1DIndices(const ExprVec &dims) const {
+Expr ExprVec::to1DIdx(const ExprVec &dims) const {
   assert(this->exprs.size() == dims.exprs.size());
   
   auto idx = this->exprs[0].clone();

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -138,16 +138,15 @@ std::vector<Expr> Expr::toElements(const std::vector<Expr>& dims) const {
   std::vector<Expr> exprs;
   exprs.reserve(dims.size());
 
-  auto acc = std::accumulate(dims.crbegin(), dims.crend(), 
+  auto expanded_exprs = std::accumulate(dims.crbegin(), dims.crend(), 
     std::make_pair(this->clone(), std::move(exprs)),
     [](std::pair<Expr, std::vector<Expr>>& acc, const Expr& dim) {
       auto [idx_1d, expanded_exprs] = std::move(acc);
       expanded_exprs.push_back(urem(idx_1d, dim));
       idx_1d = udiv(idx_1d, dim);
       return std::make_pair(std::move(idx_1d), std::move(expanded_exprs));
-    });
-  
-  auto expanded_exprs = std::move(acc.second);
+    })
+    .second;
   std::reverse(expanded_exprs.begin(), expanded_exprs.end());
   return expanded_exprs;
 }

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -160,11 +160,6 @@ Expr::Expr(Context* const ctx, std::optional<z3::expr> &&z3_expr) : Expr(ctx) {
   this->z3_expr = std::move(z3_expr);
 }
 
-Expr::Expr(Expr&& from) {
-  this->ctx = from.ctx;
-  this->z3_expr = std::move(from.z3_expr);
-}
-
 Expr Expr::clone() const {
   auto cloned_z3_expr = this->z3_expr;
   return Expr(this->ctx, std::move(cloned_z3_expr));
@@ -246,10 +241,6 @@ Expr Expr::boolOr(const Expr& rhs) const {
 
 ExprVec::ExprVec(Context* const ctx, std::vector<Expr>&& exprs) : ExprVec(ctx) {
   this->exprs = std::move(exprs);
-}
-
-ExprVec::ExprVec(ExprVec&& from) : ExprVec(from.ctx) {
-  this->exprs = std::move(from.exprs);
 }
 
 ExprVec ExprVec::withCapacity(Context* const ctx, size_t size) {

--- a/src/smt.h
+++ b/src/smt.h
@@ -67,9 +67,9 @@ public:
   friend Expr operator&(const Expr &lhs, const Expr &rhs);
   friend Expr operator|(const Expr &lhs, const Expr &rhs);
 
-  Expr mkBV(const uint64_t val, const size_t sz);
-  Expr mkVar(char* const name, const size_t sz);
-  Expr mkBool(const bool val);
+  static Expr mkBV(const uint64_t val, const size_t sz);
+  static Expr mkVar(char* const name, const size_t sz);
+  static Expr mkBool(const bool val);
 };
 } // namespace smt
 

--- a/src/smt.h
+++ b/src/smt.h
@@ -67,7 +67,7 @@ public:
   friend Expr operator&(const Expr &lhs, const Expr &rhs);
   friend Expr operator|(const Expr &lhs, const Expr &rhs);
 
-  Expr mkBV(const uint32_t val, const size_t sz);
+  Expr mkBV(const uint64_t val, const size_t sz);
   Expr mkVar(char* const name, const size_t sz);
   Expr mkBool(const bool val);
 };

--- a/src/smt.h
+++ b/src/smt.h
@@ -10,6 +10,8 @@ namespace smt {
 using expr = z3::expr;
 
 class Expr;
+class ExprVec;
+class Context;
 
 extern z3::context ctx;
 
@@ -26,74 +28,81 @@ expr fitsInDims(const std::vector<expr> &idxs,
 z3::expr_vector toExprVector(const std::vector<expr> &vec);
 std::string or_omit(const expr &e);
 
+class ContextBuilder {
+  private:
+    bool use_z3;
+
+  public:
+    ContextBuilder();
+    ContextBuilder& useZ3();
+    std::optional<Context> build() const;
+};
+
 class Context {
+  friend ContextBuilder;
+
 private:
     z3::context* z3_ctx;
-
-    template<typename F, typename T, typename... Ts>
-    std::optional<z3::expr> applyZ3Op(const F&& op, const T arg0, const Ts... args) {
-        if (this->z3_ctx) {
-            return std::optional(op(arg0, args...));
-        } else {
-            return {};
-        }
-    }
+    Context();
+    Context(bool use_z3);
 
 public:
-    Context();
-    void useZ3();
-
     Expr bvVal(const uint32_t val, const size_t sz);
     Expr bvConst(char* const name, const size_t sz);
+    Expr boolVal(const bool val);
 };
 
 class Expr {
+  friend Context;
 private:
+  Context* ctx;
   std::optional<z3::expr> z3_expr;
-
-  Expr(std::optional<z3::expr> z3_expr): z3_expr(z3_expr) {}
+  
+  Expr(Context* const ctx) : ctx(ctx) {};
+  Expr(Context* const ctx, std::optional<z3::expr> &&z3_expr);
 
 public:
+  Expr(Expr&& from);
+  Expr& operator=(Expr &&from) = default;
+  Expr clone() const;
+
   Expr simplify() const;
+  ExprVec toNDIndices(const ExprVec &dims) const;
 
   Expr urem(const Expr &rhs) const;
   Expr udiv(const Expr &rhs) const;
+  Expr add(const Expr &rhs) const;
+  Expr sub(const Expr &rhs) const;
+  Expr mul(const Expr &rhs) const;
+  Expr ult(const Expr &rhs) const;
+  Expr ugt(const Expr &rhs) const;
+  Expr boolAnd(const Expr &rhs) const;
+  Expr boolOr(const Expr &rhs) const;
 };
 
 class ExprVec {
+  friend Context;
+  friend Expr;
+
 private:
-    std::vector<Expr> exprs;
-    ExprVec(std::vector<Expr>&& exprs);
-    ExprVec(ExprVec&& from);
+  Context* ctx;
+  std::vector<Expr> exprs;
+
+  ExprVec(Context* const ctx): ctx(ctx) {};
+  ExprVec(Context* const ctx, std::vector<Expr>&& exprs);
+
+  static ExprVec withCapacity(Context* ctx, size_t size);
 
 public:
-    size_t size() const;
-    std::vector<Expr>::const_iterator cbegin() const;
-    std::vector<Expr>::const_iterator cend() const;
-    std::vector<Expr>::const_reverse_iterator crbegin() const;
-    std::vector<Expr>::const_reverse_iterator crend() const;
+  ExprVec(ExprVec&& from);
+  ExprVec& operator=(ExprVec &&from) = default;
+  ExprVec clone() const;
 
-    ExprVec simplify() const;
-    Expr to1DSize() const;
-    Expr to1DIdx(ExprVec dims) const;
-    Expr to1DIdxWithLayout(Expr layout) const;
+  ExprVec simplify() const;
+  Expr to1DIndices(const ExprVec &dims) const;
+  Expr fitsInDims(const ExprVec &sizes) const;
 };
-
-class Sort {
-private:
-    z3::sort z3_sort;
-
-public:
-};
-
-class SortVec {
-private:
-    std::vector<Sort> sorts;
-
-public:
-
-};
-}; // namespace smt
+} // namespace smt
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const smt::expr &e);
 llvm::raw_ostream& operator<<(

--- a/src/smt.h
+++ b/src/smt.h
@@ -12,10 +12,6 @@ using model = z3::model;
 using sort = z3::sort;
 using func_decl = z3::func_decl;
 
-class Expr;
-class ExprVec;
-class Context;
-
 extern z3::context ctx;
 
 expr get1DSize(const std::vector<expr> &dims);
@@ -50,44 +46,16 @@ sort bvSort(unsigned bw);
 sort boolSort();
 sort arraySort(const sort &domain, const sort &range);
 
-class ContextBuilder {
-  private:
-    bool use_z3;
-
-  public:
-    ContextBuilder();
-    ContextBuilder& useZ3();
-    std::optional<Context> build() const;
-};
-
-class Context {
-  friend ContextBuilder;
-
-private:
-    z3::context* z3_ctx;
-    Context();
-    Context(bool use_z3);
-
-public:
-    Expr bvVal(const uint32_t val, const size_t sz);
-    Expr bvConst(char* const name, const size_t sz);
-    Expr boolVal(const bool val);
-};
+class Expr;
+using ExprVec = std::vector<Expr>;
 
 class Expr {
-  friend Context;
 private:
-  Context* ctx;
   std::optional<z3::expr> z3_expr;
-  
-  Expr(Context* const ctx) : ctx(ctx) {};
-  Expr(Context* const ctx, std::optional<z3::expr> &&z3_expr);
+
+  Expr(std::optional<z3::expr> &&z3_expr);
 
 public:
-  Expr(Expr&& from) = default;
-  Expr& operator=(Expr &&from) = default;
-  Expr clone() const;
-
   Expr simplify() const;
   ExprVec toNDIndices(const ExprVec &dims) const;
 
@@ -100,29 +68,10 @@ public:
   Expr ugt(const Expr &rhs) const;
   Expr boolAnd(const Expr &rhs) const;
   Expr boolOr(const Expr &rhs) const;
-};
 
-class ExprVec {
-  friend Context;
-  friend Expr;
-
-private:
-  Context* ctx;
-  std::vector<Expr> exprs;
-
-  ExprVec(Context* const ctx): ctx(ctx) {};
-  ExprVec(Context* const ctx, std::vector<Expr>&& exprs);
-
-  static ExprVec withCapacity(Context* ctx, size_t size);
-
-public:
-  ExprVec(ExprVec&& from) = default;
-  ExprVec& operator=(ExprVec &&from) = default;
-  ExprVec clone() const;
-
-  ExprVec simplify() const;
-  Expr to1DIdx(const ExprVec &dims) const;
-  Expr fitsInDims(const ExprVec &sizes) const;
+  Expr bvVal(const uint32_t val, const size_t sz);
+  Expr bvConst(char* const name, const size_t sz);
+  Expr boolVal(const bool val);
 };
 } // namespace smt
 

--- a/src/smt.h
+++ b/src/smt.h
@@ -28,40 +28,15 @@ std::string or_omit(const expr &e);
 
 class Expr {
 private:
-    std::optional<z3::expr> z3_expr;
+  std::optional<z3::expr> z3_expr;
 
-    bool checkZ3(const Expr& arg0) {
-        return arg0.z3_expr.has_value();
-    }
-
-    template<typename... Es>
-    bool checkZ3(const Expr& arg0, const Es&... args) {
-        return arg0.z3_expr.has_value() && checkZ3(args...);
-    }
-
-    template<typename F, typename... Ts>
-    void applyZ3Op(F&& op, const Expr& arg0, const Ts... args) {
-        if (checkZ3(arg0, args...)) {
-            this->replaceExpr(op(arg0.z3_expr.value(), args.z3_expr.value()...));
-        }
-    }
+  Expr(std::optional<z3::expr> z3_expr): z3_expr(z3_expr) {}
 
 public:
-    Expr() = default;
-    Expr(const Expr& from) = default;
-    Expr(Expr&& from) = default;
-    Expr& operator=(const Expr& from) = default;
-    Expr& operator=(Expr&& from) = default;
-    // simplify expressions
-    Expr simplify() const;
-    // equivalent to from1DIdx
-    std::vector<Expr> toElements(const std::vector<Expr>& dims) const;
+  Expr simplify() const;
 
-    // update internal z3::expr and get previous z3::expr
-    std::optional<z3::expr> replaceExpr(z3::expr&& z3_expr);
-
-    Expr urem(const Expr& rhs) const;
-    Expr udiv(const Expr& rhs) const;
+  Expr urem(const Expr &rhs) const;
+  Expr udiv(const Expr &rhs) const;
 };
 } // namespace smt
 

--- a/src/smt.h
+++ b/src/smt.h
@@ -62,7 +62,7 @@ private:
   Expr(Context* const ctx, std::optional<z3::expr> &&z3_expr);
 
 public:
-  Expr(Expr&& from);
+  Expr(Expr&& from) = default;
   Expr& operator=(Expr &&from) = default;
   Expr clone() const;
 
@@ -94,7 +94,7 @@ private:
   static ExprVec withCapacity(Context* ctx, size_t size);
 
 public:
-  ExprVec(ExprVec&& from);
+  ExprVec(ExprVec&& from) = default;
   ExprVec& operator=(ExprVec &&from) = default;
   ExprVec clone() const;
 

--- a/src/smt.h
+++ b/src/smt.h
@@ -58,17 +58,18 @@ public:
 
   Expr urem(const Expr &rhs) const;
   Expr udiv(const Expr &rhs) const;
-  Expr add(const Expr &rhs) const;
-  Expr sub(const Expr &rhs) const;
-  Expr mul(const Expr &rhs) const;
   Expr ult(const Expr &rhs) const;
   Expr ugt(const Expr &rhs) const;
-  Expr boolAnd(const Expr &rhs) const;
-  Expr boolOr(const Expr &rhs) const;
 
-  Expr bvVal(const uint32_t val, const size_t sz);
-  Expr bvConst(char* const name, const size_t sz);
-  Expr boolVal(const bool val);
+  friend Expr operator+(const Expr &lhs, const Expr &rhs);
+  friend Expr operator-(const Expr &lhs, const Expr &rhs);
+  friend Expr operator*(const Expr &lhs, const Expr &rhs);
+  friend Expr operator&(const Expr &lhs, const Expr &rhs);
+  friend Expr operator|(const Expr &lhs, const Expr &rhs);
+
+  Expr mkBV(const uint32_t val, const size_t sz);
+  Expr mkVar(char* const name, const size_t sz);
+  Expr mkBool(const bool val);
 };
 } // namespace smt
 

--- a/src/smt.h
+++ b/src/smt.h
@@ -99,7 +99,7 @@ public:
   ExprVec clone() const;
 
   ExprVec simplify() const;
-  Expr to1DIndices(const ExprVec &dims) const;
+  Expr to1DIdx(const ExprVec &dims) const;
   Expr fitsInDims(const ExprVec &sizes) const;
 };
 } // namespace smt

--- a/src/smt.h
+++ b/src/smt.h
@@ -46,9 +46,6 @@ sort bvSort(unsigned bw);
 sort boolSort();
 sort arraySort(const sort &domain, const sort &range);
 
-class Expr;
-using ExprVec = std::vector<Expr>;
-
 class Expr {
 private:
   std::optional<z3::expr> z3_expr;
@@ -57,7 +54,7 @@ private:
 
 public:
   Expr simplify() const;
-  ExprVec toNDIndices(const ExprVec &dims) const;
+  std::vector<Expr> toNDIndices(const std::vector<Expr> &dims) const;
 
   Expr urem(const Expr &rhs) const;
   Expr udiv(const Expr &rhs) const;

--- a/src/smt.h
+++ b/src/smt.h
@@ -38,7 +38,7 @@ public:
   Expr urem(const Expr &rhs) const;
   Expr udiv(const Expr &rhs) const;
 };
-} // namespace smt
+};
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const smt::expr &e);
 llvm::raw_ostream& operator<<(

--- a/src/smt.h
+++ b/src/smt.h
@@ -3,6 +3,8 @@
 #include "llvm/Support/raw_ostream.h"
 #include "z3++.h"
 #include <vector>
+#include <functional>
+#include <optional>
 
 namespace smt {
 using expr = z3::expr;
@@ -15,13 +17,42 @@ std::vector<expr> from1DIdx(
 std::vector<expr> simplifyList(const std::vector<expr> &exprs);
 
 expr to1DIdx(const std::vector<expr> &idxs,
-                 const std::vector<expr> &dims);
+                const std::vector<expr> &dims);
 expr to1DIdxWithLayout(const std::vector<expr> &idxs, expr layout);
 expr fitsInDims(const std::vector<expr> &idxs,
-                    const std::vector<expr> &sizes);
+                const std::vector<expr> &sizes);
 z3::expr_vector toExprVector(const std::vector<expr> &vec);
 std::string or_omit(const expr &e);
+
+class Expr {
+private:
+    std::optional<z3::expr> z3_expr;
+    Expr(const Expr& from);
+
+    void applyZ3Operation(std::function<z3::expr(z3::expr const&)>&& op, const Expr& arg0);
+    void applyZ3Operation(std::function<z3::expr(z3::expr const&, z3::expr const&)>&& op, const Expr& arg0, const Expr& arg1);
+
+public:
+    // default constructor
+    Expr();
+    // move constructor
+    Expr(Expr&& from);
+    // explicit copy 
+    Expr clone() const;
+    // move assignment operator
+    Expr& operator=(Expr&& from);
+    // simplify expressions
+    Expr simplify() const;
+    // equivalent to from1DIdx
+    std::vector<Expr> toElements(const std::vector<Expr>& dims) const;
+
+    // update internal z3::expr and get previous z3::expr
+    std::optional<z3::expr> replaceExpr(z3::expr&& z3_expr);
+
+    friend Expr urem(const Expr& lhs, const Expr& rhs);
+    friend Expr udiv(const Expr& lhs, const Expr& rhs);
 };
+} // namespace smt
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const smt::expr &e);
 llvm::raw_ostream& operator<<(

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,7 +7,7 @@
 // Fn is simply declared because std::function with template arguments works
 // poorly. :(
 template<class T, class Fn>
-auto fmap(const std::optional<T> &x, Fn &&fn) {
+auto fmap(const std::optional<T> &x, Fn fn) {
   if (x)
     return std::optional(fn(*x));
   return std::optional<decltype(fn(*x))>();

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,7 +7,7 @@
 // Fn is simply declared because std::function with template arguments works
 // poorly. :(
 template<class T, class Fn>
-auto fmap(const std::optional<T> &x, Fn fn) {
+auto fmap(const std::optional<T> &x, Fn &&fn) {
   if (x)
     return std::optional(fn(*x));
   return std::optional<decltype(fn(*x))>();

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,3 +12,10 @@ auto fmap(const std::optional<T> &x, Fn fn) {
     return std::optional(fn(*x));
   return std::optional<decltype(fn(*x))>();
 }
+
+template<class T, class Fn>
+auto fupdate(std::optional<T> &x, Fn fn) {
+  if (x)
+    return std::optional(fn(*x));
+  return std::optional<decltype(fn(*x))>();
+}


### PR DESCRIPTION
This PR implements two new wrapper classes for solvers
- ~~`ExprVec` is a wrapper for vector of `Expr`s.~~ Removed
- `Context` is a wrapper for solver contexts.

Also, new semantics for `Expr` has been introduced
- `Expr`s cannot be constructed using constructors: instead, class static methods construct commonly used values.

Also, in order to reduce the mental load of tracking down aliases and mutations, `Expr` objects...
- are immutable: every methods create a new object instead of mutating itself
- ~~cannot be copy-assigned: one must use `clone()` method to do so, making sure that user acknowledges the object is being copied.~~ Excluded as of now
- ~~clearly distinguishes move and copy: this makes reasoning about aliases easier (*because there's virtually no alias*), reduces confusion, and helps avoid giant wave of compiler error messages regarding deleted operators.~~ Excluded as of now