### PR TITLE
Implement wrapper class for solver and result

### DIFF
--- a/src/smt.h
+++ b/src/smt.h
@@ -46,8 +46,11 @@ sort boolSort();
 sort arraySort(const sort &domain, const sort &range);
 
 class Sort;
+class Solver;
 
 class Expr {
+  friend Solver;
+
 private:
   std::optional<z3::expr> z3_expr;
 
@@ -86,6 +89,33 @@ public:
   static Sort bvSort(size_t bw);
   static Sort boolSort();
   static Sort arraySort(const Sort &domain, const Sort &range);
+};
+
+class Result {
+public:
+  enum Internal {
+    SAT,
+    UNSAT,
+    UNKNOWN
+  };
+
+  Result(const std::optional<z3::check_result> &z3_result);
+  const bool operator==(const Result &rhs);
+  
+private:
+  Internal result;
+};
+
+class Solver {
+private:
+  std::optional<z3::solver> z3_solver;
+
+public:
+  Solver();
+
+  void add(const Expr &e);
+  void reset();
+  Result check();
 };
 } // namespace smt
 

--- a/src/smt.h
+++ b/src/smt.h
@@ -101,6 +101,7 @@ public:
 
   Result(const std::optional<z3::check_result> &z3_result);
   const bool operator==(const Result &rhs);
+  const bool operator!=(const Result &rhs) { return !(*this == rhs); }
   
 private:
   Internal result;


### PR DESCRIPTION
This PR implements generic solver and result class to support using multiple solvers.

As of now, `Solver` class only supports `add(Expr)`, `reset()`, and `check()`. I looked into previous uses of z3::solver and assumed we don't use much more than these three. (And yet we can implement more methods when they become necessary)

`Result` class is a one-on-one replacement for SMT result, and supports basic comparison.