### PR TITLE
Fix bugs in subview encoding

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -657,6 +657,7 @@ optional<MemRef::Layout> MemRef::getLayout(
 pair<Expr, Expr> MemRef::get(const vector<Expr> &indices) const {
   auto [idx, inbounds] = to1DIdxWithLayout(indices);
   auto [loaded, success] = m->load(bid, (Expr)offset + idx);
+
   return {loaded, (success & inbounds).simplify()};
 }
 

--- a/src/value.h
+++ b/src/value.h
@@ -286,6 +286,7 @@ public:
   MemRef subview(const std::vector<smt::Expr> &offsets,
       const std::vector<smt::Expr> &sizes,
       const std::vector<smt::Expr> &strides,
+      const llvm::SmallDenseSet<unsigned> &unusedDims,
       int rankDiff = 0);
 
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, const MemRef &);

--- a/src/value.h
+++ b/src/value.h
@@ -309,5 +309,6 @@ private:
 
   MemRef::Layout createSubViewLayout(const std::vector<smt::Expr> &indVars,
       const std::vector<smt::Expr> &offsets,
-      const std::vector<smt::Expr> &strides);
+      const std::vector<smt::Expr> &strides,
+      const std::vector<smt::Expr> &sizes);
 };

--- a/tests/litmus/memref-ops/subview_out_of_bounds.src.mlir
+++ b/tests/litmus/memref-ops/subview_out_of_bounds.src.mlir
@@ -1,0 +1,9 @@
+// EXPECT: "correct (source is always undefined)"
+
+func @fold_rank_reducing_subview_with_load(%arg0 : memref<?x?xf32>) -> f32 {
+  %c0 = constant 0: index
+  %c1 = constant 1: index
+  %ptr = memref.subview %arg0[%c0, %c0][1, 1][%c1, %c1] : memref<?x?xf32> to memref<1xf32, offset:?, strides: [?]>
+  %1 = memref.load %ptr[%c1] : memref<1xf32, offset:?, strides: [?]>
+  return %1 : f32
+}

--- a/tests/litmus/memref-ops/subview_out_of_bounds.tgt.mlir
+++ b/tests/litmus/memref-ops/subview_out_of_bounds.tgt.mlir
@@ -1,0 +1,7 @@
+
+func @fold_rank_reducing_subview_with_load(%arg0: memref<?x?xf32>) -> f32 {
+    %c1 = constant 1 : index
+    %c0 = constant 0 : index
+    %0 = memref.load %arg0[%c1, %c0] : memref<?x?xf32>
+    return %0 : f32
+}

--- a/tests/opts/fold-memref-subview-op/rank_reduction.src.mlir
+++ b/tests/opts/fold-memref-subview-op/rank_reduction.src.mlir
@@ -1,0 +1,15 @@
+// VERIFY
+
+func @fold_rank_reducing_subview_with_load
+    (%arg0 : memref<?x?x?x?x?x?xf32>, %arg1 : index, %arg2 : index,
+     %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index,
+     %arg7 : index, %arg8 : index, %arg9 : index, %arg10: index,
+     %arg11 : index, %arg12 : index, %arg13 : index, %arg14: index,
+     %arg15 : index, %arg16 : index) -> f32 {
+  %0 = memref.subview %arg0[%arg1, %arg2, %arg3, %arg4, %arg5, %arg6][4, 1, 1, 4, 1, 1][%arg7, %arg8, %arg9, %arg10, %arg11, %arg12] : memref<?x?x?x?x?x?xf32> to memref<4x1x4x1xf32, offset:?, strides: [?, ?, ?, ?]>
+  %1 = memref.load %0[%arg13, %arg14, %arg15, %arg16] : memref<4x1x4x1xf32, offset:?, strides: [?, ?, ?, ?]>
+  return %1 : f32
+}
+
+// How to reproduce tgt:
+// mlir-opt -fold-memref-subview-ops <src>

--- a/tests/opts/fold-memref-subview-op/rank_reduction.tgt.mlir
+++ b/tests/opts/fold-memref-subview-op/rank_reduction.tgt.mlir
@@ -1,0 +1,14 @@
+#map = affine_map<(d0)[s0, s1] -> (d0 * s0 + s1)>
+builtin.module  {
+  builtin.func @fold_rank_reducing_subview_with_load(%arg0: memref<?x?x?x?x?x?xf32>, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index, %arg8: index, %arg9: index, %arg10: index, %arg11: index, %arg12: index, %arg13: index, %arg14: index, %arg15: index, %arg16: index) -> f32 {
+    %c0 = constant 0 : index
+    %0 = affine.apply #map(%arg13)[%arg7, %arg1]
+    %1 = affine.apply #map(%arg14)[%arg8, %arg2]
+    %2 = affine.apply #map(%c0)[%arg9, %arg3]
+    %3 = affine.apply #map(%arg15)[%arg10, %arg4]
+    %4 = affine.apply #map(%arg16)[%arg11, %arg5]
+    %5 = affine.apply #map(%c0)[%arg12, %arg6]
+    %6 = memref.load %arg0[%0, %1, %2, %3, %4, %5] : memref<?x?x?x?x?x?xf32>
+    return %6 : f32
+  }
+}


### PR DESCRIPTION
From mlir-testsuites, we found three bugs in subview encoding.

## 1. MemRef subview's offsets should be considered in original memref strides

Before : <(d0, d1) -> (d0 * s0 + d1)>,
After: <(d0, d1) -> ((indVars[0] + offsets[0]) * strides[0] * s0 + (indVars[1] + offsets[1]) * strides[1])> ➡️ ❌
After: <(d0, d1) -> ((indVars[0] * strides[0] + offsets[0]) * s0 + indVars[1] * strides[1] + offsets[1])>.  ➡️ ⭕


Related information can be found in `MemRef/Trnasforms/FoldSubViewOps.cpp`.

```

//===----------------------------------------------------------------------===//
// Utility functions
//===----------------------------------------------------------------------===//

/// Given the 'indices' of an load/store operation where the memref is a result
/// of a subview op, returns the indices w.r.t to the source memref of the
/// subview op. For example
///
/// %0 = ... : memref<12x42xf32>
/// %1 = subview %0[%arg0, %arg1][][%stride1, %stride2] : memref<12x42xf32> to
///          memref<4x4xf32, offset=?, strides=[?, ?]>
/// %2 = load %1[%i1, %i2] : memref<4x4xf32, offset=?, strides=[?, ?]>
///
/// could be folded into
///
/// %2 = load %0[%arg0 + %i1 * %stride1][%arg1 + %i2 * %stride2] :
///          memref<12x42xf32>
```


## 2. MemRef subview reduction logic depends on `mlir::computeRankReductionMask`.

To clarify this logics in documents, I'll post it to LLVM Discourse :) 


## 3. Out of bounds check in subview MemRef does not work properly.

This was fixed by adding dimension-wise bounds check in `MemRef::subview` function.
Also added `subview_out_of_bounds.src.mlir` litmus test for it.
