### PR TITLE
Implement option to fold fadd and fmul identity

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -49,11 +49,13 @@ Expr fpConst(double f) {
     return itr->second;
 
   uint64_t absval;
-  if (f == 0.0)
+  if (f == 0.0) {
     absval = 0; // This is consistent with what mkZeroElemFromArr assumes
-  else {
-    assert(1 + fpconst_absrepr_num < (1ull << (uint64_t)FP_BITS));
-    absval = 1 + fpconst_absrepr_num++;
+  } else if (f == 1.0) {
+    absval = 1;
+  } else {
+    assert(2 + fpconst_absrepr_num < (1ull << (uint64_t)FP_BITS));
+    absval = 2 + fpconst_absrepr_num++;
   }
   Expr e = Expr::mkBV(absval, FP_BITS);
   fpconst_absrepr.emplace(f, e);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "memory.h"
 #include "smt.h"
 #include "vcgen.h"
+#include "value.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/PrettyStackTrace.h"
@@ -50,6 +51,16 @@ llvm::cl::opt<unsigned int> num_memblocks("num-memory-blocks",
 
 llvm::cl::opt<bool> arg_associative_sum("associative",
   llvm::cl::desc("Assume that floating point add is associative "
+                 "(experimental)"),
+  llvm::cl::init(false));
+
+llvm::cl::opt<bool> arg_add_identity("add-identity",
+  llvm::cl::desc("Assume that fpadd 0.0 is an identity operation "
+                 "(experimental)"),
+  llvm::cl::init(false));
+
+llvm::cl::opt<bool> arg_mul_identity("mul-identity",
+  llvm::cl::desc("Assume that fpmul 1.0 is an identity operation "
                  "(experimental)"),
   llvm::cl::init(false));
 
@@ -131,6 +142,13 @@ int main(int argc, char* argv[]) {
   if (arg_cross_check)
     smt::useCVC5();
 #endif
+
+  if (arg_add_identity) {
+    Float::useAddIdentity();
+  }
+  if (arg_mul_identity) {
+    Float::useMulIdentity();
+  }
 
   MLIRContext context;
   DialectRegistry registry;

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -644,15 +644,20 @@ Expr Expr::substitute(
 bool Expr::isIdentical(const Expr &e2, bool is_or) const {
   bool res = !is_or;
   bool temp;
+
   IF_Z3_ENABLED(
-    temp = z3 && (Z3_ast)*z3 == (Z3_ast)*e2.z3;
-    res = is_or ? (res || temp) : (res && temp));
+    if (z3) {
+      temp = (Z3_ast)*z3 == (Z3_ast)*e2.z3;
+      res = is_or ? (res || temp) : (res && temp);
+    })
+  
   IF_CVC5_ENABLED(
-    temp = cvc5 && cvc5->getId() == e2.cvc5->getId();
-    res = is_or ? (res || temp) : (res && temp));
+    if (cvc5) {
+      temp = cvc5->getId() == e2.cvc5->getId();
+      res = is_or ? (res || temp) : (res && temp);
+    })
   return res;
 }
-
 
 Expr Expr::mkFreshVar(const Sort &s, const std::string &prefix) {
   Expr e;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -7,6 +7,9 @@
 using namespace smt;
 using namespace std;
 
+bool Float::add_identity;
+bool Float::mul_identity;
+
 static string freshName(string prefix) {
   static int count = 0;
   return prefix + to_string(count ++);
@@ -122,13 +125,32 @@ Float Float::eval(Model m) const {
 }
 
 Float Float::add(const Float &b) const {
+  if (add_identity) {
+    // note: returning this or b leads to copying!
+    if (this->e.isIdentical(Float(0.0), false)) {
+      return b;
+    } else if (b.e.isIdentical(Float(0.0), false)) {
+      return *this;
+    }
+  }
+  // fold_add_identity is not set to true
+  // or both expressions are not 0.0
   return Float(aop::fpAdd(e, b.e));
 }
 
 Float Float::mul(const Float &b) const {
+  if (mul_identity) {
+    // note: returning this or b leads to copying!
+    if (this->e.isIdentical(Float(1.0), false)) {
+      return b;
+    } else if (b.e.isIdentical(Float(1.0), false)) {
+      return *this;
+    }
+  }
+  // fold_mul_identity is not set to true
+  // or both expressions are not 1.0
   return Float(aop::fpMul(e, b.e));
 }
-
 
 Integer::Integer(int64_t i, unsigned bw):
   e(Expr::mkBV(i, bw)) {}

--- a/src/value.h
+++ b/src/value.h
@@ -46,6 +46,8 @@ public:
 };
 
 class Float {
+  static bool add_identity;
+  static bool mul_identity;
   smt::Expr e;
 
 public:
@@ -66,6 +68,9 @@ public:
   std::pair<smt::Expr, std::vector<smt::Expr>> refines(
       const Float &other) const;
   Float eval(smt::Model m) const;
+
+  static void useAddIdentity() { add_identity = true; }
+  static void useMulIdentity() { mul_identity = true; }
 };
 
 class Integer {

--- a/tests/litmus/identity/add.src.mlir
+++ b/tests/litmus/identity/add.src.mlir
@@ -1,0 +1,9 @@
+// VERIFY
+
+func @f(%arg0: f32, %arg1: f32) -> f32 {
+  %i = constant 0.0 : f32
+  %v1 = addf %i, %arg0 : f32
+  %v2 = addf %i, %arg1 : f32
+  %c = addf %v1, %v2 : f32
+  return %c : f32
+}

--- a/tests/litmus/identity/add.tgt.mlir
+++ b/tests/litmus/identity/add.tgt.mlir
@@ -1,0 +1,4 @@
+func @f(%arg0: f32, %arg1: f32) -> f32 {
+  %c = addf %arg0, %arg1 : f32
+  return %c: f32
+}

--- a/tests/litmus/identity/add_const.src.mlir
+++ b/tests/litmus/identity/add_const.src.mlir
@@ -1,0 +1,10 @@
+// VERIFY
+
+func @f() -> f32 {
+  %i = constant 0.0 : f32
+  %v = constant 3.0 : f32
+  %v1 = addf %i, %v : f32
+  %v2 = addf %v, %i : f32
+  %c = addf %v1, %v2 : f32
+  return %c : f32
+}

--- a/tests/litmus/identity/add_const.tgt.mlir
+++ b/tests/litmus/identity/add_const.tgt.mlir
@@ -1,0 +1,8 @@
+// VERIFY
+
+func @f() -> f32 {
+  %v1 = constant 3.0 : f32
+  %v2 = constant 3.0 : f32
+  %c = addf %v1, %v2 : f32
+  return %c : f32
+}

--- a/tests/litmus/identity/mul.src.mlir
+++ b/tests/litmus/identity/mul.src.mlir
@@ -1,0 +1,9 @@
+// VERIFY
+
+func @f(%arg0: f32, %arg1: f32) -> f32 {
+  %i = constant 1.0 : f32
+  %v1 = mulf %i, %arg0 : f32
+  %v2 = mulf %i, %arg1 : f32
+  %c = addf %v1, %v2 : f32
+  return %c : f32
+}

--- a/tests/litmus/identity/mul.tgt.mlir
+++ b/tests/litmus/identity/mul.tgt.mlir
@@ -1,0 +1,4 @@
+func @f(%arg0: f32, %arg1: f32) -> f32 {
+  %c = addf %arg0, %arg1 : f32
+  return %c: f32
+}

--- a/tests/litmus/identity/mul_const.src.mlir
+++ b/tests/litmus/identity/mul_const.src.mlir
@@ -1,0 +1,10 @@
+// VERIFY
+
+func @f() -> f32 {
+  %i = constant 1.0 : f32
+  %v = constant 3.0 : f32
+  %v1 = mulf %i, %v : f32
+  %v2 = mulf %v, %i : f32
+  %c = addf %v1, %v2 : f32
+  return %c : f32
+}

--- a/tests/litmus/identity/mul_const.tgt.mlir
+++ b/tests/litmus/identity/mul_const.tgt.mlir
@@ -1,0 +1,8 @@
+// VERIFY
+
+func @f() -> f32 {
+  %v1 = constant 3.0 : f32
+  %v2 = constant 3.0 : f32
+  %c = addf %v1, %v2 : f32
+  return %c : f32
+}


### PR DESCRIPTION
This PR implements a set of new behaviors related to identity to Float::add() and Float::mul().

- When `--add-identity` flag is set, Float(a).add(Float(0.0)) directly returns Float(a) and Float(0.0).add(Float(a)) directly returns Float(a).
- When `--mul-identity` flag is set, Float(a).mul(Float(1.0)) directly returns Float(a) and Float(1.0).mul(Float(a)) directly returns Float(a).
- Litmus tests are added to show the changed behavior