### PR TITLE
Make Tensor, MemRef class inherit Shaped class

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -328,7 +328,7 @@ optional<string> encodeOp(State &st, mlir::memref::LoadOp op) {
   for (auto idx0: op.indices())
     indices.emplace_back(st.regs.get<Index>(idx0));
 
-  auto [Expr, success] = m.load(indices);
+  auto [Expr, success] = m.get(indices);
   if (auto vt = fromExpr(move(Expr), op.getType())) {
     st.regs.add(op, move(*vt));
     st.wellDefined(op.getOperation(), move(success));
@@ -411,7 +411,7 @@ optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
   } else {
     vector<Expr> idxs = createBoundIndexVars(memrefTy.getRank());
     auto [tVal, tSuccess] = tensor.get(idxs);
-    auto [mVal, mSuccess] = memref.load(idxs);
+    auto [mVal, mSuccess] = memref.get(idxs);
     auto success = tSuccess & mSuccess;
 
     st.wellDefined(
@@ -433,7 +433,7 @@ optional<string> encodeOp(State &st, mlir::memref::TensorLoadOp op) {
   // Step 2. Create a new Tensor using Tensor::mkLambda
   auto dims = m.getDims();
   vector<Expr> idxs = createBoundIndexVars(dims.size());
-  auto [Expr, success] = m.load(idxs);
+  auto [Expr, success] = m.get(idxs);
   Tensor t_res = Tensor::mkLambda(move(dims), move(idxs), Expr);
 
   st.regs.add(op.getResult(), t_res);

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -309,15 +309,13 @@ optional<string> encodeOp(State &st, mlir::tensor::ExtractOp op) {
   for (auto idx0: op.indices())
     indices.emplace_back(st.regs.get<Index>(idx0));
 
-  if (auto v = fromExpr(t.get(indices), op.getType()))
+  auto [elem, inbounds] = t.get(indices);
+  if (auto v = fromExpr(move(elem), op.getType()))
     st.regs.add(op, move(*v));
   else
     return "unsupported type";
 
-  for (unsigned i = 0; i < indices.size(); ++i)
-    // TODO: revisit this; may not be axis-wise
-    st.wellDefined(op.getOperation(), indices[i].ult(t.getDim(i)));
-
+  st.wellDefined(op.getOperation(), move(inbounds));
   return {};
 }
 
@@ -412,8 +410,9 @@ optional<string> encodeOp(State &st, mlir::memref::BufferCastOp op) {
 
   } else {
     vector<Expr> idxs = createBoundIndexVars(memrefTy.getRank());
-    auto tVal = tensor.get(idxs);
-    auto [mVal, success] = memref.load(idxs);
+    auto [tVal, tSuccess] = tensor.get(idxs);
+    auto [mVal, mSuccess] = memref.load(idxs);
+    auto success = tSuccess & mSuccess;
 
     st.wellDefined(
         op.getOperation(),
@@ -800,6 +799,7 @@ encodeUBForTensorShapeMatch(State &st, mlir::linalg::GenericOp op,
 
 static optional<string> initInputStateForLoopBody(
     State &st, mlir::linalg::GenericOp op) {
+  // TODO: Currently we do not encode UB in loop body. How to deal with UB properly?
   auto indexingMaps = op.indexing_maps().getValue();
   auto outputMap = indexingMaps.back().cast<mlir::AffineMapAttr>().getValue();
   auto &block = *op.region().begin();
@@ -828,8 +828,7 @@ static optional<string> initInputStateForLoopBody(
 
       if (inputMap.getNumResults() == 0) {
         // A tensor with a single element; e.g. tensor<f32>.
-        st.regs.add(block.getArgument(arg_i), t_input.get({Index::zero()}),
-                    elemty);
+        st.regs.add(block.getArgument(arg_i), t_input.get({Index::zero()}).first, elemty);
       } else {
         vector<Expr> affine_Exprs;
         for (unsigned i = 0; i < inputMap.getNumResults(); ++i) {
@@ -841,7 +840,7 @@ static optional<string> initInputStateForLoopBody(
           affine_Exprs.emplace_back(move(*ae_res));
         }
 
-        auto t_elem = t_input.get(affine_Exprs);
+        auto [t_elem, inbounds] = t_input.get(affine_Exprs);
         st.regs.add(block.getArgument(arg_i), t_elem, elemty);
       }
     } else {
@@ -1008,7 +1007,7 @@ static optional<string> encodeReductionLoopBodyAndOutput(
     auto t_sum = Tensor::mkLambda(
           addOne(move(boundsForRes)),
           move(indVarsForRes),
-          t_v.get(linalgInfo.indVars))
+          t_v.get(linalgInfo.indVars).first)
         .sum();
 
     auto outputIndVars = doMap(linalgInfo.indVars, outputMap);

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -62,10 +62,10 @@ void printCounterEx(
         auto indices = simplifyList(from1DIdx(param, t_src.getDims()));
         llvm::outs() << "Index: " << or_omit(indices) << '\n';
         llvm::outs() << "Element (src): "
-                    << or_omit(t_src.get(indices).simplify())
+                    << or_omit(t_src.get(indices).first.simplify())
                     << '\n';
         llvm::outs() << "Element (tgt): "
-                    << or_omit(t_tgt.get(indices).simplify())
+                    << or_omit(t_tgt.get(indices).first.simplify())
                     << '\n';
       }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -244,10 +244,6 @@ pair<Expr, Expr> Tensor::get(const vector<Expr> &indices) const {
   return {elem, inbounds.simplify()};
 }
 
-Index Tensor::getDim(uint64_t idx) const {
-  return Index(dims[idx]);
-}
-
 Tensor Tensor::affine(
     const vector<Expr> &newidxvars,
     vector<Expr> srcidxs,
@@ -655,7 +651,7 @@ MemRef::getDimsAndLayoutAndElemTy(
   }
 }
 
-pair<Expr, Expr> MemRef::load(const vector<Expr> &indices) {
+pair<Expr, Expr> MemRef::get(const vector<Expr> &indices) const {
   auto [idx, inbounds] = to1DIdxWithLayout(indices);
   auto [loaded, success] = m->load(bid, (Expr)offset + idx);
 
@@ -688,10 +684,6 @@ Expr MemRef::isGlobalBlock() const {
 
 Expr MemRef::isLocalBlock() const {
   return m->isLocalBlock(bid);
-}
-
-Index MemRef::getDim(uint64_t idx) const {
-  return Index(dims[idx]);
 }
 
 void MemRef::setWritable(bool writable) {
@@ -749,7 +741,7 @@ MemRef MemRef::eval(Model mdl) const {
   return m2;
 }
 
-pair<Expr, Expr> MemRef::to1DIdxWithLayout(const vector<Expr> &idxs) {
+pair<Expr, Expr> MemRef::to1DIdxWithLayout(const vector<Expr> &idxs) const {
   auto Expr = layout.mapping.select(idxs);
   auto inbounds = layout.inbounds.select(idxs);
   return {Expr, inbounds};

--- a/src/value.h
+++ b/src/value.h
@@ -88,6 +88,10 @@ public:
   Integer eval(smt::Model m) const;
 };
 
+// class Shaped {
+//   virtual smt::Expr get(const std::vector<smt::Expr> &indices) const;
+// }
+
 class Tensor {
   std::vector<smt::Expr> dims;
   smt::Expr arr;
@@ -119,7 +123,7 @@ public:
   //   Expr v = tensor.get(indices)
   //   useAsInt(Integer(v)) // valid only if tensor had integer elems
   //   useAsFloat(Float(v)) // valid only if tensor had float elems
-  smt::Expr get(const std::vector<smt::Expr> &indices) const;
+  std::pair<smt::Expr, smt::Expr> get(const std::vector<smt::Expr> &indices) const;
 
   smt::Expr get1DSize() const { return smt::get1DSize(dims); }
 

--- a/src/value.h
+++ b/src/value.h
@@ -88,11 +88,16 @@ public:
   Integer eval(smt::Model m) const;
 };
 
-// class Shaped {
-//   virtual smt::Expr get(const std::vector<smt::Expr> &indices) const;
-// }
+class Shaped {
+public:
+  virtual std::vector<smt::Expr> getDims() const = 0;
+  virtual std::pair<smt::Expr, smt::Expr> get(const std::vector<smt::Expr> &indices) const = 0;
 
-class Tensor {
+  Index getDim(uint64_t idx) const { return Index(getDims()[idx]); }
+  smt::Expr get1DSize() const { return smt::get1DSize(getDims()); }
+};
+
+class Tensor: public Shaped {
   std::vector<smt::Expr> dims;
   smt::Expr arr;
 
@@ -123,12 +128,9 @@ public:
   //   Expr v = tensor.get(indices)
   //   useAsInt(Integer(v)) // valid only if tensor had integer elems
   //   useAsFloat(Float(v)) // valid only if tensor had float elems
-  std::pair<smt::Expr, smt::Expr> get(const std::vector<smt::Expr> &indices) const;
+  std::pair<smt::Expr, smt::Expr> get(const std::vector<smt::Expr> &indices) const override;
 
-  smt::Expr get1DSize() const { return smt::get1DSize(dims); }
-
-  Index getDim(uint64_t idx) const;
-  std::vector<smt::Expr> getDims() const { return dims; }
+  std::vector<smt::Expr> getDims() const override { return dims; }
 
   // Return a new tensor T2 s.t.
   //   T2[newidxvars] = this[srcidxs]
@@ -180,7 +182,7 @@ private:
       const std::vector<smt::Expr> &sizes) const;
 };
 
-class MemRef {
+class MemRef: public Shaped {
 public:
   // This may be parameterized later..
   static const unsigned MAX_MEMREF_SIZE = 1000000;
@@ -255,7 +257,9 @@ public:
       std::optional<std::vector<smt::Expr>> predefinedDims = {},
       bool freshVarForUnknownSize = true);
 
-  std::pair<smt::Expr, smt::Expr> load(const std::vector<smt::Expr> &indices);
+  std::vector<smt::Expr> getDims() const override { return dims; }
+
+  std::pair<smt::Expr, smt::Expr> get(const std::vector<smt::Expr> &indices) const override;
   smt::Expr store(const smt::Expr &value, const std::vector<smt::Expr> &indices);
   smt::Expr storeArray(const smt::Expr &array, const smt::Expr &startOffset,
       const smt::Expr &size, bool ubIfReadonly = true);
@@ -264,9 +268,6 @@ public:
   smt::Expr isLocalBlock() const;
   smt::Expr getBID() const { return bid; }
   Index getOffset() const { return offset; }
-  smt::Expr get1DSize() const { return smt::get1DSize(dims); }
-  Index getDim(uint64_t idx) const;
-  std::vector<smt::Expr> getDims() const { return dims; }
   void setWritable(bool writable);
   void setMemory(Memory *m) { this->m = m; }
 
@@ -292,7 +293,7 @@ private:
   smt::Expr to1DArrayWithOfs(
       const std::vector<smt::Expr> &offbegins,
       const std::vector<smt::Expr> &sizes) const;
-  std::pair<smt::Expr, smt::Expr> to1DIdxWithLayout(const std::vector<smt::Expr> &idxs);
+  std::pair<smt::Expr, smt::Expr> to1DIdxWithLayout(const std::vector<smt::Expr> &idxs) const;
 
   MemRef::Layout createSubViewLayout(const std::vector<smt::Expr> &indVars,
       const std::vector<smt::Expr> &offsets,

--- a/src/value.h
+++ b/src/value.h
@@ -88,7 +88,7 @@ public:
   Integer eval(smt::Model m) const;
 };
 
-class Shaped {
+class ShapedValue {
 public:
   virtual std::vector<smt::Expr> getDims() const = 0;
   virtual std::pair<smt::Expr, smt::Expr> get(const std::vector<smt::Expr> &indices) const = 0;
@@ -97,7 +97,7 @@ public:
   smt::Expr get1DSize() const { return smt::get1DSize(getDims()); }
 };
 
-class Tensor: public Shaped {
+class Tensor: public ShapedValue {
   std::vector<smt::Expr> dims;
   smt::Expr arr;
 
@@ -182,7 +182,7 @@ private:
       const std::vector<smt::Expr> &sizes) const;
 };
 
-class MemRef: public Shaped {
+class MemRef: public ShapedValue {
 public:
   // This may be parameterized later..
   static const unsigned MAX_MEMREF_SIZE = 1000000;


### PR DESCRIPTION
In this PR, we make a common class of Tensor, MemRef class which contains common index (dimension) based logic.
Maybe linalg operations related with both Tensor, MemRef are fit here.
These operations will be added in following PR.