### PR TITLE
Fix numeral related bugs in cvc5

### DIFF
--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -276,6 +276,9 @@ bool Expr::isUInt(uint64_t &v) const {
 #ifdef SOLVER_CVC5
   if (this->cvc5 && this->cvc5->isUInt64Value())
     writeOrCheck(res, this->cvc5->getUInt64Value());
+  else if (this->cvc5 && this->cvc5->isBitVectorValue())
+    writeOrCheck(res, std::stoull(this->cvc5->getBitVectorValue(10)));
+
 #endif // SOLVER_CVC5
 
   if (res)
@@ -296,6 +299,9 @@ bool Expr::isInt(int64_t &v) const {
 #ifdef SOLVER_CVC5
   if (this->cvc5 && this->cvc5->isInt64Value())
     writeOrCheck(res, this->cvc5->getInt64Value());
+  else if (this->cvc5 && this->cvc5->isBitVectorValue())
+    writeOrCheck(res, std::stoll(this->cvc5->getBitVectorValue(10)));
+
 #endif // SOLVER_CVC5
 
   if (res)
@@ -306,7 +312,7 @@ bool Expr::isInt(int64_t &v) const {
 bool Expr::isNumeral() const {
   bool res = false;
   IF_Z3_ENABLED(res |= z3 && z3->is_numeral());
-  IF_CVC5_ENABLED(res |= cvc5 && cvc5->isIntegerValue());
+  IF_CVC5_ENABLED(res |= cvc5 && (cvc5->isIntegerValue() || cvc5->isBitVectorValue()));
   return res;
 }
 

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -38,6 +38,25 @@ void writeOrCheck(optional<T> &org, T &&t) {
   else
     org.emplace(move(t));
 }
+
+uint64_t to_uint64(string &&str) {
+  istringstream ss(str);
+  uint64_t tmp;
+  ss >> tmp;
+  return tmp;
+}
+
+int64_t to_int64(string &&str) {
+  uint64_t i = to_uint64(move(str));
+  // Don't do (int64_t)i; it may raise UB
+  union {
+    uint64_t x;
+    int64_t y;
+  } u;
+  u.x = i;
+  return u.y;
+}
+
 }
 
 namespace smt {
@@ -277,7 +296,7 @@ bool Expr::isUInt(uint64_t &v) const {
   if (this->cvc5 && this->cvc5->isUInt64Value())
     writeOrCheck(res, this->cvc5->getUInt64Value());
   else if (this->cvc5 && this->cvc5->isBitVectorValue())
-    writeOrCheck(res, std::stoull(this->cvc5->getBitVectorValue(10)));
+    writeOrCheck(res, to_uint64(this->cvc5->getBitVectorValue(10)));
 
 #endif // SOLVER_CVC5
 
@@ -300,7 +319,7 @@ bool Expr::isInt(int64_t &v) const {
   if (this->cvc5 && this->cvc5->isInt64Value())
     writeOrCheck(res, this->cvc5->getInt64Value());
   else if (this->cvc5 && this->cvc5->isBitVectorValue())
-    writeOrCheck(res, std::stoll(this->cvc5->getBitVectorValue(10)));
+    writeOrCheck(res, to_int64(this->cvc5->getBitVectorValue(10)));
 
 #endif // SOLVER_CVC5
 


### PR DESCRIPTION
In cvc5, the solver interprets bit-vector and numeral types are different.
This causes problems when checking whether SMT array is constant sized. 
So in this pr, I fixed it to treats bit vector as numeral as is in Z3 SMT solver.
