### PR TITLE
Revert multiset encoding for benchmark 

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -331,11 +331,11 @@ Expr getAssociativePrecondition() {
         FnDecl hashfn(Float::sort(), Index::sort(), freshName("hash"));
 
         auto aVal = hashfn.apply(a.select(Index(0)));
-        for (unsigned i = 1; i < alen; i ++)
-          aVal = aVal + hashfn.apply(a.select(Index(i)));
+        for (unsigned k = 1; k < alen; k ++)
+          aVal = aVal + hashfn.apply(a.select(Index(k)));
         auto bVal = hashfn.apply(b.select(Index(0)));
-        for (unsigned i = 1; i < blen; i ++)
-          bVal = bVal + hashfn.apply(b.select(Index(i)));
+        for (unsigned k = 1; k < blen; k ++)
+          bVal = bVal + hashfn.apply(b.select(Index(k)));
 
         // precond: sumfn(A) != sumfn(B) -> hashfn(A) != hashfn(B)
         // This means if two summations are different, we can find concrete hash function that hashes into different value.

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -234,7 +234,7 @@ Expr fpMul(const Expr &f1, const Expr &f2) {
   );
 }
 
-Expr associativeSum(const Expr &a, const Expr &n) {
+Expr multisetSum(const Expr &a, const Expr &n) {
   uint64_t length;
   if (!n.isUInt(length))
     assert("Only an array of constant length is supported.");
@@ -257,6 +257,9 @@ Expr associativeSum(const Expr &a, const Expr &n) {
 Expr sum(const Expr &a, const Expr &n) {
   usedOps.sum = true;
   // TODO: check that a.Sort is Index::Sort() -> Float::Sort()
+
+  if (isAddAssociative && useMultiset)
+    return multisetSum(a, n);
 
   if (!sumfn)
     sumfn.emplace(a.sort(), Float::sort(), "smt_sum");
@@ -296,10 +299,7 @@ Expr dot(const Expr &a, const Expr &b, const Expr &n) {
     Expr ai = a.select(i), bi = b.select(i);
     Expr arr = Expr::mkLambda(i, fpMul(ai, bi));
 
-    if (isAddAssociative && useMultiset)
-      return associativeSum(arr, n);
-    else
-      return sum(arr, n);
+    return sum(arr, n);
   }
   llvm_unreachable("Unknown abstraction level for dot");
 }

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -20,6 +20,7 @@ enum class AbsLevelDot {
 
 // This resets the used abstract ops record.
 void setAbstraction(AbsLevelDot, bool isAddAssociative, unsigned fpBits);
+void setEncodingOptions(bool use_multiset);
 AbsLevelDot getAbstractionLevelOfDot();
 bool getAddAssociativity();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,8 @@ llvm::cl::opt<MemEncoding> memory_encoding("memory-encoding",
   ));
 
 llvm::cl::opt<bool> arg_multiset("multiset",
-  llvm::cl::desc("Use multiset when encoding floating point add"),  llvm::cl::Hidden,
+  llvm::cl::desc("Use multiset when encoding the associativity of the floating"
+                 " point addition"),  llvm::cl::Hidden,
   llvm::cl::init(false));
 
 // These functions are excerpted from ToolUtilities.cpp in mlir

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,10 @@ llvm::cl::opt<MemEncoding> memory_encoding("memory-encoding",
     clEnumValN(MemEncoding::MULTIPLE_ARRAY, "MULTIPLE", "Using multiple arrays memory encoding")
   ));
 
+llvm::cl::opt<bool> arg_multiset("multiset",
+  llvm::cl::desc("Use multiset when encoding floating point add"),  llvm::cl::Hidden,
+  llvm::cl::init(false));
+
 // These functions are excerpted from ToolUtilities.cpp in mlir
 static unsigned validateBuffer(unique_ptr<llvm::MemoryBuffer> srcBuffer,
     unique_ptr<llvm::MemoryBuffer> tgtBuffer,
@@ -92,11 +96,12 @@ static unsigned validateBuffer(unique_ptr<llvm::MemoryBuffer> srcBuffer,
   }
 
   return validate(ir_before, ir_after,
-    arg_dump_smt_to.getValue(),
-    num_memblocks.getValue(),
-    memory_encoding.getValue(),
-    fp_bits.getValue(),
-    arg_associative_sum.getValue()
+      arg_dump_smt_to.getValue(),
+      num_memblocks.getValue(),
+      memory_encoding.getValue(),
+      fp_bits.getValue(),
+      arg_associative_sum.getValue(),
+      arg_multiset.getValue()
     ).code;
 }
 

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -46,6 +46,7 @@ public:
   unsigned int numBlocks;
   unsigned int fpBits;
   bool associativeAdd;
+  bool useMultiset;
 };
 
 };
