### PR TITLE
Add CVC5 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,15 @@ set (CMAKE_CXX_STANDARD 17)
 
 set(MLIR_DIR CACHE PATH "MLIR installation top-level directory")
 set(Z3_DIR CACHE PATH "Z3 installation top-level directory")
-option(USE_LIBC "Use libc++ in case the MLIR is linked against libc++")
+set(CVC5_DIR CACHE PATH "CVC5 installation top-level directory")
+option(USE_LIBC "Use libc++ in case the MLIR (and CVC5) is linked against libc++")
 
 set(MLIR_INC_DIR "${MLIR_DIR}/include")
 set(MLIR_LIB_DIR "${MLIR_DIR}/lib")
 set(Z3_INC_DIR "${Z3_DIR}/include")
 set(Z3_LIB_DIR "${Z3_DIR}/lib")
+set(CVC5_INC_DIR "${CVC5_DIR}/include")
+set(CVC5_LIB_DIR "${CVC5_DIR}/lib")
 
 # Build library first
 set(PROJECT_LIB "mlirtv")
@@ -45,7 +48,7 @@ else()
 endif()
 
 # Check if at least one solver is available
-if(NOT Z3_DIR)
+if(NOT Z3_DIR AND NOT CVC5_DIR)
     message(FATAL_ERROR "path to at least one of the solvers must be provided!")
 endif()
 
@@ -57,6 +60,19 @@ if(Z3_DIR)
         target_include_directories(${PROJECT_LIB} PUBLIC ${Z3_INC_DIR})
         target_link_directories(${PROJECT_LIB} PUBLIC ${Z3_LIB_DIR})
         target_link_libraries(${PROJECT_LIB} PUBLIC z3)
