### PR TITLE
Implement multiplication identity behavior for `aop::fpMul`

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -49,11 +49,13 @@ Expr fpConst(double f) {
     return itr->second;
 
   uint64_t absval;
-  if (f == 0.0)
+  if (f == 0.0) {
     absval = 0; // This is consistent with what mkZeroElemFromArr assumes
-  else {
-    assert(1 + fpconst_absrepr_num < (1ull << (uint64_t)FP_BITS));
-    absval = 1 + fpconst_absrepr_num++;
+  } else if (f == 1.0) {
+    absval = 1;
+  } else {
+    assert(2 + fpconst_absrepr_num < (1ull << (uint64_t)FP_BITS));
+    absval = 2 + fpconst_absrepr_num++;
   }
   Expr e = Expr::mkBV(absval, FP_BITS);
   fpconst_absrepr.emplace(f, e);

--- a/tests/litmus/identity/mul.src.mlir
+++ b/tests/litmus/identity/mul.src.mlir
@@ -1,0 +1,9 @@
+// VERIFY
+
+func @f(%arg0: f32, %arg1: f32) -> f32 {
+  %i = constant 1.0 : f32
+  %v1 = mulf %i, %arg0 : f32
+  %v2 = mulf %i, %arg1 : f32
+  %c = addf %v1, %v2 : f32
+  return %c : f32
+}

--- a/tests/litmus/identity/mul.tgt.mlir
+++ b/tests/litmus/identity/mul.tgt.mlir
@@ -1,0 +1,4 @@
+func @f(%arg0: f32, %arg1: f32) -> f32 {
+  %c = addf %arg0, %arg1 : f32
+  return %c: f32
+}

--- a/tests/litmus/identity/mul_const.src.mlir
+++ b/tests/litmus/identity/mul_const.src.mlir
@@ -1,0 +1,10 @@
+// VERIFY
+
+func @f() -> f32 {
+  %i = constant 1.0 : f32
+  %v = constant 3.0 : f32
+  %v1 = mulf %i, %v : f32
+  %v2 = mulf %v, %i : f32
+  %c = mulf %v1, %v2 : f32
+  return %c : f32
+}

--- a/tests/litmus/identity/mul_const.tgt.mlir
+++ b/tests/litmus/identity/mul_const.tgt.mlir
@@ -1,0 +1,6 @@
+func @f() -> f32 {
+  %v1 = constant 3.0 : f32
+  %v2 = constant 3.0 : f32
+  %c = mulf %v1, %v2 : f32
+  return %c : f32
+}


### PR DESCRIPTION
This PR updates `aop::fpMul` in order to implement fmul identity behavior

- `aop::fpMul` operation now returns rhs/lhs if the value of lhs/rhs is identical to Float(1.0)
- Litmus tests are added to show the changed behavior
