### PR TITLE
Update to newer cvc5 method

### DIFF
--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -938,7 +938,7 @@ Sort Sort::toFnSort() const {
 unsigned Sort::bitwidth() const {
   optional<unsigned> res;
   IF_Z3_ENABLED(if(z3) writeOrCheck(res, z3->bv_size()));
-  IF_CVC5_ENABLED(if(cvc5) writeOrCheck(res, cvc5->getBVSize()));
+  IF_CVC5_ENABLED(if(cvc5) writeOrCheck(res, cvc5->getBitVectorSize()));
   return *res;
 }
 


### PR DESCRIPTION
This PR changes the name of cvc5 method to catch up with newer API.
See [here](https://github.com/cvc5/cvc5/pull/7428) for the updated cvc5 API