### PR TITLE
Support simple `cmpf` operation in linalg.generic

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -117,6 +117,7 @@ AbsFpEncoding::AbsFpEncoding(const llvm::fltSemantics &semantics,
   fp_dotfn.reset();
   fp_addfn.reset();
   fp_mulfn.reset();
+  fp_ultfn.reset();
   fp_sum_relations.clear();
 }
 
@@ -157,6 +158,15 @@ FnDecl AbsFpEncoding::getDotFn() {
   if (!fp_dotfn)
     fp_dotfn.emplace({arrs, arrs}, sort(), "fp_dot_" + fn_suffix);
   return *fp_dotfn;
+}
+
+FnDecl AbsFpEncoding::getUltFn() {
+  if (!fp_ultfn) {
+    auto fty = Sort::bvSort(fp_bv_bits);
+    auto fty2 = Sort::bvSort(1); // i1 type (boolean value)
+    fp_ultfn.emplace({fty, fty}, fty2, "fp_ult_" + fn_suffix);
+  }
+  return *fp_ultfn;
 }
 
 Expr AbsFpEncoding::constant(const llvm::APFloat &f) {
@@ -443,6 +453,10 @@ Expr AbsFpEncoding::dot(const Expr &a, const Expr &b, const Expr &n) {
     return sum(arr, n);
   }
   llvm_unreachable("Unknown abstraction level for fp dot");
+}
+
+Expr AbsFpEncoding::ult(const Expr &f1, const Expr &f2) {
+  return getUltFn().apply({f1, f2});
 }
 
 Expr AbsFpEncoding::getFpAssociativePrecondition() const {

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -74,6 +74,7 @@ private:
   std::optional<smt::FnDecl> fp_dotfn;
   std::optional<smt::FnDecl> fp_addfn;
   std::optional<smt::FnDecl> fp_mulfn;
+  std::optional<smt::FnDecl> fp_ultfn;
   std::string fn_suffix;
 
 public:
@@ -95,6 +96,7 @@ private:
   smt::FnDecl getAssocSumFn();
   smt::FnDecl getSumFn();
   smt::FnDecl getDotFn();
+  smt::FnDecl getUltFn();
 
 public:
   smt::Expr constant(const llvm::APFloat &f);
@@ -110,6 +112,7 @@ public:
   smt::Expr mul(const smt::Expr &f1, const smt::Expr &f2);
   smt::Expr sum(const smt::Expr &a, const smt::Expr &n);
   smt::Expr dot(const smt::Expr &a, const smt::Expr &b, const smt::Expr &n);
+  smt::Expr ult(const smt::Expr &f1, const smt::Expr &f2);
   smt::Expr getFpAssociativePrecondition() const;
 
 private:

--- a/src/simplevalue.h
+++ b/src/simplevalue.h
@@ -60,6 +60,8 @@ public:
 
   static smt::Sort sort(unsigned bw);
   static Integer var(std::string &&name, unsigned bw, VarType vty);
+  static Integer boolTrue();
+  static Integer boolFalse();
 
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, const Integer &);
   // (refinement, {})

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -178,6 +178,10 @@ Float Float::mul(const Float &b) const {
   return Float(aop::getFpEncoding(type).mul(e, b.e), type);
 }
 
+Integer Float::ult(const Float &b) const {
+  return Integer(aop::getFpEncoding(type).ult(e, b.e));
+}
+
 Float Float::abs() const {
   return Float(aop::getFpEncoding(type).abs(e), type);
 }
@@ -203,6 +207,9 @@ Integer Integer::var(std::string &&name, unsigned bw, VarType varty) {
   }
   llvm_unreachable("Unknown case");
 }
+
+Integer Integer::boolTrue() { return Integer(1, 1); }
+Integer Integer::boolFalse() { return Integer(0, 1); }
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const Integer &i) {
   os << or_omit((Expr)i);

--- a/src/value.h
+++ b/src/value.h
@@ -26,6 +26,7 @@ public:
 
   Float add(const Float &b) const;
   Float mul(const Float &b) const;
+  Integer ult(const Float &b) const;
   Float abs() const;
 
   friend llvm::raw_ostream& operator<<(llvm::raw_ostream&, const Float &);

--- a/tests/litmus/linalg-loops/simple_cmpf.src.mlir
+++ b/tests/litmus/linalg-loops/simple_cmpf.src.mlir
@@ -1,0 +1,23 @@
+// VERIFY
+
+#accesses = [
+  affine_map<(i, j) -> (i, j)>,
+  affine_map<(i, j) -> (i, j)>
+]
+#trait = {
+  indexing_maps = #accesses,
+  iterator_types = ["parallel", "parallel"]
+}
+func @dead_linalg_tensor(%arg0 : tensor<7x7xf32>) {
+  %0 = linalg.generic #trait ins(%arg0 : tensor<7x7xf32>) outs(%arg0 : tensor<7x7xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+      %cst_114 = arith.constant 0.000000e+00 : f32
+      %cst_115 = arith.constant 6.000000e+00 : f32
+      %269 = arith.cmpf olt, %arg1, %cst_114 : f32
+      %270 = select %269, %cst_114, %arg1 : f32
+      %271 = arith.cmpf olt, %cst_115, %arg1 : f32
+      %272 = select %271, %cst_115, %270 : f32
+      linalg.yield %272 : f32
+  } -> tensor<7x7xf32>
+  return
+}

--- a/tests/litmus/linalg-loops/simple_cmpf.tgt.mlir
+++ b/tests/litmus/linalg-loops/simple_cmpf.tgt.mlir
@@ -1,0 +1,21 @@
+#accesses = [
+  affine_map<(i, j) -> (i, j)>,
+  affine_map<(i, j) -> (i, j)>
+]
+#trait = {
+  indexing_maps = #accesses,
+  iterator_types = ["parallel", "parallel"]
+}
+func @dead_linalg_tensor(%arg0 : tensor<7x7xf32>) {
+  %0 = linalg.generic #trait ins(%arg0 : tensor<7x7xf32>) outs(%arg0 : tensor<7x7xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+      %cst_114 = arith.constant 0.000000e+00 : f32
+      %cst_115 = arith.constant 6.000000e+00 : f32
+      %269 = arith.cmpf olt, %arg1, %cst_114 : f32
+      %270 = select %269, %cst_114, %arg1 : f32
+      %271 = arith.cmpf olt, %cst_115, %arg1 : f32
+      %272 = select %271, %cst_115, %270 : f32
+      linalg.yield %272 : f32
+  } -> tensor<7x7xf32>
+  return
+}


### PR DESCRIPTION
Before we support `tosa.clamp`and float value's ordering, I added fully abstract `ult` function in advance.
Currently ult_fn does not have any concrete semantic yet..
In following PR, some preconditions regarding `ult_fn` will be added based on constant values exist in program.
