### PR TITLE
Fix compile failure in latest MLIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ else()
     list(APPEND LIB_LIST
         MLIRViewLikeInterface MLIRInferTypeOpInterface MLIRControlFlowInterfaces MLIRSideEffectInterfaces
         MLIRIR MLIRDialect MLIRDialectUtils MLIRLinalg MLIRAffine MLIRMemRef
-        MLIRShape MLIRMath MLIRSparseTensor
+        MLIRShape MLIRMath MLIRSparseTensor MLIRSCF
         MLIRStandard MLIRMemRefUtils MLIRTensor MLIRParser MLIRSupport
         LLVMSupport LLVMDemangle pthread m curses)
     if (APPLE) # Apple LLD does not support 'group' flags


### PR DESCRIPTION
This PR fixes build failure when using latest MLIR by linking additional library.