### PR TITLE
Refactor `Expr` operators into member methods

### DIFF
--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -245,26 +245,26 @@ Expr Expr::ugt(const Expr& rhs) const {
   return Expr(move(z3_expr));
 }
 
-Expr operator+(const Expr &lhs, const Expr &rhs) {
-  auto z3_expr = fmap(lhs.z3_expr, [&rhs](auto e) { return e + *rhs.z3_expr; });
+Expr Expr::operator+(const Expr &rhs) {
+  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e + *rhs.z3_expr; });
   
   return Expr(move(z3_expr));
 }
 
-Expr operator-(const Expr &lhs, const Expr &rhs) {
-  auto z3_expr = fmap(lhs.z3_expr, [&rhs](auto e) { return e - *rhs.z3_expr; });
+Expr Expr::operator-(const Expr &rhs) {
+  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e - *rhs.z3_expr; });
   
   return Expr(move(z3_expr));
 }
 
-Expr operator*(const Expr &lhs, const Expr &rhs) {
-  auto z3_expr = fmap(lhs.z3_expr, [&rhs](auto e) { return e * *rhs.z3_expr; });
+Expr Expr::operator*(const Expr &rhs) {
+  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e * *rhs.z3_expr; });
   
   return Expr(move(z3_expr));
 }
 
-Expr operator&(const Expr &lhs, const Expr &rhs) {
-  auto z3_expr = fmap(lhs.z3_expr, [&rhs](auto e) { 
+Expr Expr::operator&(const Expr &rhs) {
+  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { 
     if (e.is_bool()) 
       return e && *rhs.z3_expr;
     else
@@ -274,8 +274,8 @@ Expr operator&(const Expr &lhs, const Expr &rhs) {
   return Expr(move(z3_expr));
 }
 
-Expr operator|(const Expr &lhs, const Expr &rhs) {
-  auto z3_expr = fmap(lhs.z3_expr, [&rhs](auto e) { 
+Expr Expr::operator|(const Expr &rhs) {
+  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { 
     if (e.is_bool()) 
       return e || *rhs.z3_expr;
     else

--- a/src/smt.h
+++ b/src/smt.h
@@ -62,11 +62,11 @@ public:
   Expr ult(const Expr &rhs) const;
   Expr ugt(const Expr &rhs) const;
 
-  friend Expr operator+(const Expr &lhs, const Expr &rhs);
-  friend Expr operator-(const Expr &lhs, const Expr &rhs);
-  friend Expr operator*(const Expr &lhs, const Expr &rhs);
-  friend Expr operator&(const Expr &lhs, const Expr &rhs);
-  friend Expr operator|(const Expr &lhs, const Expr &rhs);
+  Expr operator+(const Expr &rhs);
+  Expr operator-(const Expr &rhs);
+  Expr operator*(const Expr &rhs);
+  Expr operator&(const Expr &rhs);
+  Expr operator|(const Expr &rhs);
 
   static Expr mkFreshVar(const Sort &s, std::string_view prefix);
   static Expr mkVar(const Sort &s, std::string_view name);


### PR DESCRIPTION
This PR refactors 'friend' `Expr` operators into member operators of `Expr`.
This does not introduce any functional difference, but apparently [declaring operators as members is preferred over declaring them as friends](https://stackoverflow.com/questions/43089272/friend-vs-member-functions-in-operator-overloading-c).