### PR TITLE
Catch up with updated MLIR

### DIFF
--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -24,16 +24,16 @@ static void analyzeAttr(const mlir::Attribute &a) {
 static void analyzeElemAttr(const mlir::ElementsAttr &attr) {
   if (auto denseAttr = attr.dyn_cast<mlir::DenseElementsAttr>()) {
     if (denseAttr.isSplat()) {
-      analyzeAttr(denseAttr.getSplatValue());
+      analyzeAttr(denseAttr.getSplatValue<mlir::Attribute>());
     } else {
-      for (unsigned i = 0; i < denseAttr.getNumElements(); i++) {
-        analyzeAttr(denseAttr.getFlatValue<mlir::Attribute>(i));
+      for (const auto& attr: denseAttr.getValues<mlir::Attribute>()) {
+        analyzeAttr(attr);
       }
     }
   } else if (auto sparseAttr = attr.dyn_cast<mlir::SparseElementsAttr>()) {
     auto denseAttr = sparseAttr.getValues();
-    for (unsigned i = 0; i < denseAttr.getNumElements(); i++) {
-      analyzeAttr(denseAttr.getFlatValue<mlir::Attribute>(i));
+    for (const auto& attr: denseAttr.getValues<mlir::Attribute>()) {
+      analyzeAttr(attr);
     }
   }
 }

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -54,7 +54,7 @@ static Tensor elemAttrToTensor(
     if (denseAttr.isSplat()) {
       // A constant tensor's type cannot have unknown dimensions
       auto dims = ShapedValue::getDims(tensorty, false);
-      auto v = attrToValueTy(denseAttr.getSplatValue());
+      auto v = attrToValueTy(denseAttr.getSplatValue<mlir::Attribute>());
 
       return Tensor(elemType, getExpr(v), move(dims));
 
@@ -85,7 +85,7 @@ static Tensor elemAttrToTensor(
             break;
         }
 
-        exprs.push_back(getExpr(attrToValueTy(denseAttr.getValue(elems))));
+        exprs.push_back(getExpr(attrToValueTy(denseAttr.getValues<mlir::Attribute>()[elems])));
         elems.back()++;
       }
 
@@ -116,7 +116,7 @@ static Tensor elemAttrToTensor(
         sparseIndBeg++;
       }
 
-      auto value = sparseAttr.getValue(curIndices);
+      auto value = sparseAttr.getValues<mlir::Attribute>()[curIndices];
       sparseIndices.push_back(move(curIndices));
 
       auto e = attrToValueTy(value);


### PR DESCRIPTION
The recently updated `mlir::Attribute` API has introduced some breaking changes.
- `get[.+]Value(mlir::ArrayRef<T> indices)` are now changed into `getValues()[mlir::ArrayRef<T> indices>]`