### PR TITLE
Add inverseMappings to MemRef Layout encoding

### DIFF
--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -79,14 +79,6 @@ expr to1DIdx(
   return idx;
 }
 
-expr to1DIdxWithLayout(const vector<expr> &idxs, expr layout) {
-  vector<expr> indices;
-  for (unsigned i = 0; i < idxs.size(); i ++)
-    indices.push_back(Index("idx" + to_string(i)));
-
-  return layout.substitute(toExprVector(indices), toExprVector(idxs));
-}
-
 expr fitsInDims(
     const vector<expr> &idxs,
     const vector<expr> &sizes) {

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -140,8 +140,28 @@ expr substitute(
   return e.substitute(toExprVector(vars), toExprVector(values));
 }
 
+expr implies(const expr &a, const expr &b) {
+  return z3::implies(a, b);
+}
+
 expr forall(const vector<expr> &vars, const expr &e) {
   return z3::forall(toExprVector(vars), e);
+}
+
+expr lambda(const expr &var, const expr &e) {
+  return z3::lambda(var, e);
+}
+
+expr lambda(const vector<expr> &vars, const expr &e) {
+  return z3::lambda(toExprVector(vars), e);
+}
+
+expr select(const expr &arr, const expr &idx) {
+  return z3::select(arr, idx);
+}
+
+expr select(const expr &arr, const vector<expr> &idxs) {
+  return z3::select(arr, toExprVector(idxs));
 }
 
 sort bvSort(unsigned bw) {

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -121,9 +121,15 @@ func_decl mkUF(
   return ctx.function(move(name).c_str(), v, range);
 }
 
+expr fapply(const func_decl &func, const vector<expr> &vars) {
+  return func(toExprVector(vars));
+}
+
 bool structurallyEq(const expr &e1, const expr &e2) {
   return (Z3_ast)e1 == (Z3_ast)e2;
 }
+
+expr init() { return ctx; }
 
 expr substitute(
     expr e,

--- a/src/smt.h
+++ b/src/smt.h
@@ -20,7 +20,6 @@ std::vector<expr> simplifyList(const std::vector<expr> &exprs);
 
 expr to1DIdx(const std::vector<expr> &idxs,
                 const std::vector<expr> &dims);
-expr to1DIdxWithLayout(const std::vector<expr> &idxs, expr layout);
 expr fitsInDims(const std::vector<expr> &idxs,
                 const std::vector<expr> &sizes);
 

--- a/src/smt.h
+++ b/src/smt.h
@@ -30,7 +30,12 @@ std::string or_omit(const std::vector<expr> &evec);
 // TODO: these functions must be member functions of Expr
 expr substitute(expr e, const std::vector<expr> &vars,
                 const std::vector<expr> &values);
+expr implies(const expr &a, const expr &b);
 expr forall(const std::vector<expr> &vars, const expr &e);
+expr lambda(const expr &var, const expr &e);
+expr lambda(const std::vector<expr> &vars, const expr &e);
+expr select(const expr &arr, const expr &idx);
+expr select(const expr &arr, const std::vector<expr> &idxs);
 expr mkFreshVar(const sort &s, std::string &&prefix);
 expr mkVar(const sort &s, std::string &&name);
 expr mkBV(uint64_t i, unsigned bw);

--- a/src/smt.h
+++ b/src/smt.h
@@ -27,6 +27,7 @@ std::string or_omit(const expr &e);
 std::string or_omit(const std::vector<expr> &evec);
 
 // TODO: these functions must be member functions of Expr
+expr init();
 expr substitute(expr e, const std::vector<expr> &vars,
                 const std::vector<expr> &values);
 expr implies(const expr &a, const expr &b);
@@ -42,6 +43,7 @@ expr mkBool(bool b);
 func_decl mkUF(const sort &domain, const sort &range, std::string &&name);
 func_decl mkUF(const std::vector<sort> &domain, const sort &range,
                std::string &&name);
+expr fapply(const func_decl &func, const std::vector<expr> &vars);
 bool structurallyEq(const expr &e1, const expr &e2);
 
 // TODO: these functions must be member functions of Sort

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -85,8 +85,12 @@ State::LinalgGenericScope::LinalgGenericScope(
 }
 
 State::State(unsigned int numBlocks, MemEncoding encoding):
-  hasQuantifier(false),
+  hasQuantifier(false), precond(mkBool(true)),
   m(Memory::create(numBlocks, numBlocks, encoding)) {}
+
+void State::addPrecondition(smt::expr &&e) {
+  precond = precond && e;
+}
 
 void State::wellDefined(mlir::Operation *val, expr &&e) {
   auto itr = welldef.find(val);
@@ -95,6 +99,10 @@ void State::wellDefined(mlir::Operation *val, expr &&e) {
   } else {
     itr->second = itr->second && move(e);
   }
+}
+
+expr State::precondition() const {
+  return precond;
 }
 
 expr State::isWellDefined() const {

--- a/src/state.h
+++ b/src/state.h
@@ -51,6 +51,7 @@ public:
 
 class State {
 private:
+  smt::expr precond;
   // welldef[i]: is instruction i well-defined?
   llvm::DenseMap<mlir::Operation *, smt::expr> welldef;
 
@@ -79,7 +80,9 @@ public:
 
   State(unsigned int numBlocks, MemEncoding encoding);
 
+  void addPrecondition(smt::expr &&e);
   void wellDefined(mlir::Operation *op, smt::expr &&e);
+  smt::expr precondition() const;
   smt::expr isWellDefined() const;
   smt::expr isOpWellDefined(mlir::Operation *op) const;
 

--- a/src/value.h
+++ b/src/value.h
@@ -178,7 +178,7 @@ public:
     // ex) {d0, d1..}
     std::vector<smt::expr> indVars;
     // Inbounds condition for induction variables
-    // ex) 0 <= d0 < 3 && 0 <= d1 < 4 && ...
+    // ex) (d0, d1) -> 0 <= d0 < 3 && 0 <= d1 < 4 && ...
     smt::expr inbounds;
     // Layout mapping of indVars (indVars -> 1D Index)
     // ex) mapping := (d0, d1) -> (4 * d0 + d1)

--- a/src/value.h
+++ b/src/value.h
@@ -174,19 +174,43 @@ public:
 
   class Layout {
   public:
+    // Induction variables
+    // ex) {d0, d1..}
     std::vector<smt::expr> indVars;
-    smt::expr expr;
+    // Inbounds condition for induction variables
+    // ex) 0 <= d0 < 3 && 0 <= d1 < 4 && ...
     smt::expr inbounds;
+    // Layout mapping of indVars (indVars -> 1D Index)
+    // ex) mapping := (d0, d1) -> (4 * d0 + d1)
+    smt::expr mapping;
+    // Inverse layout mapping of indVars (1D Index -> indVars)
+    // If we can not give exact definition of inverseMappings, then encode it with uninterpreted function.
+    // ex)
+    // - If we can give exact definition
+    //    inverseMappings := (idx) -> {(idx / 4), (idx % 4)}
+    // - If we cannot give exact definition
+    //    inverseMappings := (idx) -> {inverse0(idx), inverse1(idx)}
+    std::vector<smt::expr> inverseMappings;
+    // Precondition for inverse mapping function.
+    // If we cannot give exact definition of inverseMappings, then give its meaning with forall quantifier.
+    // This will be added to state's precondition only when inverseMappings are used explicitly.
+    // ex) forall indVars, if (indVars are inbounds) then inverse0(mapping(d0, d1)) = d0 && inverse1(mapping(d0, d1)) = d1
+    smt::expr precondition;
 
     Layout(const std::vector<smt::expr> &indVars,
-      const smt::expr &expr,
-      const smt::expr &inbounds):
-      indVars(indVars), expr(expr), inbounds(inbounds) {}
+        const smt::expr &inbounds,
+        const smt::expr &mapping,
+        const std::vector<smt::expr> &inverseMappings,
+        const smt::expr &precondition):
+      indVars(indVars), inbounds(inbounds),
+      mapping(mapping), inverseMappings(inverseMappings), precondition(precondition) {}
 
-    Layout eval(smt::model mdl) const {
-      return { indVars, mdl.eval(expr).simplify(),
-               mdl.eval(inbounds).simplify() };
-    }
+    // MARK(makesource)
+    // Without this copy constructor, I encounter libc+abi.dylib related error in MacOS
+    Layout(const Layout& copy):
+      indVars(copy.indVars), inbounds(copy.inbounds),
+      mapping(copy.mapping), inverseMappings(copy.inverseMappings),
+      precondition(copy.precondition) {}
   };
 
   MemRef(Memory *m,
@@ -207,6 +231,7 @@ public:
 
   operator smt::expr() const { return bid && offset; }
 
+  smt::expr getPrecondition() const;
   smt::expr getWellDefined() const;
 
   // If memRefTy is unsupported, return nullopt

--- a/src/value.h
+++ b/src/value.h
@@ -197,13 +197,12 @@ public:
     // ex) forall indVars, if (indVars are inbounds) then inverse0(mapping(d0, d1)) = d0 && inverse1(mapping(d0, d1)) = d1
     smt::expr precondition;
 
+    Layout(const std::vector<smt::expr> &dims);
+
     Layout(const std::vector<smt::expr> &indVars,
+        const smt::expr &layout,
         const smt::expr &inbounds,
-        const smt::expr &mapping,
-        const std::vector<smt::expr> &inverseMappings,
-        const smt::expr &precondition):
-      indVars(indVars), inbounds(inbounds),
-      mapping(mapping), inverseMappings(inverseMappings), precondition(precondition) {}
+        bool useUF = false); // encode "mapping" using uninterpreted function
 
     // MARK(makesource)
     // Without this copy constructor, I encounter libc+abi.dylib related error in MacOS

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -292,6 +292,8 @@ static Results tryValidation(
   expr precond = mkBool(true);
   for (auto &e: preconds)
     precond = precond && e;
+
+  precond = precond && st_src.precondition() && st_tgt.precondition();
   precond = precond.simplify();
 
   auto res = checkRefinement(


### PR DESCRIPTION
Before we support various memref operations, we need the definition of inverseMapping of layout map.
This is because many arithmetic operations like conv, add, mul can be encoded more easily and efficiently if we abstract concrete MemRef's layout.
In other words, it is much simpler to find the expression for %memref[i][j] and then encode it in memory by giving concrete layout information.

In this PR, we changed to use lambda when encoding layout to better express that is a function.
And add new inverseMappings which represent inverse function of layout mapping.
These will be used later when we support additional memref operations.

Since there is no operation that uses inverseMappings yet, nothing changed from current smt encoding.
I also checked `ctest` works well without problems.


