### PR TITLE
Improve fp bitwidth calculation policy

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -151,11 +151,16 @@ void setAbstraction(
       min_limit_bitwidth = 1;
     }
 
-    const unsigned doubleLimitBits = min_limit_bitwidth;
     // 29: mantissa(double) - mantissa(float)
-    // using more than 29 precision bits is unnecessary
+    // Using more than 29 precision bits is unnecessary
     // because such values do not exist in the real-world double
     const unsigned doublePrecBits = min(min_prec_bitwidth, 29u);
+    // 32: bitwidth(double) - bitwidth(float)
+    // Using more than 32 (limit + precision) bits is unnecessary
+    // because such values do not exist in the real-world double
+    // And this value will never overflow, because doublePrecBits is always <=29
+    const unsigned doubleLimitBits = min(min_limit_bitwidth,
+                                          32u - doublePrecBits);
     doubleEnc.emplace(llvm::APFloat::IEEEdouble(), doubleLimitBits,
     doublePrecBits, &*floatEnc, "double");
   } else {

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -139,8 +139,8 @@ private:
   smt::FnDecl getSumFn();
   smt::FnDecl getDotFn();
   smt::FnDecl getUltFn();
-  smt::FnDecl getExtendFn();
-  smt::FnDecl getTruncateFn();
+  smt::FnDecl getExtendFn(const AbsFpEncoding &tgt);
+  smt::FnDecl getTruncateFn(const AbsFpEncoding &tgt);
   smt::FnDecl getExpFn();
 
   uint64_t getSignBit() const;


### PR DESCRIPTION
This PR introduces a new FP bitwidth calculation method.
- If FP casting abstraction level is `FULLY_ABS`, each `AbsFpEncoding` is constructed as following:
  - Both limit and precision bitwidth are set to 0.
  - Smaller value bitwidth is calculated as `log2_ceil(#variables + #constants + 2)`
- If FP casting abstraction level is `PRECISE`, there's a whole new policy to decide each bitwidth. It is somewhat complex to explain in PR description, so please refer to paper repo for more information.