### PR TITLE
More functionalities for `smt::Expr`

### DIFF
--- a/src/smt.h
+++ b/src/smt.h
@@ -64,6 +64,10 @@ private:
 
 public:
   Expr simplify() const;
+  Expr substitute(const std::vector<Expr> &vars, const std::vector<Expr> &values) const;
+  Expr implies(const Expr &rhs) const;
+  Expr select(const Expr &idx) const;
+  Expr select(const std::vector<Expr> &indices) const;
   std::vector<Expr> toNDIndices(const std::vector<Expr> &dims) const;
 
   Expr urem(const Expr &rhs) const;
@@ -81,6 +85,8 @@ public:
   static Expr mkVar(const Sort &s, std::string_view name);
   static Expr mkBV(const uint64_t val, const size_t sz);
   static Expr mkBool(const bool val);
+
+  friend z3::expr_vector toZ3ExprVector(const std::vector<Expr> &vec);
 };
 
 class Sort {


### PR DESCRIPTION
This PR implements `substitute()`, `implies()`, and `select()` for `Expr` class.

I'm also planning on implementing `lambda()` and `forall()` for `Expr`, but the problem with these functions are that they accept a vector of `Expr`s as their first parameter. It doesn't look natural to implement them as `Expr` method...
I'll fuily open this PR once I get to implement these two in a nice form.