### PR TITLE
Implement tensor.insert operation

### DIFF
--- a/src/value.h
+++ b/src/value.h
@@ -150,6 +150,10 @@ public:
 
   size_t getRank() const { return dims.size(); }
 
+  // Return <a new tensor T2, inbounds>
+  // T2[idx] = idx == indices ? value : this[idx]
+  std::pair<Tensor, smt::Expr> insert(const smt::Expr &value, const std::vector<smt::Expr> &indices) const;
+
   // Return a new tensor T2 s.t.
   //   T2[newidxvars] = this[srcidxs]
   // For example, if newidxvars = [x, y, z] and srcidxs = [x, y + z],

--- a/tests/litmus/tensor-ops/insert.src.mlir
+++ b/tests/litmus/tensor-ops/insert.src.mlir
@@ -1,0 +1,9 @@
+// VERIFY
+
+func @from_elem(%arg: tensor<1xf32>) -> tensor<1xf32>
+{
+  %i = constant 0 : index
+  %c1 = constant 3.0 : f32
+  %ret = tensor.insert %c1 into %arg[%i] : tensor<1xf32>
+  return %ret : tensor<1xf32>
+}

--- a/tests/litmus/tensor-ops/insert.tgt.mlir
+++ b/tests/litmus/tensor-ops/insert.tgt.mlir
@@ -1,0 +1,7 @@
+
+func @from_elem(%arg: tensor<1xf32>) -> tensor<1xf32>
+{
+  %c1 = constant 3.0 : f32
+  %v = tensor.from_elements %c1 : tensor<1xf32>
+  return %v : tensor<1xf32>
+}

--- a/tests/litmus/tensor-ops/insert_bad.src.mlir
+++ b/tests/litmus/tensor-ops/insert_bad.src.mlir
@@ -1,0 +1,9 @@
+// VERIFY-INCORRECT
+
+func @from_elem(%arg: tensor<2xf32>) -> tensor<2xf32>
+{
+  %i = constant 0 : index
+  %c1 = constant 3.0 : f32
+  %ret = tensor.insert %c1 into %arg[%i] : tensor<2xf32>
+  return %ret : tensor<2xf32>
+}

--- a/tests/litmus/tensor-ops/insert_bad.tgt.mlir
+++ b/tests/litmus/tensor-ops/insert_bad.tgt.mlir
@@ -1,0 +1,7 @@
+
+func @from_elem(%arg: tensor<2xf32>) -> tensor<2xf32>
+{
+  %c1 = constant 3.0 : f32
+  %v = tensor.from_elements %c1, %c1 : tensor<2xf32>
+  return %v : tensor<2xf32>
+}


### PR DESCRIPTION
Implemented `tensor.insert` operation which allows to create new tensor based on original value.
Because tensor is immutable type, this operation always create new tensor value.