+        target_compile_definitions(${PROJECT_LIB} PUBLIC SOLVER_Z3)
+    endif()
+endif()
+
+# Check for CVC5 installation
+if(CVC5_DIR)
+    if(NOT EXISTS ${CVC5_INC_DIR} OR NOT EXISTS ${CVC5_LIB_DIR})
+        message(FATAL_ERROR "the provided path doesn't seem to be a valid CVC5 directory")
+    else()
+        target_include_directories(${PROJECT_LIB} PUBLIC ${CVC5_INC_DIR})
+        target_link_directories(${PROJECT_LIB} PUBLIC ${CVC5_LIB_DIR})
+        target_link_libraries(${PROJECT_LIB} PUBLIC cvc5)
+        target_compile_definitions(${PROJECT_LIB} PUBLIC SOLVER_CVC5)
     endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,18 @@ Currently MLIR-TV is in an experimental stage.
 Prerequisites: [CMake](https://cmake.org/download/)(>=3.15),
 [MLIR](https://github.com/llvm/llvm-project),
 [Python3](https://www.python.org/downloads/)(>=3.9)  
-Solvers (at least one of them must be used): [Z3-solver](https://github.com/Z3Prover/z3)
+Solvers (at least one of them must be used): [Z3-solver](https://github.com/Z3Prover/z3), [CVC5](https://github.com/cvc5/cvc5)
 
 - Installation of MLIR: please follow [this instruction](https://llvm.org/docs/GettingStarted.html#getting-the-source-code-and-building-llvm) & run `cmake --build . --target install`
 
 ```bash
 mkdir build
 cd build
-# -DUSE_LIBC is OFF by default. Set it to ON iff the MLIR is built using libc++
+# At least one of -DZ3_DIR and -DCVC5_DIR must be provided
+# -DUSE_LIBC is OFF by default. Set it to ON iff the MLIR (and CVC5) is linked against libc++
 cmake -DMLIR_DIR=<dir/to/mlir-install> \
-      -DZ3_DIR=<dir/to/z3-install> \
+      [-DZ3_DIR=<dir/to/z3-install>] \
+      [-DCVC5_DIR=<dir/to/cvc5-install>] \
       [-DUSE_LIBC=ON|OFF] \
       [-DCMAKE_BUILD_TYPE=DEBUG|RELEASE] \
       ..

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Solvers (at least one of them must be used): [Z3-solver](https://github.com/Z3Pr
 ```bash
 mkdir build
 cd build
-# At least one of -DZ3_DIR and -DCVC5_DIR must be provided
+# As of now, mlir-tv won't compile without -DZ3_DIR. This will be fixed soon.
 # -DUSE_LIBC is OFF by default. Set it to ON iff the MLIR (and CVC5) is linked against libc++
 cmake -DMLIR_DIR=<dir/to/mlir-install> \
-      [-DZ3_DIR=<dir/to/z3-install>] \
+      -DZ3_DIR=<dir/to/z3-install> \
       [-DCVC5_DIR=<dir/to/cvc5-install>] \
       [-DUSE_LIBC=ON|OFF] \
       [-DCMAKE_BUILD_TYPE=DEBUG|RELEASE] \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,6 +112,7 @@ int main(int argc, char* argv[]) {
   llvm::cl::ParseCommandLineOptions(argc, argv);
 
   z3::set_param("timeout", (int)arg_smt_to.getValue());
+  smt::setTimeout(arg_smt_to.getValue());
 
   MLIRContext context;
   DialectRegistry registry;

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -2,6 +2,25 @@
 #include "smt.h"
 #include "utils.h"
 
+#include <unordered_map>
+#include <numeric>
+
+#ifdef SOLVER_Z3
+#define TRY_SET_Z3_EXPR(fn) e.setZ3Expr(fn)
+#define TRY_SET_Z3_SORT(fn) s.setZ3Sort(fn)
+#else
+#define TRY_SET_Z3_EXPR(fn)
+#define TRY_SET_Z3_SORT(fn)
+#endif
+
+#ifdef SOLVER_CVC5
+#define TRY_SET_CVC5_EXPR(fn) e.setCVC5Expr(fn)
+#define TRY_SET_CVC5_SORT(fn) s.setCVC5Sort(fn)
+#else
+#define TRY_SET_CVC5_EXPR(fn)
+#define TRY_SET_CVC5_SORT(fn)
+#endif
+
 using namespace std;
 
 namespace {
@@ -15,17 +34,25 @@ z3::expr_vector toExprVector(const vector<smt::expr> &vec) {
 
 namespace smt {
 class Context {
+private:
+  unordered_map<string, uint64_t> fresh_var_map;
+
 public:
-  optional<z3::context> z3_ctx;
+  IF_Z3_ENABLED(optional<z3::context> z3_ctx);
+  IF_CVC5_ENABLED(optional<cvc5::api::Solver> cvc5_ctx);
 
   Context() {
-    this->z3_ctx = nullopt;
+    IF_Z3_ENABLED(this->z3_ctx.reset());
+    IF_CVC5_ENABLED(this->cvc5_ctx.reset());
   }
 
-  Context(bool use_z3) {
-    if (use_z3) {
-      this->z3_ctx.emplace();
-    }
+  IF_Z3_ENABLED(void useZ3() { this->z3_ctx.emplace(); })
+  IF_CVC5_ENABLED(void useCVC5() { this->cvc5_ctx.emplace(); })
+
+  string getFreshName(string prefix) {
+    this->fresh_var_map.insert({prefix, 0});
+    uint64_t suffix = fresh_var_map.at(prefix)++;
+    return prefix.append("_" + to_string(suffix));
   }
 };
 
@@ -206,14 +233,33 @@ string or_omit(const vector<expr> &evec) {
   return s;
 }
 
-Expr::Expr(optional<z3::expr> &&z3_expr) {
-  this->z3_expr = move(z3_expr);
+Expr::Expr() {
+  IF_Z3_ENABLED(this->z3_expr.reset());
+  IF_CVC5_ENABLED(this->cvc5_expr.reset());
 }
 
-Expr Expr::simplify() const {
-  auto z3_expr = fmap(this->z3_expr, [](auto e) { return e.simplify(); });
+#ifdef SOLVER_Z3
+void Expr::setZ3Expr(optional<z3::expr> &&z3_expr) {
+  this->z3_expr = move(z3_expr);
+}
+#endif // SOLVER_Z3
 
-  return Expr(move(z3_expr));
+#ifdef SOLVER_CVC5
+void Expr::setCVC5Expr(optional<cvc5::api::Term> &&cvc5_expr) {
+  this->cvc5_expr = move(cvc5_expr);
+}
+#endif // SOLVER_CVC5
+
+Expr Expr::simplify() const {
+  Expr e;
+  TRY_SET_Z3_EXPR(fmap(this->z3_expr, [](auto e) {
+    return e.simplify();
+  }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [this](auto &ctx) {
+    return ctx.simplify(*this->cvc5_expr);
+  }));
+
+  return e;
 }
 
 vector<Expr> Expr::toNDIndices(const vector<Expr> &dims) const {
@@ -232,134 +278,224 @@ vector<Expr> Expr::toNDIndices(const vector<Expr> &dims) const {
 }
 
 Expr Expr::urem(const Expr &rhs) const {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { 
+  Expr e;
+  TRY_SET_Z3_EXPR(fmap(this->z3_expr, [&rhs](auto e) { 
     return z3::urem(e, *rhs.z3_expr); 
-  });
+  }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [this, rhs](auto &ctx) { 
+    return ctx.mkTerm(cvc5::api::Kind::BITVECTOR_UREM,
+      *this->cvc5_expr, *rhs.cvc5_expr);
+  }));
   
-  return Expr(move(z3_expr));
+  return e;
 }
 
 Expr Expr::udiv(const Expr& rhs) const {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { 
+  Expr e;
+  TRY_SET_Z3_EXPR(fmap(this->z3_expr, [rhs](auto e) { 
     return z3::udiv(e, *rhs.z3_expr); 
-  });
+  }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [this, rhs](auto &ctx) { 
+    return ctx.mkTerm(cvc5::api::Kind::BITVECTOR_UDIV,
+      *this->cvc5_expr, *rhs.cvc5_expr);
+  }));
   
-  return Expr(move(z3_expr));
+  return e;
 }
 
 Expr Expr::ult(const Expr& rhs) const {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { 
+  Expr e;
+  TRY_SET_Z3_EXPR(fmap(this->z3_expr, [rhs](auto e) { 
     return z3::ult(e, *rhs.z3_expr); 
-  });
+  }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [this, rhs](auto &ctx) { 
+    return ctx.mkTerm(cvc5::api::Kind::BITVECTOR_ULT,
+      *this->cvc5_expr, *rhs.cvc5_expr);
+  }));
   
-  return Expr(move(z3_expr));
+  return e;
 }
 
 Expr Expr::ugt(const Expr& rhs) const {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { 
+  Expr e;
+  TRY_SET_Z3_EXPR(fmap(this->z3_expr, [rhs](auto e) { 
     return z3::ugt(e, *rhs.z3_expr); 
-  });
+  }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [this, rhs](auto &ctx) { 
+    return ctx.mkTerm(cvc5::api::Kind::BITVECTOR_UGT,
+      *this->cvc5_expr, *rhs.cvc5_expr);
+  }));
   
-  return Expr(move(z3_expr));
+  return e;
 }
 
 Expr Expr::operator+(const Expr &rhs) {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e + *rhs.z3_expr; });
+  Expr e;
+  TRY_SET_Z3_EXPR(fmap(this->z3_expr, [rhs](auto e) { return e + *rhs.z3_expr; }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [this, rhs](auto &ctx) { 
+    return ctx.mkTerm(cvc5::api::Kind::BITVECTOR_ADD,
+      *this->cvc5_expr, *rhs.cvc5_expr);
+  }));
   
-  return Expr(move(z3_expr));
+  return e;
 }
 
 Expr Expr::operator-(const Expr &rhs) {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e - *rhs.z3_expr; });
+  Expr e;
+  TRY_SET_Z3_EXPR(fmap(this->z3_expr, [rhs](auto e) { return e - *rhs.z3_expr; }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [this, rhs](auto &ctx) { 
+    return ctx.mkTerm(cvc5::api::Kind::BITVECTOR_SUB,
+      *this->cvc5_expr, *rhs.cvc5_expr);
+  }));
   
-  return Expr(move(z3_expr));
+  return e;
 }
 
 Expr Expr::operator*(const Expr &rhs) {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { return e * *rhs.z3_expr; });
+  Expr e;
+  TRY_SET_Z3_EXPR(fmap(this->z3_expr, [rhs](auto e) { return e * *rhs.z3_expr; }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [this, rhs](auto &ctx) { 
+    return ctx.mkTerm(cvc5::api::Kind::BITVECTOR_MULT,
+      *this->cvc5_expr, *rhs.cvc5_expr);
+  }));
   
-  return Expr(move(z3_expr));
+  return e;
 }
 
 Expr Expr::operator&(const Expr &rhs) {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { 
-    if (e.is_bool()) 
-      return e && *rhs.z3_expr;
-    else
-      return e & *rhs.z3_expr;
-  });
+  Expr e;
+  // z3::expr::operator& automatically disambiguates bool and bv
+  TRY_SET_Z3_EXPR(fmap(this->z3_expr, [rhs](auto e) { return e & *rhs.z3_expr; }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [this, rhs](auto &ctx) {
+    if (this->cvc5_expr->isBooleanValue()) {
+      return ctx.mkTerm(cvc5::api::Kind::AND,
+        *this->cvc5_expr, *rhs.cvc5_expr);
+    } else {
+      return ctx.mkTerm(cvc5::api::Kind::BITVECTOR_AND,
+        *this->cvc5_expr, *rhs.cvc5_expr);
+    }
+  }));
   
-  return Expr(move(z3_expr));
+  return e;
 }
 
 Expr Expr::operator|(const Expr &rhs) {
-  auto z3_expr = fmap(this->z3_expr, [&rhs](auto e) { 
-    if (e.is_bool()) 
-      return e || *rhs.z3_expr;
-    else
-      return e | *rhs.z3_expr;
-  });
+  Expr e;
+  // z3::expr::operator| automatically disambiguates bool and bv
+  TRY_SET_Z3_EXPR(fmap(this->z3_expr, [rhs](auto e) { return e | *rhs.z3_expr; }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [this, rhs](auto &ctx) {
+    if (this->cvc5_expr->isBooleanValue()) {
+      return ctx.mkTerm(cvc5::api::Kind::OR,
+        *this->cvc5_expr, *rhs.cvc5_expr);
+    } else {
+      return ctx.mkTerm(cvc5::api::Kind::BITVECTOR_OR,
+        *this->cvc5_expr, *rhs.cvc5_expr);
+    }
+  }));
   
-  return Expr(move(z3_expr));
+  return e;
 }
 
-Expr Expr::mkFreshVar(const Sort &s, std::string_view prefix) {
-  auto z3_expr = fupdate(sctx.z3_ctx, [s, prefix](auto &ctx){ 
-    auto ast = Z3_mk_fresh_const(ctx, prefix.data(), *s.z3_sort);
-    return z3::expr(ctx, ast);
-  });
+Expr Expr::mkFreshVar(const Sort &s, const string &prefix) {
+  string fresh_name = sctx.getFreshName(prefix);
 
-  return Expr(move(z3_expr));
+  Expr e;
+  TRY_SET_Z3_EXPR(fupdate(sctx.z3_ctx, [s, fresh_name](auto &ctx) { 
+    return ctx.constant(fresh_name.c_str(), *s.z3_sort);
+  }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [s, fresh_name](auto &ctx) { 
+    return ctx.mkConst(*s.cvc5_sort, fresh_name);
+  }));
+
+  return e;
 }
 
-Expr Expr::mkVar(const Sort &s, std::string_view name) {
-  auto z3_expr = fupdate(sctx.z3_ctx, [s, name](auto &ctx){ 
-    return ctx.constant(name.data(), *s.z3_sort);
-  });
+Expr Expr::mkVar(const Sort &s, const string &name) {
+  Expr e;
+  TRY_SET_Z3_EXPR(fupdate(sctx.z3_ctx, [s, name](auto &ctx){ 
+    return ctx.constant(name.c_str(), *s.z3_sort);
+  }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [s, name](auto &ctx){ 
+    return ctx.mkConst(*s.cvc5_sort, name);
+  }));
 
-  return Expr(move(z3_expr));
+  return e;
 }
 
 Expr Expr::mkBV(const uint64_t val, const size_t sz) {
-  auto z3_expr = fupdate(sctx.z3_ctx, [val, sz](auto &ctx){ 
+  Expr e;
+  TRY_SET_Z3_EXPR(fupdate(sctx.z3_ctx, [val, sz](auto &ctx){ 
     return ctx.bv_val(val, sz); 
-  });
+  }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [val, sz](auto &ctx){ 
+    return ctx.mkBitVector(sz, val); 
+  }));
 
-  return Expr(move(z3_expr));
+  return e;
 }
 
 Expr Expr::mkBool(const bool val) {
-  auto z3_expr = fupdate(sctx.z3_ctx, [val](auto &ctx){ 
+  Expr e;
+  TRY_SET_Z3_EXPR(fupdate(sctx.z3_ctx, [val](auto &ctx){ 
     return ctx.bool_val(val); 
-  });
+  }));
+  TRY_SET_CVC5_EXPR(fupdate(sctx.cvc5_ctx, [val](auto &ctx){ 
+    return ctx.mkBoolean(val); 
+  }));
 
-  return Expr(move(z3_expr));
+  return e;
 }
 
-Sort::Sort(std::optional<z3::sort> &&z3_sort) {
-  this->z3_sort = std::move(z3_sort);
+Sort::Sort() {
+  IF_Z3_ENABLED(this->z3_sort.reset());
+  IF_CVC5_ENABLED(this->cvc5_sort.reset());
 }
+
+#ifdef SOLVER_Z3
+void Sort::setZ3Sort(optional<z3::sort> &&z3_sort) {
+  this->z3_sort = move(z3_sort);
+}
+#endif // SOLVER_Z3
+
+#ifdef SOLVER_CVC5
+void Sort::setCVC5Sort(optional<cvc5::api::Sort> &&cvc5_sort) {
+  this->cvc5_sort = move(cvc5_sort);
+}
+#endif // SOLVER_CVC5
 
 Sort Sort::bvSort(size_t bw) {
-  auto z3_sort = fupdate(sctx.z3_ctx, [bw](auto &ctx){ return ctx.bv_sort(bw); });
+  Sort s;
+  TRY_SET_Z3_SORT(fupdate(sctx.z3_ctx, [bw](auto &ctx){ return ctx.bv_sort(bw); }));
+  TRY_SET_CVC5_SORT(fupdate(sctx.cvc5_ctx, [bw](auto &ctx){
+    return ctx.mkBitVectorSort(bw);
+  }));
 
-  return Sort(move(z3_sort));
+  return s;
 }
 
 Sort Sort::boolSort() {
-  auto z3_sort = fupdate(sctx.z3_ctx, [](auto &ctx){ return ctx.bool_sort(); });
+  Sort s;
+  TRY_SET_Z3_SORT(fupdate(sctx.z3_ctx, [](auto &ctx){ return ctx.bool_sort(); }));
+  TRY_SET_CVC5_SORT(fupdate(sctx.cvc5_ctx, [](auto &ctx){
+    return ctx.getBooleanSort();
+  }));
 
-  return Sort(move(z3_sort));
+  return s;
 }
 
 Sort Sort::arraySort(const Sort &domain, const Sort &range) {
-  auto z3_sort = fupdate(sctx.z3_ctx, [domain, range](auto &ctx){ 
+  Sort s;
+  TRY_SET_Z3_SORT(fupdate(sctx.z3_ctx, [domain, range](auto &ctx){ 
     return ctx.array_sort(*domain.z3_sort, *range.z3_sort); 
-  });
+  }));
+  TRY_SET_CVC5_SORT(fupdate(sctx.cvc5_ctx, [domain, range](auto &ctx){
+    return ctx.mkArraySort(*range.cvc5_sort, *domain.cvc5_sort);
+  }));
 
-  return Sort(move(z3_sort));
+  return s;
 }
 
+#ifdef SOLVER_Z3
 Result::Result(const optional<z3::check_result> &z3_result) {
   auto unwrapped_z3_result = z3_result.value_or(z3::check_result::unknown);
   if (unwrapped_z3_result == z3::check_result::sat) {
@@ -370,32 +506,96 @@ Result::Result(const optional<z3::check_result> &z3_result) {
     this->result = Result::UNKNOWN;
   }
 }
+#endif // SOLVER_Z3
+
+#ifdef SOLVER_CVC5
+Result::Result(const optional<cvc5::api::Result> &cvc5_result) {
+  this->result = Result::UNKNOWN; // None also becomes unknown
+  if (cvc5_result.has_value()) {
+    if (cvc5_result->isSat()) {
+      this->result = Result::SAT;
+    } else if (cvc5_result->isUnsat()) {
+      this->result = Result::UNSAT;
+    }
+  }
+}
+#endif // SOLVER_CVC5
 
 const bool Result::operator==(const Result &rhs) {
   return this->result == rhs.result;
 }
 
+Result Result::evaluateResults(const vector<Result> &results) {
+  return accumulate(results.cbegin(), results.cend(), Result(),
+    [](auto acc, const auto result) {
+      acc.result = max(acc.result, result.result); return acc;
+    }
+  );
+}
+
 Solver::Solver() {
-  this->z3_solver = fupdate(sctx.z3_ctx, [](auto &ctx){ return z3::solver(ctx); });
+#ifdef SOLVER_Z3
+  this->z3_solver = fupdate(sctx.z3_ctx, [](auto &ctx) {
+    return z3::solver(ctx);
+  });
+#endif // SOLVER_Z3
+
+  IF_CVC5_ENABLED(this->cvc5_solver.emplace());
 }
 
 void Solver::add(const Expr &e) {
-  fupdate(this->z3_solver, [e](auto &solver) { solver.add(*e.z3_expr); return 0; });
+#ifdef SOLVER_Z3
+  fupdate(this->z3_solver, [e](auto &solver) {
+    solver.add(*e.z3_expr); return 0;
+  });
+#endif // SOLVER_Z3
+
+#ifdef SOLVER_CVC5
+  fupdate(this->cvc5_solver, [e](auto &solver) {
+    solver.assertFormula(*e.cvc5_expr); return 0;
+  });
+#endif // SOLVER_CVC5
 }
 
 void Solver::reset() {
-  fupdate(this->z3_solver, [](auto &solver) { solver.reset(); return 0; });
+#ifdef SOLVER_Z3
+  fupdate(this->z3_solver, [](auto &solver) {
+    solver.reset(); return 0;
+  });
+#endif // SOLVER_Z3
+
+#ifdef SOLVER_CVC5
+  fupdate(this->cvc5_solver, [](auto &solver) {
+    solver.resetAssertions(); return 0;
+  });
+#endif // SOLVER_CVC5
 }
 
 Result Solver::check() {
-  auto z3_result = fupdate(this->z3_solver, [](auto &solver) {
-    return solver.check();
-  });
+  vector<Result> solver_results;
+
+#ifdef SOLVER_Z3
+  solver_results.push_back(
+    Result(fupdate(this->z3_solver, [](auto &solver) {
+      return solver.check();
+    }))
+  );
+#endif // SOLVER_Z3
+
+#ifdef SOLVER_CVC5
+  solver_results.push_back(
+    Result(fupdate(this->cvc5_solver, [](auto &solver) {
+      return solver.checkSat();
+    }))
+  );
+#endif // SOLVER_CVC5
   
-  // TODO: compare with results from other solvers
   // TODO: concurrent run with solvers and return the fastest one?
-  return Result(z3_result);    
+  return Result::evaluateResults(solver_results);
 }
+
+IF_Z3_ENABLED(void useZ3() { sctx.useZ3(); })
+IF_CVC5_ENABLED(void useCVC5() { sctx.useCVC5(); })
 } // namespace smt
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const smt::expr &e) {

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -528,6 +528,7 @@ const bool Result::operator==(const Result &rhs) {
 Result Result::evaluateResults(const vector<Result> &results) {
   return accumulate(results.cbegin(), results.cend(), Result(),
     [](auto acc, const auto result) {
+      // precedence is UNKNOWN < SAT < UNSAT
       acc.result = max(acc.result, result.result); return acc;
     }
   );

--- a/src/smt.h
+++ b/src/smt.h
@@ -76,15 +76,21 @@ private:
 #ifdef SOLVER_Z3
   std::optional<z3::expr> z3_expr;
   void setZ3Expr(std::optional<z3::expr> &&z3_expr);
+  friend z3::expr_vector toZ3ExprVector(const std::vector<Expr> &vec);
 #endif // SOLVER_Z3
 
 #ifdef SOLVER_CVC5
   std::optional<cvc5::api::Term> cvc5_expr;
   void setCVC5Expr(std::optional<cvc5::api::Term> &&cvc5_expr);
+  friend std::vector<cvc5::api::Term> toCVC5ExprVector(const std::vector<Expr> &vec);
 #endif // SOLVER_CVC5
 
 public:
   Expr simplify() const;
+  Expr substitute(const std::vector<Expr> &vars, const std::vector<Expr> &values) const;
+  Expr implies(const Expr &rhs) const;
+  Expr select(const Expr &idx) const;
+  Expr select(const std::vector<Expr> &indices) const;
   std::vector<Expr> toNDIndices(const std::vector<Expr> &dims) const;
 
   Expr urem(const Expr &rhs) const;
@@ -102,6 +108,13 @@ public:
   static Expr mkVar(const Sort &s, const std::string &name);
   static Expr mkBV(const uint64_t val, const size_t sz);
   static Expr mkBool(const bool val);
+
+  static Expr mkLambda(const Expr &var, const Expr &body);
+  static Expr mkLambda(const std::vector<Expr> &vars, const Expr &body);
+  static Expr mkForall(const std::vector<Expr> &vars, const Expr &body);
+  static Expr mk1DIdx(const std::vector<Expr> &indices, const std::vector<Expr> &dims);
+  static Expr mkFitsInDims(const std::vector<Expr> &indices, const std::vector<Expr> &sizes);
+  static std::vector<Expr> mkSimplifiedList(const std::vector<Expr> &exprs);
 };
 
 class Sort {

--- a/src/smt.h
+++ b/src/smt.h
@@ -175,6 +175,7 @@ public:
 
 IF_Z3_ENABLED(void useZ3());
 IF_CVC5_ENABLED(void useCVC5());
+void setTimeout(const uint64_t ms);
 } // namespace smt
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const smt::expr &e);


### PR DESCRIPTION
This PR adds CVC5 support for `smt::Expr`, `smt::Sort`, and `smt::Solver`.

- Added a lot of CVC5 API codes
- Added even more macros to allow building without some of the solvers
- Updated CMakeLists to link against CVC5 library
- Updated README