### PR TITLE
Support commutative sum in linalg.generic

### DIFF
--- a/tests/litmus/linalg-ops/dot_commutative.src.mlir
+++ b/tests/litmus/linalg-ops/dot_commutative.src.mlir
@@ -1,0 +1,8 @@
+// VERIFY
+
+func @f(%a: tensor<100xf32>, %b: tensor<100xf32>) -> tensor<f32> {
+  %i = linalg.init_tensor []: tensor<f32>
+  %e = linalg.dot ins(%a, %b : tensor<100xf32>,tensor<100xf32>)
+    outs(%i: tensor<f32>) -> tensor<f32>
+  return %e : tensor<f32>
+}

--- a/tests/litmus/linalg-ops/dot_commutative.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_commutative.tgt.mlir
@@ -1,0 +1,16 @@
+func @f(%a: tensor<100xf32>, %b: tensor<100xf32>) -> tensor<f32> {
+  %outty = linalg.init_tensor [] : tensor<f32>
+  %result = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> ()>],
+      iterator_types = ["reduction"]}
+     ins(%a, %b : tensor<100xf32>, tensor<100xf32>)
+     outs(%outty : tensor<f32>) {
+     ^bb0(%ai : f32, %bi: f32, %res : f32):
+    %s = mulf %ai, %bi: f32
+    %res2 = addf %s, %res : f32
+    linalg.yield %res2 : f32
+  } -> tensor<f32>
+  return %result : tensor<f32>
+}


### PR DESCRIPTION
Support this type of `linalg.generic` loop.
Because addf is commutative ops, `%res2 = addf %s, %res : f32`, `%res2 = addf %res, %s : f32` is encoded into same SMT expression. 

```
  %result = linalg.generic {
      indexing_maps = [affine_map<(d0) -> (d0)>,
                       affine_map<(d0) -> (d0)>,
                       affine_map<(d0) -> ()>],
      iterator_types = ["reduction"]}
     ins(%a, %b : tensor<100xf32>, tensor<100xf32>)
     outs(%outty : tensor<f32>) {
     ^bb0(%ai : f32, %bi: f32, %res : f32):
    %s = mulf %ai, %bi: f32
    %res2 = addf %s, %res : f32
    linalg.yield %res2 : f32
  } -> tensor<f32>
```