### PR TITLE
Fix bug in Daily-update action

### DIFF
--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -35,6 +35,8 @@ jobs:
     if: github.repository == 'aqjune/mlir-tv'
     needs: configure-dependencies
     runs-on: ubuntu-20.04
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
     steps:
       - name: Checkout Z3
         uses: actions/checkout@v2
@@ -80,6 +82,8 @@ jobs:
     if: github.repository == 'aqjune/mlir-tv'
     needs: configure-dependencies
     runs-on: ubuntu-20.04
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
     steps:
       - name: Checkout CVC5
         uses: actions/checkout@v2
@@ -126,6 +130,8 @@ jobs:
     if: github.repository == 'aqjune/mlir-tv'
     needs: configure-dependencies
     runs-on: ubuntu-20.04
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@v2
@@ -182,25 +188,19 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/image/opt/z3
-          key: cache-z3-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            cache-z3-${{ secrets.CACHE_VERSION }}
+          key: cache-z3-${{ secrets.CACHE_VERSION }}-${{ needs.configure-z3.outputs.sha }}
 
       - name: Fetch CVC5 cache
         uses: actions/cache@v2
         with:
           path: /tmp/image/opt/cvc5
-          key: cache-cvc5-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            cache-cvc5-${{ secrets.CACHE_VERSION }}
+          key: cache-cvc5-${{ secrets.CACHE_VERSION }}-${{ needs.configure-cvc5.outputs.sha }}
 
       - name: Fetch LLVM cache
         uses: actions/cache@v2
         with:
           path: /tmp/image/opt/llvm
-          key: cache-llvm-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            cache-llvm-${{ secrets.CACHE_VERSION }}
+          key: cache-llvm-${{ secrets.CACHE_VERSION }}-${{ needs.configure-llvm.outputs.sha }}
 
       - name: Checkout this repo
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR fixes the bug in CI environment image update script.

* Reported issue: LLVM in the docker image created by `Daily-update` action is outdated
* Reason: When building the image, the action runner kept fetching the older Z3/cvc5/LLVM cache. This was due to misconfiguration in the script's cache fall-back behavior.
* Fix: Instead of using cache fallback, the action runner will now identify and fetch the correct cache using the commit hash of Z3/cvc5/LLVM.