### PR TITLE
Remove `AbsFpEncoding::smaller_fpty_enc`

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -191,13 +191,12 @@ AbsFpEncoding &getFpEncoding(mlir::Type ty) {
 
 AbsFpEncoding::AbsFpEncoding(const llvm::fltSemantics &semantics,
       unsigned limit_bw, unsigned smaller_value_bw, unsigned prec_bw,
-      AbsFpEncoding* smaller_fpty_enc, std::string &&fn_suffix)
+       std::string &&fn_suffix)
      :semantics(semantics), fn_suffix(move(fn_suffix)) {
   assert(smaller_value_bw > 0);
   // BWs for casting
   value_bit_info = { limit_bw, smaller_value_bw, prec_bw };
   value_bitwidth = value_bit_info.get_value_bitwidth();
-  this->smaller_fpty_enc = smaller_fpty_enc;
 
   fp_bitwidth = SIGN_BITS + value_bitwidth;
 

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -90,8 +90,6 @@ private:
   };
   ValueBitInfo value_bit_info;
 
-  AbsFpEncoding* smaller_fpty_enc;
-
   std::vector<std::tuple<smt::Expr, smt::Expr, smt::Expr>> fp_sum_relations;
 
   // These are lazily created.
@@ -109,19 +107,18 @@ private:
 private:
   AbsFpEncoding(const llvm::fltSemantics &semantics,
       unsigned limit_bw, unsigned smaller_value_bw, unsigned prec_bw,
-      AbsFpEncoding* smaller_fpty_enc, std::string &&fn_suffix);
+      std::string &&fn_suffix);
 
 public:
   AbsFpEncoding(const llvm::fltSemantics &semantics, unsigned value_bw,
       std::string &&fn_suffix)
-      : AbsFpEncoding(semantics, 0u, value_bw, 0u, nullptr,
-        std::move(fn_suffix)) {}
+      : AbsFpEncoding(semantics, 0u, value_bw, 0u, std::move(fn_suffix)) {}
   // Use smaller_fpty_enc's value_bv_bits to calculate this type's value_bv_bits
   AbsFpEncoding(const llvm::fltSemantics &semantics,
       unsigned limit_bw, unsigned prec_bw, AbsFpEncoding* smaller_fpty_enc,
       std::string &&fn_suffix)
       : AbsFpEncoding(semantics, limit_bw, smaller_fpty_enc->value_bitwidth,
-        prec_bw, smaller_fpty_enc, std::move(fn_suffix)) {}
+        prec_bw, std::move(fn_suffix)) {}
 
   smt::Sort sort() const {
     return smt::Sort::bvSort(fp_bitwidth);


### PR DESCRIPTION
This PR removes redundant variable and related constructors.