### PR TITLE
Fix linking issue on linkers without automatic tsort

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,11 @@ elseif(NOT EXISTS ${MLIR_INC_DIR} OR NOT EXISTS ${MLIR_LIB_DIR})
 else()
     target_include_directories(${PROJECT_LIB} PUBLIC ${MLIR_INC_DIR})
     target_link_directories(${PROJECT_LIB} PUBLIC ${MLIR_LIB_DIR})
-    target_link_libraries(${PROJECT_LIB} PUBLIC
+    target_link_libraries(${PROJECT_LIB} PUBLIC "-Wl,--start-group"
         MLIRViewLikeInterface MLIRInferTypeOpInterface MLIRControlFlowInterfaces MLIRSideEffectInterfaces
         MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRAffine MLIRMemRef MLIRShape MLIRMath
         MLIRStandard MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport
-        LLVMSupport LLVMDemangle pthread m curses)
+        LLVMSupport LLVMDemangle pthread m curses "-Wl,--end-group")
 endif()
 
 # Check if at least one solver is available


### PR DESCRIPTION
This PR adds some more linker options to use topology sort when linking libraries.

More recent linkers such as LLD automatically sorts libraries prior to linking process, but older ones should be given an explicit order to do so. This change has turned out successful on GNU LD, which previously failed to link libraries.