### PR TITLE
Cherry-pick solver-macros, CMakeLists, and README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,15 @@ set (CMAKE_CXX_STANDARD 17)
 
 set(MLIR_DIR CACHE PATH "MLIR installation top-level directory")
 set(Z3_DIR CACHE PATH "Z3 installation top-level directory")
-option(USE_LIBC "Use libc++ in case the MLIR is linked against libc++")
+set(CVC5_DIR CACHE PATH "CVC5 installation top-level directory")
+option(USE_LIBC "Use libc++ in case the MLIR (and CVC5) is linked against libc++")
 
 set(MLIR_INC_DIR "${MLIR_DIR}/include")
 set(MLIR_LIB_DIR "${MLIR_DIR}/lib")
 set(Z3_INC_DIR "${Z3_DIR}/include")
 set(Z3_LIB_DIR "${Z3_DIR}/lib")
+set(CVC5_INC_DIR "${CVC5_DIR}/include")
+set(CVC5_LIB_DIR "${CVC5_DIR}/lib")
 
 # Build library first
 set(PROJECT_LIB "mlirtv")
@@ -45,7 +48,7 @@ else()
 endif()
 
 # Check if at least one solver is available
-if(NOT Z3_DIR)
+if(NOT Z3_DIR AND NOT CVC5_DIR)
     message(FATAL_ERROR "path to at least one of the solvers must be provided!")
 endif()
 
@@ -57,6 +60,19 @@ if(Z3_DIR)
         target_include_directories(${PROJECT_LIB} PUBLIC ${Z3_INC_DIR})
         target_link_directories(${PROJECT_LIB} PUBLIC ${Z3_LIB_DIR})
         target_link_libraries(${PROJECT_LIB} PUBLIC z3)
+        target_compile_definitions(${PROJECT_LIB} PUBLIC SOLVER_Z3)
+    endif()
+endif()
+
+# Check for CVC5 installation
+if(CVC5_DIR)
+    if(NOT EXISTS ${CVC5_INC_DIR} OR NOT EXISTS ${CVC5_LIB_DIR})
+        message(FATAL_ERROR "the provided path doesn't seem to be a valid CVC5 directory")
+    else()
+        target_include_directories(${PROJECT_LIB} PUBLIC ${CVC5_INC_DIR})
+        target_link_directories(${PROJECT_LIB} PUBLIC ${CVC5_LIB_DIR})
+        target_link_libraries(${PROJECT_LIB} PUBLIC cvc5)
+        target_compile_definitions(${PROJECT_LIB} PUBLIC SOLVER_CVC5)
     endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,18 @@ Currently MLIR-TV is in an experimental stage.
 Prerequisites: [CMake](https://cmake.org/download/)(>=3.15),
 [MLIR](https://github.com/llvm/llvm-project),
 [Python3](https://www.python.org/downloads/)(>=3.9)  
-Solvers (at least one of them must be used): [Z3-solver](https://github.com/Z3Prover/z3)
+Solvers (at least one of them must be used): [Z3-solver](https://github.com/Z3Prover/z3), [CVC5](https://github.com/cvc5/cvc5)
 
 - Installation of MLIR: please follow [this instruction](https://llvm.org/docs/GettingStarted.html#getting-the-source-code-and-building-llvm) & run `cmake --build . --target install`
 
 ```bash
 mkdir build
 cd build
-# -DUSE_LIBC is OFF by default. Set it to ON iff the MLIR is built using libc++
+# As of now, mlir-tv won't compile without -DZ3_DIR. This will be fixed soon.
+# -DUSE_LIBC is OFF by default. Set it to ON iff the MLIR (and CVC5) is linked against libc++
 cmake -DMLIR_DIR=<dir/to/mlir-install> \
       -DZ3_DIR=<dir/to/z3-install> \
+      [-DCVC5_DIR=<dir/to/cvc5-install>] \
       [-DUSE_LIBC=ON|OFF] \
       [-DCMAKE_BUILD_TYPE=DEBUG|RELEASE] \
       ..

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -3,19 +3,19 @@
 #include "utils.h"
 
 #ifdef SOLVER_Z3
-#define TRY_SET_Z3_EXPR(fn) e.setZ3Expr(fn)
-#define TRY_SET_Z3_SORT(fn) s.setZ3Sort(fn)
+  #define TRY_SET_Z3_EXPR(fn) e.setZ3Expr(fn)
+  #define TRY_SET_Z3_SORT(fn) s.setZ3Sort(fn)
 #else
-#define TRY_SET_Z3_EXPR(fn)
-#define TRY_SET_Z3_SORT(fn)
+  #define TRY_SET_Z3_EXPR(fn)
+  #define TRY_SET_Z3_SORT(fn)
 #endif
 
 #ifdef SOLVER_CVC5
-#define TRY_SET_CVC5_EXPR(fn) e.setCVC5Expr(fn)
-#define TRY_SET_CVC5_SORT(fn) s.setCVC5Sort(fn)
+  #define TRY_SET_CVC5_EXPR(fn) e.setCVC5Expr(fn)
+  #define TRY_SET_CVC5_SORT(fn) s.setCVC5Sort(fn)
 #else
-#define TRY_SET_CVC5_EXPR(fn)
-#define TRY_SET_CVC5_SORT(fn)
+  #define TRY_SET_CVC5_EXPR(fn)
+  #define TRY_SET_CVC5_SORT(fn)
 #endif
 
 using namespace std;

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -2,6 +2,22 @@
 #include "smt.h"
 #include "utils.h"
 
+#ifdef SOLVER_Z3
+#define TRY_SET_Z3_EXPR(fn) e.setZ3Expr(fn)
+#define TRY_SET_Z3_SORT(fn) s.setZ3Sort(fn)
+#else
+#define TRY_SET_Z3_EXPR(fn)
+#define TRY_SET_Z3_SORT(fn)
+#endif
+
+#ifdef SOLVER_CVC5
+#define TRY_SET_CVC5_EXPR(fn) e.setCVC5Expr(fn)
+#define TRY_SET_CVC5_SORT(fn) s.setCVC5Sort(fn)
+#else
+#define TRY_SET_CVC5_EXPR(fn)
+#define TRY_SET_CVC5_SORT(fn)
+#endif
+
 using namespace std;
 
 namespace {

--- a/src/smt.h
+++ b/src/smt.h
@@ -1,9 +1,22 @@
 #pragma once
 
 #include "llvm/Support/raw_ostream.h"
-#include "z3++.h"
 #include <vector>
 #include <optional>
+
+#ifdef SOLVER_Z3
+  #include "z3++.h"
+  #define IF_Z3_ENABLED(stmt) stmt
+#else
+  #define IF_Z3_ENABLED(stmt)
+#endif
+
+#ifdef SOLVER_CVC5
+  #include "cvc5/cvc5.h"
+  #define IF_CVC5_ENABLED(stmt) stmt
+#else
+  #define IF_CVC5_ENABLED(stmt)
+#endif
 
 namespace smt {
 using expr = z3::expr;


### PR DESCRIPTION
This PR adds SOLVER-<solver> macros and updates CMakeLists to allow linking against CVC5.
README is updated as well.