### PR TITLE
Fix broken conv2_2d_nhwc_hwcf optimization tests

### DIFF
--- a/tests/opts/conv2d-to-img2col/nhwc_filter-bad.src.mlir
+++ b/tests/opts/conv2d-to-img2col/nhwc_filter-bad.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY-INCORRECT
 
 func @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
-    %0 = linalg.conv_2d_input_nhwc_filter_hwcf
+    %0 = linalg.conv_2d_nhwc_hwcf
       {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
        ins(%arg0, %arg1: tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)
       outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>

--- a/tests/opts/conv2d-to-img2col/nhwc_filter.src.mlir
+++ b/tests/opts/conv2d-to-img2col/nhwc_filter.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
-    %0 = linalg.conv_2d_input_nhwc_filter_hwcf
+    %0 = linalg.conv_2d_nhwc_hwcf
       {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
        ins(%arg0, %arg1: tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)
       outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>


### PR DESCRIPTION
In recent MLIR, `linalg.conv_2d_input_nhwc_filter_hwcf` operations are renamed to `linalg.conv_2d_nhwc_hwcf`.