@@ -370,6 +371,7 @@ static void checkIsSrcAlwaysUB(
   // be able to detect always-UB cases
   aop::setAbstraction(aop::AbsLevelDot::SUM_MUL, vinput.associativeAdd,
       vinput.fpBits);
+  aop::setEncodingOptions(vinput.useMultiset);
 
   ArgInfo args_dummy;
   vector<Expr> preconds;
@@ -411,6 +413,7 @@ static Results validate(ValidationInput vinput) {
   aop::setAbstraction(
       aop::AbsLevelDot::FULLY_ABS, /*isAddAssociative*/false,
       /*fp bits*/vinput.fpBits);
+  aop::setEncodingOptions(/*useMultiset*/false);
   auto res = tryValidation(vinput, true, false, elapsedMillisec);
 
   if (res.code == Results::INCONSISTENT)
@@ -429,6 +432,7 @@ static Results validate(ValidationInput vinput) {
 
   if (assocAdd || useSumMulForDot) {
     aop::setAbstraction(aop::AbsLevelDot::SUM_MUL, assocAdd, vinput.fpBits);
+    aop::setEncodingOptions(vinput.useMultiset);
     if (!vinput.dumpSMTPath.empty())
       vinput.dumpSMTPath += "_noabs";
   } else {
@@ -455,7 +459,7 @@ Results validate(
     mlir::OwningModuleRef &src, mlir::OwningModuleRef &tgt,
     const string &dumpSMTPath,
     unsigned int numBlocks, MemEncoding encoding,
-    unsigned fpBits, bool associativeAdd) {
+    unsigned fpBits, bool associativeAdd, bool useMultiset) {
   map<llvm::StringRef, mlir::FuncOp> srcfns, tgtfns;
   auto fillFns = [](map<llvm::StringRef, mlir::FuncOp> &m, mlir::Operation &op) {
     auto fnop = mlir::dyn_cast<mlir::FuncOp>(op);
@@ -484,6 +488,7 @@ Results validate(
     vinput.fpBits = fpBits;
     vinput.encoding = encoding;
     vinput.associativeAdd = associativeAdd;
+    vinput.useMultiset = useMultiset;
 
     verificationResult.merge(validate(vinput));
   }

--- a/src/vcgen.h
+++ b/src/vcgen.h
@@ -46,4 +46,5 @@ Results validate(mlir::OwningModuleRef &src, mlir::OwningModuleRef &tgt,
     unsigned int numBlocks,
     MemEncoding encoding,
     unsigned fpBits,
-    bool associativeAdd);
+    bool associativeAdd,
+    bool useMultiset);


### PR DESCRIPTION
Revert previous multi sets encoding in https://github.com/aqjune/mlir-tv/pull/125.
But in previous PR, bag equality with uninterpreted function is not well supported in CVC5..
To resolve this issue, I added bag equality precondition in `getAssociativePrecondition()` and this works well!

cf. Currently CVC5 support ackermannization in very limited condition. So I just encoded it in precondition :(