### PR TITLE
Implement more precise fp counting

### DIFF
--- a/src/analysis.h
+++ b/src/analysis.h
@@ -1,15 +1,17 @@
 #pragma once
 
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include <set>
+
+struct SolePrecisionAnalysisResult {
+  std::set<llvm::APFloat> fpConstSet;
+  size_t fpVarCount;
+  size_t fpArgCount;
+};
 
 struct AnalysisResult {
-    int constF32Count;
-    int varF32Count;
-    int argF32Count;
-    
-    int constF64Count;
-    int varF64Count;
-    int argF64Count;
+    SolePrecisionAnalysisResult F32;
+    SolePrecisionAnalysisResult F64;
 };
 
 AnalysisResult analyze(mlir::FuncOp &fn, bool isFullyAbstract);

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -5,8 +5,8 @@
 
 struct SolePrecisionAnalysisResult {
   std::set<llvm::APFloat> fpConstSet;
-  size_t fpVarCount;
-  size_t fpArgCount;
+  size_t fpVarCount = 0;
+  size_t fpArgCount = 0;
 };
 
 struct AnalysisResult {

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -3,10 +3,13 @@
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 
 struct AnalysisResult {
-    int argFpCount;
-    int varFpCount;
     int constF32Count;
+    int varF32Count;
+    int argF32Count;
+    
     int constF64Count;
+    int varF64Count;
+    int argF64Count;
 };
 
 AnalysisResult analyze(mlir::FuncOp &fn, bool isFullyAbstract);

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -5,7 +5,8 @@
 struct AnalysisResult {
     int argFpCount;
     int varFpCount;
-    int constFpCount;
+    int constF32Count;
+    int constF64Count;
 };
 
 AnalysisResult analyze(mlir::FuncOp &fn, bool isFullyAbstract);

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -540,12 +540,16 @@ Results validate(
     auto src_res = analyze(srcfn, false);
     auto tgt_res = analyze(tgtfn, false);
     // TODO: need some more tight bounds..?
-    auto totalFpCounts = 2 + // reserved for zero, inf constants
-      src_res.argFpCount + // # of variables in argument lists
+    auto totalF32Counts = 4 + // reserved for 0.0, 1.0, Inf, NaN constants
+      src_res.argF32Count +// # of variables in argument lists
       // we only count F64 consts because they contain F32 consts as well
-      src_res.constF64Count * 2 + tgt_res.constF64Count * 2 + // # of constants needed
-      src_res.varFpCount + tgt_res.varFpCount ; // # of variables in virtual register
-    auto bits = calculateRequiredBITS(totalFpCounts);
+      src_res.constF32Count * 2 + tgt_res.constF32Count * 2 + // # of constants needed
+      src_res.varF32Count + tgt_res.varF32Count; // # of variables in virtual register
+    auto totalF64Counts = 4 + src_res.argF64Count +
+      src_res.constF64Count * 2 + tgt_res.constF64Count * 2 +
+      src_res.varF64Count + tgt_res.varF64Count;
+    auto bitsF32 = calculateRequiredBITS(totalF32Counts);
+    auto bitsF64 = calculateRequiredBITS(totalF64Counts);
 
     ValidationInput vinput;
     vinput.src = srcfn;
@@ -556,8 +560,8 @@ Results validate(
       vinput.floatBits = fpBits.first;
       vinput.doubleBits = fpBits.second;
     } else {
-      vinput.floatBits = bits;
-      vinput.doubleBits = bits;
+      vinput.floatBits = bitsF32;
+      vinput.doubleBits = bitsF64;
     }
     vinput.encoding = encoding;
     vinput.isFpAddAssociative = isFpAddAssociative;

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -537,13 +537,14 @@ Results validate(
     // TODO: check fn signature
     auto tgtfn = itr->second;
 
-    auto res1 = analyze(srcfn, false);
-    auto res2 = analyze(tgtfn, false);
+    auto src_res = analyze(srcfn, false);
+    auto tgt_res = analyze(tgtfn, false);
     // TODO: need some more tight bounds..?
     auto totalFpCounts = 2 + // reserved for zero, inf constants
-      res1.argFpCount + // # of variables in argument lists
-      res1.constFpCount * 2 + res2.constFpCount * 2 + // # of constants needed
-      res1.varFpCount + res2.varFpCount ; // # of variables in virtual register
+      src_res.argFpCount + // # of variables in argument lists
+      // we only count F64 consts because they contain F32 consts as well
+      src_res.constF64Count * 2 + tgt_res.constF64Count * 2 + // # of constants needed
+      src_res.varFpCount + tgt_res.varFpCount ; // # of variables in virtual register
     auto bits = calculateRequiredBITS(totalFpCounts);
 
     ValidationInput vinput;

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -538,16 +538,24 @@ Results validate(
     auto tgtfn = itr->second;
 
     auto src_res = analyze(srcfn, false);
+    auto src_f32_res = src_res.F32;
+    auto src_f64_res = src_res.F64;
+
     auto tgt_res = analyze(tgtfn, false);
-    // TODO: need some more tight bounds..?
-    auto totalF32Counts = 4 + // reserved for 0.0, 1.0, Inf, NaN constants
-      src_res.argF32Count +// # of variables in argument lists
-      // we only count F64 consts because they contain F32 consts as well
-      src_res.constF32Count * 2 + tgt_res.constF32Count * 2 + // # of constants needed
-      src_res.varF32Count + tgt_res.varF32Count; // # of variables in virtual register
-    auto totalF64Counts = 4 + src_res.argF64Count +
-      src_res.constF64Count * 2 + tgt_res.constF64Count * 2 +
-      src_res.varF64Count + tgt_res.varF64Count;
+    auto tgt_f32_res = tgt_res.F32;
+    auto tgt_f64_res = tgt_res.F64;
+    
+    auto calculateTotalFpCounts = [](const auto& src_res, const auto& tgt_res) {
+      size_t total = 4 + // reserved for 0.0, 1.0, Inf, NaN constants
+      src_res.fpArgCount + // # of variables in argument lists
+      src_res.fpConstSet.size() * 2 + tgt_res.fpConstSet.size() * 2 + // # of constants needed
+      src_res.fpVarCount + tgt_res.fpVarCount; // # of variables in virtual register
+      
+      return total;
+    };
+
+    auto totalF32Counts = calculateTotalFpCounts(src_f32_res, tgt_f32_res);
+    auto totalF64Counts = calculateTotalFpCounts(src_f64_res, tgt_f64_res);
     auto bitsF32 = calculateRequiredBITS(totalF32Counts);
     auto bitsF64 = calculateRequiredBITS(totalF64Counts);
 


### PR DESCRIPTION
This PR implements precision-sensitive FP counting.
- F32 and F64 constants/variables are counted separately
- Each F32 and F64 constant found is also added respectively to F64 and F32 constant list, with possible rounding if necessary.