### PR TITLE
Replace `z3::expr` in `Index` with `smt::Expr`

### DIFF
--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -303,6 +303,22 @@ Expr Expr::operator|(const Expr &rhs) {
   return Expr(move(z3_expr));
 }
 
+Expr Expr::operator==(const Expr &rhs) {
+  auto z3_expr = fmap(this->z3_expr, [&rhs](auto z3_lhs) {
+    return z3_lhs == *rhs.z3_expr;
+  });
+  
+  return Expr(move(z3_expr));
+}
+
+Expr Expr::operator!=(const Expr &rhs) {
+  auto z3_expr = fmap(this->z3_expr, [&rhs](auto z3_lhs) {
+    return z3_lhs != *rhs.z3_expr;
+  });
+  
+  return Expr(move(z3_expr));
+}
+
 Expr Expr::mkFreshVar(const Sort &s, std::string_view prefix) {
   auto z3_expr = fupdate(sctx.z3_ctx, [s, prefix](auto &ctx){ 
     auto ast = Z3_mk_fresh_const(ctx, prefix.data(), *s.z3_sort);

--- a/src/smt.h
+++ b/src/smt.h
@@ -76,6 +76,8 @@ public:
   Expr operator*(const Expr &rhs);
   Expr operator&(const Expr &rhs);
   Expr operator|(const Expr &rhs);
+  Expr operator==(const Expr &rhs);
+  Expr operator!=(const Expr &rhs);
 
   static Expr mkFreshVar(const Sort &s, std::string_view prefix);
   static Expr mkVar(const Sort &s, std::string_view name);

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -68,17 +68,22 @@ getLayout(const mlir::MemRefType &memRefTy, const vector<expr> &dims) {
   return MemRef::Layout(indVars, layout, inbounds);
 }
 
-Index::Index(unsigned i): e(mkBV(i, BITS)) {}
+Index::Index(unsigned i): e(mkBV(i, BITS)), se(smt::Expr::mkBV(i, BITS)) {}
 
 Index::Index(std::string &&name, bool freshvar):
     e(freshvar ?
       mkFreshVar(Index::sort(), move(name)) :
-      mkVar(Index::sort(), move(name))) {}
-
-Index::Index(const expr &e): e(e) {}
+      mkVar(Index::sort(), move(name))),
+    se(freshvar ?
+      Expr::mkFreshVar(Index::sSort(), name) :
+      Expr::mkVar(Index::sSort(), name)) {}
 
 smt::sort Index::sort() {
   return bvSort(BITS);
+}
+
+Sort Index::sSort() {
+  return Sort::bvSort(BITS);
 }
 
 Index Index::one() { return Index(1); }
@@ -91,6 +96,10 @@ llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const Index &i) {
 
 std::pair<expr, vector<expr>> Index::refines(const Index &other) const {
   return {(expr) other == (expr) *this, {}};
+}
+
+std::pair<Expr, vector<Expr>> Index::sRefines(const Index &other) const {
+  return {(Expr) other == (Expr) *this, {}};
 }
 
 Index Index::eval(model m) const {

--- a/src/value.h
+++ b/src/value.h
@@ -11,15 +11,18 @@ class Memory;
 
 class Index {
   smt::expr e;
+  smt::Expr se;
 
 public:
   static const unsigned BITS = 32;
 
   Index(unsigned);
   Index(std::string &&name, bool freshvar = false);
-  Index(const smt::expr &e);
+  // DEPRECATED: this constructor creates invalid se
+  Index(const smt::expr &e): e(e), se(smt::Expr::mkBV(0, BITS)) {}
 
   operator smt::expr() const { return e; }
+  operator smt::Expr() const { return se; }
   Index ofs(int i) const {
     uint64_t v;
     if (e.is_numeral_u64(v))
@@ -28,11 +31,14 @@ public:
   }
 
   static smt::sort sort();
+  static smt::Sort sSort();
   static Index one();
   static Index zero();
 
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, const Index &);
   std::pair<smt::expr, std::vector<smt::expr>> refines(
+      const Index &other) const;
+  std::pair<smt::Expr, std::vector<smt::Expr>> sRefines(
       const Index &other) const;
   Index eval(smt::model m) const;
 };


### PR DESCRIPTION
This PR 'tries' replacing the `z3::expr` in `Index` with `smt::Expr` into `Index`. (Both of them exist as of now)

`Index` has some methods that depends on `z3::expr`. `smt::Expr` cannot directly replace the `z3::expr`, so these methods are marked as 'deprecated'. They will be removed once we actually start replacing the exprs.

After merging this PR, I'll start replacing the exprs in `Float` and `Integer` as well.