### PR TITLE
Add platform-specific linking options in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,17 @@ elseif(NOT EXISTS ${MLIR_INC_DIR} OR NOT EXISTS ${MLIR_LIB_DIR})
 else()
     target_include_directories(${PROJECT_LIB} PUBLIC ${MLIR_INC_DIR})
     target_link_directories(${PROJECT_LIB} PUBLIC ${MLIR_LIB_DIR})
-    target_link_libraries(${PROJECT_LIB} PUBLIC "-Wl,--start-group"
+
+    list(APPEND LIB_LIST
         MLIRViewLikeInterface MLIRInferTypeOpInterface MLIRControlFlowInterfaces MLIRSideEffectInterfaces
         MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRAffine MLIRMemRef MLIRShape MLIRMath
         MLIRStandard MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport
-        LLVMSupport LLVMDemangle pthread m curses "-Wl,--end-group")
+        LLVMSupport LLVMDemangle pthread m curses)
+    if (APPLE) # Apple LLD does not support 'group' flags
+        target_link_libraries(${PROJECT_LIB} PUBLIC ${LIB_LIST})
+    else()
+        target_link_libraries(${PROJECT_LIB} PUBLIC "-Wl,--start-group" ${LIB_LIST} "-Wl,--end-group")
+    endif()
 endif()
 
 # Check if at least one solver is available


### PR DESCRIPTION
This PR fixes the linker issue in Apple platform due to https://github.com/aqjune/mlir-tv/pull/99.
Apple LLD does not support `--start-group` and `--end-group` flags, so these flags won't be added when Apple platform is detected.