### PR TITLE
Support linalg::conv encoding

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -188,7 +188,7 @@ encodeOp(State &st, mlir::linalg::ConvOp op) {
   auto filter = st.regs.get<MemRef>(op.filter());
   auto output = st.regs.get<MemRef>(op.output());
 
-  if (!output.getPrecondition().isIdentical(Expr::mkBool(true)))
+  if (!output.getPrecondition().isTrue())
     return "Currently output MemRef should have plain layout..";
 
   auto success = output.conv(input, filter, strides, dilations);

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -188,8 +188,8 @@ encodeOp(State &st, mlir::linalg::ConvOp op) {
   auto filter = st.regs.get<MemRef>(op.filter());
   auto output = st.regs.get<MemRef>(op.output());
 
-  if (!output.getPrecondition().isTrue())
-    return "Currently output MemRef should have plain layout..";
+  if (!output.isIdentityMap())
+    return "Currently output MemRef should have identity layout..";
 
   auto success = output.conv(input, filter, strides, dilations);
   // add well defined

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -722,11 +722,11 @@ Expr MemRef::conv(const MemRef &input,
     const MemRef &filter,
     const std::vector<smt::Expr> strides,
     const std::vector<smt::Expr> dilations) {
-  auto [indices, expr] = ((ShapedValue *) &input)->conv(filter, strides, dilations);
+  auto [indices, expr] = input.ShapedValue::conv(filter, strides, dilations);
 
   // we splat results into 1D memory layout
   auto idx = Index::var("outputIdx", VarType::BOUND);
-  auto outputIndices = getInverseIndices(idx);
+  auto outputIndices = layout.getInverseIndices(idx);
   auto outputExpr = expr.substitute(indices, outputIndices);
   auto outputArray = Expr::mkLambda(idx, outputExpr);
 
@@ -788,10 +788,10 @@ MemRef::Layout MemRef::createSubViewLayout(
   return Layout(transformedIndVars, transformedLayout, transformedInbounds);
 }
 
-vector<Expr> MemRef::getInverseIndices(const Expr &idx) const {
+vector<Expr> MemRef::Layout::getInverseIndices(const Expr &idx) const {
   vector<Expr> indices;
-  for (unsigned i = 0; i < dims.size(); i ++)
-    indices.push_back(layout.inverseMappings[i].select(idx));
+  for (auto inverse: inverseMappings)
+    indices.push_back(inverse.select(idx));
 
   return indices;
 }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -678,7 +678,7 @@ Expr MemRef::storeArray(
 Expr MemRef::isInBounds() const {
   auto numelem = m->getNumElementsOfMemBlock(bid);
   auto memrefSize = get1DSize();
-  return numelem.uge(memrefSize) & ((Expr)offset).ult(numelem - memrefSize);
+  return numelem.uge(memrefSize) & ((Expr)offset).ule(numelem - memrefSize);
 }
 
 Expr MemRef::isGlobalBlock() const {
@@ -731,7 +731,9 @@ Expr MemRef::conv(const MemRef &input,
   auto outputArray = Expr::mkLambda(idx, outputExpr);
 
   // store output memref
-  auto success = storeArray(outputArray, Index::zero(), get1DSize());
+  auto success = isInBounds() & input.isInBounds() & filter.isInBounds() &
+    storeArray(outputArray, Index::zero(), get1DSize());
+
   return success;
 }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -694,13 +694,13 @@ smt::Expr MemRef::noalias(const MemRef &other) const {
     assert("Noalias check with arbitrary layout memref is not supported yet");
 
   auto l1 = (Expr) offset;
-  auto r1 = (Expr) offset +  get1DSize() - 1;
+  auto r1 = (Expr) offset + get1DSize();
   auto l2 = (Expr) other.offset;
-  auto r2 = (Expr) other.offset + other.get1DSize()- 1;
+  auto r2 = (Expr) other.offset + other.get1DSize();
 
   // Case 1. bid != other.bid
-  // Case 2. bid == other.bid && (r2 < l1 || r1 < l2)
-  return !(bid == other.bid) | (bid == other.bid & (r2.ult(l1) | r1.ult(l2)));
+  // Case 2. bid == other.bid && (r2 <= l1 || r1 <= l2)
+  return !(bid == other.bid) | (bid == other.bid & (r2.ule(l1) | r1.ule(l2)));
 }
 
 void MemRef::setWritable(bool writable) {

--- a/src/value.h
+++ b/src/value.h
@@ -288,6 +288,12 @@ public:
       const std::vector<smt::Expr> &strides,
       int rankDiff = 0);
 
+  // Store results which is convolution of input, filter and return wellDefined.
+  smt::Expr conv(const MemRef &input,
+      const MemRef &filter,
+      const std::vector<smt::Expr> strides,
+      const std::vector<smt::Expr> dilations);
+
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, const MemRef &);
   // (refinement, unbound variables used in the refinement formula)
   std::pair<smt::Expr, std::vector<smt::Expr>> refines(
@@ -309,4 +315,6 @@ private:
   MemRef::Layout createSubViewLayout(const std::vector<smt::Expr> &indVars,
       const std::vector<smt::Expr> &offsets,
       const std::vector<smt::Expr> &strides);
+
+  std::vector<smt::Expr> getInverseIndices(const smt::Expr &idx) const;
 };

--- a/src/value.h
+++ b/src/value.h
@@ -237,6 +237,8 @@ public:
       indVars(copy.indVars), inbounds(copy.inbounds),
       mapping(copy.mapping), inverseMappings(copy.inverseMappings),
       precondition(copy.precondition) {}
+
+    std::vector<smt::Expr> getInverseIndices(const smt::Expr &idx) const;
   };
 
   MemRef(Memory *m,
@@ -267,6 +269,9 @@ public:
       getLayout(mlir::MemRefType memRefTy, const std::vector<smt::Expr> &dims);
   static std::optional<smt::Sort> getElemTy(mlir::MemRefType memRefTy);
 
+  // Property getters
+  smt::Expr getBID() const { return bid; }
+  Index getOffset() const { return offset; }
   std::vector<smt::Expr> getDims() const override { return dims; }
 
   std::pair<smt::Expr, smt::Expr> get(const std::vector<smt::Expr> &indices) const override;
@@ -277,8 +282,6 @@ public:
   smt::Expr isInBounds() const;
   smt::Expr isGlobalBlock() const;
   smt::Expr isLocalBlock() const;
-  smt::Expr getBID() const { return bid; }
-  Index getOffset() const { return offset; }
   void setWritable(bool writable);
   void setMemory(Memory *m) { this->m = m; }
 
@@ -315,6 +318,4 @@ private:
   MemRef::Layout createSubViewLayout(const std::vector<smt::Expr> &indVars,
       const std::vector<smt::Expr> &offsets,
       const std::vector<smt::Expr> &strides);
-
-  std::vector<smt::Expr> getInverseIndices(const smt::Expr &idx) const;
 };

--- a/src/value.h
+++ b/src/value.h
@@ -221,6 +221,7 @@ public:
     // Precondition for inverse mapping function.
     // If we cannot give exact definition of inverseMappings, then give its meaning with forall quantifier.
     // This will be added to state's precondition only when inverseMappings are used explicitly.
+    // If the layout has simple identity mapping, this will be constantly true.
     // ex) forall indVars, if (indVars are inbounds) then inverse0(mapping(d0, d1)) = d0 && inverse1(mapping(d0, d1)) = d1
     smt::Expr precondition;
 
@@ -282,8 +283,10 @@ public:
   smt::Expr isInBounds() const;
   smt::Expr isGlobalBlock() const;
   smt::Expr isLocalBlock() const;
+  smt::Expr noalias(const MemRef &other) const;
   void setWritable(bool writable);
   void setMemory(Memory *m) { this->m = m; }
+  bool isIdentityMap() const;
 
   // Return a new memerf which is subview of source memref.
   MemRef subview(const std::vector<smt::Expr> &offsets,

--- a/tests/litmus/linalg-ops/convolution.src.mlir
+++ b/tests/litmus/linalg-ops/convolution.src.mlir
@@ -1,0 +1,10 @@
+// VERIFY
+
+func @conv(%input: tensor<1x225x225x3xf32>, %filter: tensor<3x3x3x32xf32>,
+           %output: tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32> {
+  %0 = linalg.conv_2d_nhwc_hwcf
+      {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64> }
+       ins(%input, %filter: tensor<1x225x225x3xf32>, tensor<3x3x3x32xf32>)
+      outs(%output: tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
+  return %0 : tensor<1x112x112x32xf32>
+}

--- a/tests/litmus/linalg-ops/convolution.tgt.mlir
+++ b/tests/litmus/linalg-ops/convolution.tgt.mlir
@@ -1,0 +1,10 @@
+func @conv(%input: tensor<1x225x225x3xf32>, %filter: tensor<3x3x3x32xf32>,
+           %output: tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32> {
+  %0 = memref.buffer_cast %input : memref<1x225x225x3xf32>
+  %1 = memref.buffer_cast %filter : memref<3x3x3x32xf32>
+  %2 = memref.alloc() : memref<1x112x112x32xf32>
+  linalg.conv(%1, %0, %2) {dilations = [1, 1], strides = [2, 2]}
+    : memref<3x3x3x32xf32>, memref<1x225x225x3xf32>, memref<1x112x112x32xf32>
+  %3 = memref.tensor_load %2 : memref<1x112x112x32xf32>
+  return %3 : tensor<1x112x112x32xf32>
+}


### PR DESCRIPTION
In this PR, we added `linalg::conv`operations encoding.
Main convolution calculation is done by `ShapedValue::conv`, and memref's conv operation just store result values into Memory.
For simplicity, currently we support only plain layout mapped MemRef.
This constraint may be relaxed later..