### PR TITLE
Encode sum_fn's associativity using uninterpreted hash function

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -84,7 +84,7 @@ Expr mkZeroElemFromArr(const Expr &arr) {
   return Expr::mkBV(0, bvsz);
 }
 
-optional<FnDecl> sumfn, assoc_sumfn, dotfn, fpaddfn, fpmulfn, hashfn;
+optional<FnDecl> sumfn, assoc_sumfn, dotfn, fpaddfn, fpmulfn;
 
 Expr fpAdd(const Expr &f1, const Expr &f2) {
   usedOps.add = true;
@@ -179,7 +179,7 @@ Expr getAssociativePrecondition() {
         bVal = bVal + hashfn.apply(b.select(Index(i)));
 
       // precond: sumfn(A) != sumfn(B) -> hashfn(A) != hashfn(B)
-      // This means if two summations are different, we can find concrete hash function that satisfies different hash value.
+      // This means if two summations are different, we can find concrete hash function that hashes into different value.
       auto associativity = (!(asum == bsum)).implies(!(aVal == bVal));
       precond = precond & associativity;
     }

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -6,6 +6,11 @@
 using namespace smt;
 using namespace std;
 
+static string freshName(string prefix) {
+  static int count = 0;
+  return prefix + to_string(count ++);
+}
+
 namespace {
 // Abstract representation of fp constants.
 map<double, Expr> fpconst_absrepr;
@@ -22,6 +27,7 @@ namespace aop {
 static AbsLevelDot alDot;
 static bool isAddAssociative;
 static UsedAbstractOps usedOps;
+static vector<tuple<Expr, Expr, Expr>> staticArrays;
 
 UsedAbstractOps getUsedAbstractOps() { return usedOps; }
 
@@ -32,6 +38,8 @@ void setAbstractionLevel(AbsLevelDot ad, bool addAssoc) {
 
   fpconst_absrepr.clear();
   fpconst_absrepr_num = 0;
+
+  staticArrays.clear();
 }
 
 bool getAddAssociativity() { return isAddAssociative; }
@@ -115,25 +123,12 @@ Expr sum(const Expr &a, const Expr &n) {
   auto i = Index::var("idx", VarType::BOUND);
   Expr ai = a.select(i);
   Expr zero = mkZeroElemFromArr(a);
-  return (*sumfn)(Expr::mkLambda(i, Expr::mkIte(((Expr)i).ult(n), ai, zero)));
-}
+  Expr result = (*sumfn)(Expr::mkLambda(i, Expr::mkIte(((Expr)i).ult(n), ai, zero)));
 
-Expr associativeSum(const Expr &a, const Expr &n) {
-  uint64_t length;
-  if (!n.isUInt(length))
-    assert("Only an array of constant length is supported.");
+  if (n.isNumeral())
+    staticArrays.push_back({a, n, result});
 
-  if (!hashfn)
-    hashfn.emplace(Float::sort(), Index::sort(), "hash");
-
-  auto hash = hashfn->apply(a.select(Index(0)));
-  for (unsigned i = 1; i < length; i ++)
-    hash = hash + hashfn->apply(a.select(Index(i)));
-  hash = hash.simplify();
-
-  if (!assoc_sumfn)
-    assoc_sumfn.emplace(hash.sort(), Float::sort(), "smt_assoc_sum");
-  return (*assoc_sumfn)(hash);
+  return result;
 }
 
 Expr dot(const Expr &a, const Expr &b, const Expr &n) {
@@ -161,12 +156,36 @@ Expr dot(const Expr &a, const Expr &b, const Expr &n) {
     Expr ai = a.select(i), bi = b.select(i);
     Expr arr = Expr::mkLambda(i, fpMul(ai, bi));
 
-    if (isAddAssociative)
-      return associativeSum(arr, n);
-    else
-      return sum(arr, n);
+    return sum(arr, n);
   }
   llvm_unreachable("Unknown abstraction level for dot");
+}
+
+Expr getAssociativePrecondition() {
+  Expr precond = Expr::mkBool(true);
+  for (unsigned i = 0; i < staticArrays.size(); i ++) {
+    for (unsigned j = i + 1; j < staticArrays.size(); j ++) {
+      auto [a, an, asum] = staticArrays[i];
+      auto [b, bn, bsum] = staticArrays[j];
+      uint64_t alen, blen;
+      if (!an.isUInt(alen) || !bn.isUInt(blen) || alen != blen) continue;
+      FnDecl hashfn(Float::sort(), Index::sort(), freshName("hash"));
+
+      auto aVal = hashfn.apply(a.select(Index(0)));
+      for (unsigned i = 1; i < alen; i ++)
+        aVal = aVal + hashfn.apply(a.select(Index(i)));
+      auto bVal = hashfn.apply(b.select(Index(0)));
+      for (unsigned i = 1; i < blen; i ++)
+        bVal = bVal + hashfn.apply(b.select(Index(i)));
+
+      // precond: sumfn(A) != sumfn(B) -> hashfn(A) != hashfn(B)
+      // This means if two summations are different, we can find concrete hash function that satisfies different hash value.
+      auto associativity = (!(asum == bsum)).implies(!(aVal == bVal));
+      precond = precond & associativity;
+    }
+  }
+  precond = precond.simplify();
+  return precond;
 }
 
 }

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -32,7 +32,7 @@ smt::Expr mkZeroElemFromArr(const smt::Expr &arr);
 smt::Expr fpAdd(const smt::Expr &f1, const smt::Expr &f2);
 smt::Expr fpMul(const smt::Expr &f1, const smt::Expr &f2);
 smt::Expr sum(const smt::Expr &arr, const smt::Expr &n);
-smt::Expr associativeSum(const smt::Expr &arr, const smt::Expr &n);
 smt::Expr dot(const smt::Expr &arr1, const smt::Expr &arr2, const smt::Expr &n);
+smt::Expr getAssociativePrecondition();
 
 };

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -117,6 +117,10 @@ vector<Expr> makeCube(Expr &&e, unsigned rank) {
 Expr to1DIdx(
     const vector<Expr> &idxs,
     const vector<Expr> &dims) {
+  // to handle `tensor.extract %t[] : tensor<f32>` case.
+  if (idxs.size() == 0)
+    return Index::zero();
+
   assert(idxs.size() == dims.size());
   auto idx = idxs[0];
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -353,10 +353,7 @@ Expr Tensor::dot(const Tensor &t2) const {
 }
 
 Expr Tensor::sum() const {
-  if (aop::getAddAssociativity())
-    return aop::associativeSum(arr, get1DSize());
-  else
-    return aop::sum(arr, get1DSize());
+  return aop::sum(arr, get1DSize());
 }
 
 pair<Expr, vector<Expr>> Tensor::refines(const Tensor &other) const {

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -337,6 +337,9 @@ static tuple<State, State, Expr> encodeFinalStates(
   State st_tgt = encodeFinalState(
       vinput, move(initMemTgt), printOps, false, args, preconds);
 
+  if (aop::getAddAssociativity())
+    preconds.push_back(aop::getAssociativePrecondition());
+
   Expr precond =
       exprAnd(preconds) & st_src.precondition() & st_tgt.precondition();
   precond = precond.simplify();

--- a/tests/litmus/linalg-ops/dot_associativity2.src.mlir
+++ b/tests/litmus/linalg-ops/dot_associativity2.src.mlir
@@ -1,0 +1,26 @@
+// VERIFY
+// ARGS: --associative
+
+// Even if fp addition is not associative in the precise definition of floating
+// point arithmetics, people might want to allow rewritings based on it for
+// performance.
+// To conditionally allow this, we add --associative option to mlir-tv.
+// Given the flag, mlir-tv checks the equality between two input arguments of
+// dot based on multiset theroy (to be precise, the argument of 'sum').
+
+func @f() -> f32 {
+  %c0 = constant 0 : index
+  %i = linalg.init_tensor []: tensor<f32>
+  %a1 = constant sparse<[[0], [1]], [-12.0, 3.0]> : tensor<2xf32>
+  %a2 = constant sparse<[[0], [1], [2]], [2.0, 5.0, 4.0]> : tensor<3xf32>
+  %b1 = constant sparse<[[0], [1]], [1.0, 8.0]> : tensor<2xf32>
+  %b2 = constant sparse<[[0], [1], [2]], [5.0, 6.0, 0.0]> : tensor<3xf32>
+  %o1 = linalg.dot ins(%a1, %b1 : tensor<2xf32>,tensor<2xf32>)
+    outs(%i: tensor<f32>) -> tensor<f32>
+  %o2 = linalg.dot ins(%a2, %b2 : tensor<3xf32>,tensor<3xf32>)
+    outs(%i: tensor<f32>) -> tensor<f32>
+  %res1 = tensor.extract %o1[] : tensor<f32>
+  %res2 = tensor.extract %o2[] : tensor<f32>
+  %res = addf %res1, %res2 : f32
+  return %res : f32
+}

--- a/tests/litmus/linalg-ops/dot_associativity2.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_associativity2.tgt.mlir
@@ -1,0 +1,16 @@
+func @f() -> f32 {
+  %c0 = constant 0 : index
+  %i = linalg.init_tensor []: tensor<f32>
+  %a1 = constant sparse<[[1], [0]], [-12.0, 3.0]> : tensor<2xf32>
+  %a2 = constant sparse<[[2], [1], [0]], [2.0, 5.0, 4.0]> : tensor<3xf32>
+  %b1 = constant sparse<[[1], [0]], [1.0, 8.0]> : tensor<2xf32>
+  %b2 = constant sparse<[[2], [1], [1]], [5.0, 6.0, 0.0]> : tensor<3xf32>
+  %o1 = linalg.dot ins(%a1, %b1 : tensor<2xf32>,tensor<2xf32>)
+    outs(%i: tensor<f32>) -> tensor<f32>
+  %o2 = linalg.dot ins(%a2, %b2 : tensor<3xf32>,tensor<3xf32>)
+    outs(%i: tensor<f32>) -> tensor<f32>
+  %res1 = tensor.extract %o1[] : tensor<f32>
+  %res2 = tensor.extract %o2[] : tensor<f32>
+  %res = addf %res1, %res2 : f32
+  return %res : f32
+}


### PR DESCRIPTION
Encode `sum_fn`'s associativity by using uninterpreted function.
`sum_fn`'s equality is given by preconditions which are built when encoding src, tgt smt arrays.

We only add equality conditions when two smt arrays have same length to reduce the number of candidate pairs.
For each candidate pairs, we use distinct `hashfn`s to check whether they can be hashed into different values.
