### PR TITLE
Support linalg::generic encoding for memref

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1170,7 +1170,6 @@ optional<string> encodeOp(State &st, mlir::linalg::GenericOp op) {
     auto str = attr.cast<mlir::StringAttr>().getValue();
     return str != mlir::getParallelIteratorTypeName() &&
            str != mlir::getReductionIteratorTypeName() &&
-           // TODO (makesource)
            str != mlir::getWindowIteratorTypeName();
   }))
     return "unsupported iterator type";

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -201,9 +201,7 @@ std::pair<std::vector<smt::Expr>, smt::Expr> ShapedValue::conv(const ShapedValue
 
   Expr inputExpr = Expr::mkLambda(cubeIdx, get(inputIdxs).first);
   Expr filterExpr = Expr::mkLambda(cubeIdx, filter.get(filterIdxs).first);
-  // TODO (makesource) support commutative dot operation
-  // Expr outputExpr = aop::dot(inputExpr, filterExpr, ::get1DSize(cubeSize));
-  Expr outputExpr = aop::dot(filterExpr, inputExpr, ::get1DSize(cubeSize));
+  Expr outputExpr = aop::dot(inputExpr, filterExpr, ::get1DSize(cubeSize));
 
   return {move(outputIdxs), move(outputExpr)};
 }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -201,7 +201,9 @@ std::pair<std::vector<smt::Expr>, smt::Expr> ShapedValue::conv(const ShapedValue
 
   Expr inputExpr = Expr::mkLambda(cubeIdx, get(inputIdxs).first);
   Expr filterExpr = Expr::mkLambda(cubeIdx, filter.get(filterIdxs).first);
-  Expr outputExpr = aop::dot(inputExpr, filterExpr, ::get1DSize(cubeSize));
+  // TODO (makesource) support commutative dot operation
+  // Expr outputExpr = aop::dot(inputExpr, filterExpr, ::get1DSize(cubeSize));
+  Expr outputExpr = aop::dot(filterExpr, inputExpr, ::get1DSize(cubeSize));
 
   return {move(outputIdxs), move(outputExpr)};
 }

--- a/tests/opts/llvmcpu-plan-conv-loop-order/simple-small.src.mlir
+++ b/tests/opts/llvmcpu-plan-conv-loop-order/simple-small.src.mlir
@@ -1,0 +1,11 @@
+// VERIFY
+
+func @conv(%filter: memref<3x3x1x1xf32>, %input: memref<1x3x3x1xf32>,
+           %output: memref<1x1x1x1xf32>) {
+  linalg.conv(%filter, %input, %output)
+    : memref<3x3x1x1xf32>, memref<1x3x3x1xf32>, memref<1x1x1x1xf32>
+  return
+}
+
+// How to reproduce tgt:
+// iree-opt -iree-llvmcpu-plan-conv-loop-order <src>

--- a/tests/opts/llvmcpu-plan-conv-loop-order/simple-small.tgt.mlir
+++ b/tests/opts/llvmcpu-plan-conv-loop-order/simple-small.tgt.mlir
@@ -1,0 +1,14 @@
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d3, d2 + d4, d5)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d6)>
+module  {
+  func @conv(%arg0: memref<3x3x1x1xf32>, %arg1: memref<1x3x3x1xf32>, %arg2: memref<1x1x1x1xf32>) {
+    linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "window", "window", "reduction", "parallel"]} ins(%arg0, %arg1 : memref<3x3x1x1xf32>, memref<1x3x3x1xf32>) outs(%arg2 : memref<1x1x1x1xf32>) {
+    ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+      %0 = mulf %arg3, %arg4 : f32
+      %1 = addf %0, %arg5 : f32
+      linalg.yield %1 : f32
+    }
+    return
+  }
+}


### PR DESCRIPTION
Add MemRef related encoding for linalg.generic loop.
And we finally verify `llvmcpu-plan-conv-loop-order` optimization!

```
Test project /Users/makesource/src/mlir-tv/build
      Start  1: Opts-conv2d-to-img2col
 1/16 Test  #1: Opts-conv2d-to-img2col ..............   Passed    2.32 sec
      Start  2: Opts-fold-memref-subview-op
 2/16 Test  #2: Opts-fold-memref-subview-op .........   Passed    0.59 sec
      Start  3: Opts-fold-tensor-extract-op
 3/16 Test  #3: Opts-fold-tensor-extract-op .........   Passed    2.01 sec
      Start  4: Opts-fusion-tensor
 4/16 Test  #4: Opts-fusion-tensor ..................   Passed    3.28 sec
      Start  5: Opts-llvmcpu-plan-conv-loop-order
 5/16 Test  #5: Opts-llvmcpu-plan-conv-loop-order ...   Passed  172.78 sec
      Start  6: Litmus-abstraction
 6/16 Test  #6: Litmus-abstraction ..................   Passed    0.19 sec
      Start  7: Litmus-affine-ops
 7/16 Test  #7: Litmus-affine-ops ...................   Passed    0.17 sec
      Start  8: Litmus-cexprint
 8/16 Test  #8: Litmus-cexprint .....................   Passed    0.16 sec
      Start  9: Litmus-linalg-loops
 9/16 Test  #9: Litmus-linalg-loops .................   Passed    0.19 sec
      Start 10: Litmus-linalg-ops
10/16 Test #10: Litmus-linalg-ops ...................   Passed    4.27 sec
      Start 11: Litmus-memref-ops
11/16 Test #11: Litmus-memref-ops ...................   Passed    2.19 sec
      Start 12: Litmus-refinement
12/16 Test #12: Litmus-refinement ...................   Passed    0.21 sec
      Start 13: Litmus-sparsetensor-ops
13/16 Test #13: Litmus-sparsetensor-ops .............   Passed    0.20 sec
      Start 14: Litmus-std-ops
14/16 Test #14: Litmus-std-ops ......................   Passed    0.16 sec
      Start 15: Litmus-tensor-constant
15/16 Test #15: Litmus-tensor-constant ..............   Passed    0.27 sec
      Start 16: Litmus-tensor-ops
16/16 Test #16: Litmus-tensor-ops ...................   Passed    0.22 sec

100% tests passed, 0 tests failed out of 16

Total Test time (real) = 189.22 sec
```