### PR TITLE
Use dedicated type-check methods instead of `isa<Ty>`

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -87,9 +87,9 @@ bool getFpAddAssociativity() { return isFpAddAssociative; }
 AbsFpEncoding &getFloatEncoding() { return *floatEnc; }
 AbsFpEncoding &getDoubleEncoding() { return *doubleEnc; }
 AbsFpEncoding &getFpEncoding(mlir::Type ty) {
-  if (ty.isa<mlir::Float32Type>()) {
+  if (ty.isF32()) {
     return getFloatEncoding();
-  } else if (ty.isa<mlir::Float64Type>()) {
+  } else if (ty.isF64()) {
      return getDoubleEncoding();
   }
   llvm_unreachable("Unknown type");

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -50,7 +50,7 @@ static optional<ValueTy> attrToValueTy(mlir::Attribute a) {
       return {};
 
     return Integer(a.dyn_cast<mlir::IntegerAttr>().getValue());
-  } else if (ty.isa<mlir::IndexType>()) {
+  } else if (ty.isIndex()) {
     llvm::APInt i = a.dyn_cast<mlir::IntegerAttr>().getValue();
     assert(i.getBitWidth() == 64);
     int64_t ii = i.getSExtValue();
@@ -61,7 +61,7 @@ static optional<ValueTy> attrToValueTy(mlir::Attribute a) {
 }
 
 static optional<ValueTy> fromExpr(Expr &&e, mlir::Type ty) {
-  if (ty.isa<mlir::IndexType>())
+  if (ty.isIndex())
     return Index(e);
   else if (ty.isa<mlir::FloatType>())
     return Float(e, ty);
@@ -120,7 +120,7 @@ static Expr evalIndexCastOp(mlir::Type src, mlir::Type tgt, Expr &&val) {
   if (auto dstty = tgt.dyn_cast<mlir::IntegerType>())
     destWidth = dstty.getWidth();
   else {
-    assert(tgt.isa<mlir::IndexType>());
+    assert(tgt.isIndex());
     destWidth = Index::BITS;
   }
 
@@ -1168,7 +1168,7 @@ optional<string> encodeOp(State &st, mlir::memref::StoreOp op) {
   for (auto idx0: op.indices())
     indices.emplace_back(st.regs.get<Index>(idx0));
 
-  if (op.getOperand(0).getType().isa<mlir::Float32Type>()) {
+  if (op.getOperand(0).getType().isF32()) {
     auto val = st.regs.get<Float>(op.getOperand(0));
     auto success = m.store(val, indices);
     st.wellDefined(op.getOperation(), move(success));

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -49,7 +49,7 @@ void RegFile::add(mlir::Value v, const Expr &e, mlir::Type ty) {
     m.insert({v, Float(e, ty)});
   else if (ty.isa<mlir::IntegerType>())
     m.insert({v, Integer(e)});
-  else if (ty.isa<mlir::IndexType>())
+  else if (ty.isIndex())
     m.insert({v, Index(e)});
   else {
     llvm::errs() << "Unsupported type: " << ty << "\n";

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -17,7 +17,7 @@ optional<smt::Sort> convertTypeToSort(mlir::Type elemty) {
     return Integer::sort(ielemty.getWidth());
   } else if (auto felemty = elemty.dyn_cast<mlir::FloatType>()) {
     return Float::sort(felemty);
-  } else if (elemty.isa<mlir::IndexType>()) {
+  } else if (elemty.isIndex()) {
     return Index::sort();
   }
 
@@ -32,7 +32,7 @@ optional<Expr> getZero(mlir::Type eltType) {
     return Float::constant(llvm::APFloat(0.0), eltType);
   else if (eltType.isa<mlir::IntegerType>())
     return Integer(0, eltType.getIntOrFloatBitWidth());
-  else if (eltType.isa<mlir::IndexType>())
+  else if (eltType.isIndex())
     return Index(0);
   return {};
 }
@@ -116,9 +116,9 @@ Index Index::eval(Model m) const {
 }
 
 optional<Sort> Float::sort(mlir::Type t) {
-  if (t.isa<mlir::Float32Type>()) {
+  if (t.isF32()) {
     return aop::getFloatEncoding().sort();
-  } else if (t.isa<mlir::Float64Type>()) {
+  } else if (t.isF64()) {
     return aop::getDoubleEncoding().sort();
   }
   return nullopt;
@@ -736,7 +736,7 @@ bool MemRef::isTypeSupported(mlir::MemRefType memRefTy) {
 
   auto elemty = memRefTy.getElementType();
   // Currently we only support f32 element type.
-  return elemty.isa<mlir::Float32Type>();
+  return elemty.isF32();
 }
 
 MemRef::Layout MemRef::getLayout(


### PR DESCRIPTION
This PR replaces `isa<Ty>` with dedicated type check methods
- use `isF32()` instead of `isa<mlir::Float32Type>()`
- use `isF64()` instead of `isa<mlir::Float64Type>()`
- use `isIndex()` instead of `isa<mlir::IndexType>()`
```c++
// lib/IR/Types.cpp, line 23
bool Type::isF32() const { return isa<Float32Type>(); }
bool Type::isF64() const { return isa<Float64Type>(); }
// -- snip --
bool Type::isIndex() const { return isa<IndexType>(); }
// -- snip --
```

We can't replace `isa<mlir::IntegerType>` with `isInteger(unsigned int bw)` because we can't figure out the bitwidth in advance.