### PR TITLE
Revert multiset encoding for benchmark

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -213,11 +213,11 @@ Expr getAssociativePrecondition() {
         FnDecl hashfn(Float::sort(), Index::sort(), freshName("hash"));
 
         auto aVal = hashfn.apply(a.select(Index(0)));
-        for (unsigned i = 1; i < alen; i ++)
-          aVal = aVal + hashfn.apply(a.select(Index(i)));
+        for (unsigned k = 1; k < alen; k ++)
+          aVal = aVal + hashfn.apply(a.select(Index(k)));
         auto bVal = hashfn.apply(b.select(Index(0)));
-        for (unsigned i = 1; i < blen; i ++)
-          bVal = bVal + hashfn.apply(b.select(Index(i)));
+        for (unsigned k = 1; k < blen; k ++)
+          bVal = bVal + hashfn.apply(b.select(Index(k)));
 
         // precond: sumfn(A) != sumfn(B) -> hashfn(A) != hashfn(B)
         // This means if two summations are different, we can find concrete hash function that hashes into different value.

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -26,14 +26,16 @@ namespace aop {
 
 static AbsLevelDot alDot;
 static bool isAddAssociative;
+static bool useMultiset;
 static UsedAbstractOps usedOps;
 static vector<tuple<Expr, Expr, Expr>> staticArrays;
 
 UsedAbstractOps getUsedAbstractOps() { return usedOps; }
 
-void setAbstractionLevel(AbsLevelDot ad, bool addAssoc) {
+void setAbstractionLevel(AbsLevelDot ad, bool addAssoc, bool multiset) {
   alDot = ad;
   isAddAssociative = addAssoc;
+  useMultiset = multiset;
   memset(&usedOps, 0, sizeof(usedOps));
 
   fpconst_absrepr.clear();
@@ -114,6 +116,26 @@ Expr fpMul(const Expr &f1, const Expr &f2) {
   );
 }
 
+Expr associativeSum(const Expr &a, const Expr &n) {
+  uint64_t length;
+  if (!n.isUInt(length))
+    assert("Only an array of constant length is supported.");
+  auto bag = Expr::mkEmptyBag(Float::sort());
+  for (unsigned i = 0; i < length; i ++) {
+    bag = bag.insert(a.select(Index(i)));
+    bag = bag.simplify();
+  }
+
+  if (!assoc_sumfn)
+    assoc_sumfn.emplace(bag.sort(), Float::sort(), "smt_assoc_sum");
+  Expr result = (*assoc_sumfn)(bag);
+
+  if (n.isNumeral())
+    staticArrays.push_back({bag, n, result});
+
+  return result;
+}
+
 Expr sum(const Expr &a, const Expr &n) {
   usedOps.sum = true;
   // TODO: check that a.Sort is Index::Sort() -> Float::Sort()
@@ -156,36 +178,56 @@ Expr dot(const Expr &a, const Expr &b, const Expr &n) {
     Expr ai = a.select(i), bi = b.select(i);
     Expr arr = Expr::mkLambda(i, fpMul(ai, bi));
 
-    return sum(arr, n);
+    if (isAddAssociative && useMultiset)
+      return associativeSum(arr, n);
+    else
+      return sum(arr, n);
   }
   llvm_unreachable("Unknown abstraction level for dot");
 }
 
 Expr getAssociativePrecondition() {
-  Expr precond = Expr::mkBool(true);
-  for (unsigned i = 0; i < staticArrays.size(); i ++) {
-    for (unsigned j = i + 1; j < staticArrays.size(); j ++) {
-      auto [a, an, asum] = staticArrays[i];
-      auto [b, bn, bsum] = staticArrays[j];
-      uint64_t alen, blen;
-      if (!an.isUInt(alen) || !bn.isUInt(blen) || alen != blen) continue;
-      FnDecl hashfn(Float::sort(), Index::sort(), freshName("hash"));
-
-      auto aVal = hashfn.apply(a.select(Index(0)));
-      for (unsigned i = 1; i < alen; i ++)
-        aVal = aVal + hashfn.apply(a.select(Index(i)));
-      auto bVal = hashfn.apply(b.select(Index(0)));
-      for (unsigned i = 1; i < blen; i ++)
-        bVal = bVal + hashfn.apply(b.select(Index(i)));
-
-      // precond: sumfn(A) != sumfn(B) -> hashfn(A) != hashfn(B)
-      // This means if two summations are different, we can find concrete hash function that hashes into different value.
-      auto associativity = (!(asum == bsum)).implies(!(aVal == bVal));
-      precond = precond & associativity;
+  if (useMultiset) {
+    // precondition between `bag equality <-> assoc_sumfn`
+    Expr precond = Expr::mkBool(true);
+    for (unsigned i = 0; i < staticArrays.size(); i ++) {
+      for (unsigned j = i + 1; j < staticArrays.size(); j ++) {
+        auto [abag, an, asum] = staticArrays[i];
+        auto [bbag, bn, bsum] = staticArrays[j];
+        uint64_t alen, blen;
+        if (!an.isUInt(alen) || !bn.isUInt(blen) || alen != blen) continue;
+        precond = precond & (abag == bbag).implies(asum == bsum);
+      }
     }
+    precond = precond.simplify();
+    return precond;
+  } else {
+    // precondition between `hashfn <-> sumfn`
+    Expr precond = Expr::mkBool(true);
+    for (unsigned i = 0; i < staticArrays.size(); i ++) {
+      for (unsigned j = i + 1; j < staticArrays.size(); j ++) {
+        auto [a, an, asum] = staticArrays[i];
+        auto [b, bn, bsum] = staticArrays[j];
+        uint64_t alen, blen;
+        if (!an.isUInt(alen) || !bn.isUInt(blen) || alen != blen) continue;
+        FnDecl hashfn(Float::sort(), Index::sort(), freshName("hash"));
+
+        auto aVal = hashfn.apply(a.select(Index(0)));
+        for (unsigned i = 1; i < alen; i ++)
+          aVal = aVal + hashfn.apply(a.select(Index(i)));
+        auto bVal = hashfn.apply(b.select(Index(0)));
+        for (unsigned i = 1; i < blen; i ++)
+          bVal = bVal + hashfn.apply(b.select(Index(i)));
+
+        // precond: sumfn(A) != sumfn(B) -> hashfn(A) != hashfn(B)
+        // This means if two summations are different, we can find concrete hash function that hashes into different value.
+        auto associativity = (!(asum == bsum)).implies(!(aVal == bVal));
+        precond = precond & associativity;
+      }
+    }
+    precond = precond.simplify();
+    return precond;
   }
-  precond = precond.simplify();
-  return precond;
 }
 
 }

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -19,7 +19,7 @@ enum class AbsLevelDot {
 };
 
 // This resets the used abstract ops record.
-void setAbstractionLevel(AbsLevelDot, bool isAddAssociative);
+void setAbstractionLevel(AbsLevelDot, bool isAddAssociative, bool useMultiset);
 AbsLevelDot getAbstractionLevelOfDot();
 bool getAddAssociativity();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,10 @@ llvm::cl::opt<MemEncoding> memory_encoding("memory-encoding",
     clEnumValN(MemEncoding::MULTIPLE_ARRAY, "MULTIPLE", "Using multiple arrays memory encoding")
   ));
 
+llvm::cl::opt<bool> arg_multiset("multiset",
+  llvm::cl::desc("Use multiset when encoding floating point add"),  llvm::cl::Hidden,
+  llvm::cl::init(false));
+
 // These functions are excerpted from ToolUtilities.cpp in mlir
 static unsigned validateBuffer(unique_ptr<llvm::MemoryBuffer> srcBuffer,
     unique_ptr<llvm::MemoryBuffer> tgtBuffer,
@@ -81,7 +85,8 @@ static unsigned validateBuffer(unique_ptr<llvm::MemoryBuffer> srcBuffer,
     arg_dump_smt_to.getValue(),
     num_memblocks.getValue(),
     memory_encoding.getValue(),
-    arg_associative_sum.getValue()
+    arg_associative_sum.getValue(),
+    arg_multiset.getValue()
     ).code;
 }
 

--- a/src/vcgen.h
+++ b/src/vcgen.h
@@ -45,4 +45,5 @@ Results validate(mlir::OwningModuleRef &src, mlir::OwningModuleRef &tgt,
     const std::string &dump_smt_to,
     unsigned int numBlocks,
     MemEncoding encoding,
-    bool associativeAdd);
+    bool associativeAdd,
+    bool useMultiset);


### PR DESCRIPTION
Revert previous multi sets encoding in https://github.com/aqjune/mlir-tv/pull/125.
But in previous PR, bag equality with uninterpreted function is not well supported in CVC5..
To resolve this issue, I added bag equality precondition in `getAssociativePrecondition()` and this works well!

cf. Currently CVC5 support ackermannization in very limited condition. So I just encoded it in precondition :(