### PR TITLE
Fix bug when creating empty bag.

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -340,7 +340,8 @@ static Expr fpMultisetSum(const Expr &a, const Expr &n) {
     assert("Only an array of constant length is supported.");
 
   auto &enc = *floatEnc;
-  auto bag = Expr::mkEmptyBag(a.sort());
+  auto elemtSort = a.select(Index(0)).sort();
+  auto bag = Expr::mkEmptyBag(elemtSort);
   for (unsigned i = 0; i < length; i ++) {
     bag = bag.insert(a.select(Index(i)));
     bag = bag.simplify();


### PR DESCRIPTION
Maybe side effect of [this commit](https://github.com/aqjune/mlir-tv/commit/bffa9d54cb4c170558077e901122443972edca10#diff-4e15726697358a950e6b67a319f071b4782328c178106426d5055b4f550c3288R332-R333).
a is constant size array, so it's sort is `Index::sort() -> Float::sort()`.