### PR TITLE
Use `float`(f32) instead of `double`(f64) in `Float`

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -13,7 +13,7 @@ static string freshName(string prefix) {
 
 namespace {
 // Abstract representation of fp constants.
-map<double, Expr> fpconst_absrepr;
+map<float, Expr> fpconst_absrepr;
 unsigned fpconst_absrepr_num;
 
 // TODO: this must be properly set
@@ -50,7 +50,7 @@ Sort fpSort() {
   return Sort::bvSort(FP_BITS);
 }
 
-Expr fpConst(double f) {
+Expr fpConst(float f) {
   // We don't explicitly encode f
   auto itr = fpconst_absrepr.find(f);
   if (itr != fpconst_absrepr.end())
@@ -70,8 +70,8 @@ Expr fpConst(double f) {
   return e;
 }
 
-vector<double> fpPossibleConsts(const Expr &e) {
-  vector<double> vec;
+vector<float> fpPossibleConsts(const Expr &e) {
+  vector<float> vec;
   for (auto &[k, v]: fpconst_absrepr) {
     if (v.isIdentical(e))
       vec.push_back(k);

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -24,9 +24,9 @@ AbsLevelDot getAbstractionLevelOfDot();
 bool getAddAssociativity();
 
 smt::Sort fpSort();
-smt::Expr fpConst(double f);
+smt::Expr fpConst(float f);
 // Return the set of possible FP constants for 'e'.
-std::vector<double> fpPossibleConsts(const smt::Expr &e);
+std::vector<float> fpPossibleConsts(const smt::Expr &e);
 
 smt::Expr mkZeroElemFromArr(const smt::Expr &arr);
 smt::Expr fpAdd(const smt::Expr &f1, const smt::Expr &f2);

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -49,7 +49,7 @@ static optional<Expr> getZero(mlir::Type eltType) {
 static optional<ValueTy> attrToValueTy(mlir::Attribute a) {
   auto ty = a.getType();
   if (ty.isa<mlir::FloatType>()) {
-    return Float(a.dyn_cast<mlir::FloatAttr>().getValueAsDouble());
+    return Float(a.dyn_cast<mlir::FloatAttr>().getValue().convertToFloat());
   } else if (ty.isa<mlir::IntegerType>()) {
     if (64 < ty.getIntOrFloatBitWidth())
       // size is too large

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -81,9 +81,9 @@ Index Index::eval(Model m) const {
   return Index(m.eval(e, true).simplify());
 }
 
-Float::Float(double f): e(aop::fpConst(f)) {}
+Float::Float(float f): e(aop::fpConst(f)) {}
 
-Float::Float(const llvm::APFloat &f): Float(f.convertToDouble()) {}
+Float::Float(const llvm::APFloat &f): Float(f.convertToFloat()) {}
 
 Sort Float::sort() {
   return aop::fpSort();

--- a/src/value.h
+++ b/src/value.h
@@ -51,7 +51,7 @@ class Float {
 public:
   Float(const smt::Expr &e): e(e) {}
   Float(const llvm::APFloat &apf);
-  Float(double f);
+  Float(float f);
 
   operator smt::Expr() const { return e; }
 


### PR DESCRIPTION
This PR changes `double` to `float` where their uses are related to `Float` class.

* `Float`s are now initialized using `float`
* `Float`s are now managed by maps that use `float` as their key