### PR TITLE
Implement FP division

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -708,6 +708,7 @@ Expr AbsFpEncoding::div(const Expr &_f1, const Expr &_f2) {
       bv_false.concat(fpdiv_res.extract(value_bitwidth - 1, 0)),
       bv_true.concat(fpdiv_res.extract(value_bitwidth - 1, 0))
   ));
+}
 
 Expr AbsFpEncoding::lambdaSum(const smt::Expr &a, const smt::Expr &n) {
   auto i = Index::var("idx", VarType::BOUND);

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -692,7 +692,8 @@ Expr AbsFpEncoding::div(const Expr &_f1, const Expr &_f2) {
   // +-0.0 / +-0.0 -> NaN, x / +-0.0 -> ?Inf (if x != 0.0 | Inf)
   // IEEE 754-2019 section 7.2 'Invalid operation'
   // IEEE 754-2019 section 7.3 'Division by zero'
-  // division by zero should explicitly raise exception!
+  // Division by zero should explicitly signal exception.
+  // However, LLVM chooses to simply continue the execution without notifying
   Expr::mkIte((f2 == fp_zero_pos) | (f2 == fp_zero_neg),
     Expr::mkIte((f1 == fp_zero_pos) | (f1 == fp_zero_neg), fp_nan, fp_inf_pos),
     // If both operands do not fall into any of the cases above,

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -13,6 +13,7 @@ struct UsedAbstractOps {
   bool fpDot;
   bool fpAdd;
   bool fpMul;
+  bool fpDiv;
   bool fpSum;
   bool fpUlt;
   bool fpCastRound;
@@ -103,6 +104,7 @@ private:
   std::optional<smt::FnDecl> fp_dotfn;
   std::optional<smt::FnDecl> fp_addfn;
   std::optional<smt::FnDecl> fp_mulfn;
+  std::optional<smt::FnDecl> fp_divfn;
   std::optional<smt::FnDecl> fp_ultfn;
   std::optional<smt::FnDecl> fp_extendfn;
   std::optional<smt::FnDecl> fp_truncatefn;
@@ -138,6 +140,9 @@ private:
   // Returns a fully abstract mul fn fp_mul(value_bv_bits-1, value_bv_bits-1)
   // -> BV(value_bv_bits)
   smt::FnDecl getMulFn();
+  // Returns a fully abstract div fn fp_mul(value_bv_bits-1, value_bv_bits-1)
+  // -> BV(value_bv_bits)
+  smt::FnDecl getDivFn();
   smt::FnDecl getAssocSumFn();
   smt::FnDecl getSumFn();
   smt::FnDecl getDotFn();
@@ -165,6 +170,7 @@ public:
   smt::Expr neg(const smt::Expr &f);
   smt::Expr add(const smt::Expr &f1, const smt::Expr &f2);
   smt::Expr mul(const smt::Expr &f1, const smt::Expr &f2);
+  smt::Expr div(const smt::Expr &f1, const smt::Expr &f2);
   smt::Expr sum(const smt::Expr &a, const smt::Expr &n);
   smt::Expr exp(const smt::Expr &x);
   smt::Expr dot(const smt::Expr &a, const smt::Expr &b, const smt::Expr &n);

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -466,6 +466,15 @@ void encodeOp(State &st, mlir::arith::MulFOp op, bool) {
 }
 
 template<>
+void encodeOp(State &st, mlir::arith::DivFOp op, bool) {
+  mlir::Value arg0 = op.getOperand(0);
+  mlir::Value arg1 = op.getOperand(1);
+
+  encodeBinaryOp(st, op, arg0, arg1,
+      [](auto &&a, auto &&b) { return a.div(b); }, {});
+}
+
+template<>
 void encodeOp(State &st, mlir::arith::NegFOp op, bool) {
   mlir::Value arg = op.getOperand();
 
@@ -2604,6 +2613,7 @@ static void encodeBlock(
     ENCODE(st, op, mlir::arith::IndexCastOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::arith::MulFOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::arith::MulIOp, encodeMemWriteOps);
+    ENCODE(st, op, mlir::arith::DivFOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::arith::NegFOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::arith::SubFOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::arith::SubIOp, encodeMemWriteOps);

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -188,6 +188,10 @@ Float Float::mul(const Float &b) const {
   return Float(aop::getFpEncoding(type).mul(e, b.e), type);
 }
 
+Float Float::div(const Float &b) const {
+  return Float(aop::getFpEncoding(type).div(e, b.e), type);
+}
+
 Integer Float::fult(const Float &b) const {
   return Integer(aop::getFpEncoding(type).fult(e, b.e));
 }

--- a/src/value.h
+++ b/src/value.h
@@ -31,6 +31,7 @@ public:
 
   Float add(const Float &b) const;
   Float mul(const Float &b) const;
+  Float div(const Float &b) const;
   Integer fult(const Float &b) const;
   Float abs() const;
   Float neg() const;

--- a/tests/litmus/fp-ops/comm_div-bad.src.mlir
+++ b/tests/litmus/fp-ops/comm_div-bad.src.mlir
@@ -1,0 +1,6 @@
+// VERIFY-INCORRECT
+
+func @f(%arg0: f32, %arg1: f32) -> f32 {
+  %c = arith.divf %arg0, %arg1 : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/comm_div-bad.tgt.mlir
+++ b/tests/litmus/fp-ops/comm_div-bad.tgt.mlir
@@ -1,0 +1,4 @@
+func @f(%arg0: f32, %arg1: f32) -> f32 {
+  %c = arith.divf %arg1, %arg0 : f32
+  return %c: f32
+}

--- a/tests/litmus/fp-ops/comm_div_const-bad.src.mlir
+++ b/tests/litmus/fp-ops/comm_div_const-bad.src.mlir
@@ -1,0 +1,8 @@
+// VERIFY-INCORRECT
+
+func @f() -> f32 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.divf %i, %v : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/comm_div_const-bad.tgt.mlir
+++ b/tests/litmus/fp-ops/comm_div_const-bad.tgt.mlir
@@ -1,0 +1,6 @@
+func @f() -> f32 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.divf %v, %i : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/ident_div.src.mlir
+++ b/tests/litmus/fp-ops/ident_div.src.mlir
@@ -1,0 +1,9 @@
+// VERIFY
+
+func @f(%arg0: f32, %arg1: f32) -> f32 {
+  %i = arith.constant 1.0 : f32
+  %v1 = arith.divf %arg0, %i : f32
+  %v2 = arith.divf %arg1, %i : f32
+  %c = arith.addf %v1, %v2 : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/ident_div.tgt.mlir
+++ b/tests/litmus/fp-ops/ident_div.tgt.mlir
@@ -1,0 +1,4 @@
+func @f(%arg0: f32, %arg1: f32) -> f32 {
+  %c = arith.addf %arg0, %arg1 : f32
+  return %c: f32
+}

--- a/tests/litmus/fp-ops/ident_div_const.src.mlir
+++ b/tests/litmus/fp-ops/ident_div_const.src.mlir
@@ -1,0 +1,8 @@
+// VERIFY
+
+func @f() -> f32 {
+  %v = arith.constant 3.0 : f32
+  %i = arith.constant -1.0 : f32
+  %c = arith.divf %v, %i : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/ident_div_const.tgt.mlir
+++ b/tests/litmus/fp-ops/ident_div_const.tgt.mlir
@@ -1,0 +1,4 @@
+func @f() -> f32 {
+  %c = arith.constant -3.0 : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/inf_div_const.src.mlir
+++ b/tests/litmus/fp-ops/inf_div_const.src.mlir
@@ -1,0 +1,15 @@
+// VERIFY
+
+func @f1() -> f32 {
+  %inf = arith.constant 0x7F800000 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.divf %inf, %v : f32
+  return %c : f32
+}
+
+func @f2() -> f32 {
+  %inf = arith.constant 0x7F800000 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.divf %v, %inf : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/inf_div_const.tgt.mlir
+++ b/tests/litmus/fp-ops/inf_div_const.tgt.mlir
@@ -1,0 +1,9 @@
+func @f1() -> f32 {
+  %c = arith.constant 0x7F800000 : f32
+  return %c : f32
+}
+
+func @f2() -> f32 {
+  %c = arith.constant 0.0 : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/inf_div_const_neg.src.mlir
+++ b/tests/litmus/fp-ops/inf_div_const_neg.src.mlir
@@ -1,0 +1,8 @@
+// VERIFY
+
+func @f() -> f32 {
+  %inf = arith.constant 0xFF800000 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.divf %inf, %v : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/inf_div_const_neg.tgt.mlir
+++ b/tests/litmus/fp-ops/inf_div_const_neg.tgt.mlir
@@ -1,0 +1,6 @@
+func @f() -> f32 {
+  %inf = arith.constant 0x7F800000 : f32
+  %v = arith.constant -3.0 : f32
+  %c = arith.divf %inf, %v : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/inf_div_inf.src.mlir
+++ b/tests/litmus/fp-ops/inf_div_inf.src.mlir
@@ -1,0 +1,8 @@
+// VERIFY
+
+func @f() -> f32 {
+  %inf_p = arith.constant 0x7F800000 : f32
+  %inf_n = arith.constant 0xFF800000 : f32
+  %c = arith.divf %inf_p, %inf_n : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/inf_div_inf.tgt.mlir
+++ b/tests/litmus/fp-ops/inf_div_inf.tgt.mlir
@@ -1,0 +1,4 @@
+func @f() -> f32 {
+  %c = arith.constant 0x7FC00000 : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/inf_div_zero.src.mlir
+++ b/tests/litmus/fp-ops/inf_div_zero.src.mlir
@@ -1,0 +1,15 @@
+// VERIFY
+
+func @f1() -> f32 {
+  %inf_p = arith.constant 0xFF800000 : f32
+  %zero = arith.constant 0.0 : f32
+  %c = arith.divf %inf_p, %zero : f32
+  return %c : f32
+}
+
+func @f2() -> f32 {
+  %inf_p = arith.constant 0xFF800000 : f32
+  %zero = arith.constant 0.0 : f32
+  %c = arith.divf %zero, %inf_p : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/inf_div_zero.tgt.mlir
+++ b/tests/litmus/fp-ops/inf_div_zero.tgt.mlir
@@ -1,0 +1,9 @@
+func @f1() -> f32 {
+  %c = arith.constant 0xFF800000 : f32
+  return %c : f32
+}
+
+func @f2() -> f32 {
+  %c = arith.constant -0.0 : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/nan_div.src.mlir
+++ b/tests/litmus/fp-ops/nan_div.src.mlir
@@ -1,0 +1,13 @@
+// VERIFY
+
+func @f1(%arg0: f32) -> f32 {
+  %nan = arith.constant 0x7FC00000 : f32
+  %c = arith.divf %nan, %arg0 : f32
+  return %c : f32
+}
+
+func @f2(%arg0: f32) -> f32 {
+  %nan = arith.constant 0x7FC00000 : f32
+  %c = arith.divf %arg0, %nan : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/nan_div.tgt.mlir
+++ b/tests/litmus/fp-ops/nan_div.tgt.mlir
@@ -1,0 +1,9 @@
+func @f1(%arg0: f32) -> f32 {
+  %nan = arith.constant 0x7FC00000 : f32
+  return %nan: f32
+}
+
+func @f2(%arg0: f32) -> f32 {
+  %nan = arith.constant 0x7FC00000 : f32
+  return %nan: f32
+}

--- a/tests/litmus/fp-ops/zero_div_const.src.mlir
+++ b/tests/litmus/fp-ops/zero_div_const.src.mlir
@@ -1,0 +1,8 @@
+// VERIFY
+
+func @f() -> f32 {
+  %inf = arith.constant 0x7F800000 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.divf %inf, %v : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/zero_div_const.tgt.mlir
+++ b/tests/litmus/fp-ops/zero_div_const.tgt.mlir
@@ -1,0 +1,4 @@
+func @f() -> f32 {
+  %c = arith.constant 0x7F800000 : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/zero_div_zero.src.mlir
+++ b/tests/litmus/fp-ops/zero_div_zero.src.mlir
@@ -1,0 +1,8 @@
+// VERIFY
+
+func @f() -> f32 {
+  %zero_p = arith.constant 0.0 : f32
+  %zero_n = arith.constant -0.0 : f32
+  %c = arith.divf %zero_p, %zero_n : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/zero_div_zero.tgt.mlir
+++ b/tests/litmus/fp-ops/zero_div_zero.tgt.mlir
@@ -1,0 +1,4 @@
+func @f() -> f32 {
+  %c = arith.constant 0x7FC00000 : f32
+  return %c : f32
+}


### PR DESCRIPTION
This PR implements abstract FP division (aka `smt::Expr AbsFpEncoding::div()`)
- If one or more operand of div is NaN, it yields NaN as well.
- 0.0 / 0.0 and Inf / Inf yields NaN.
- finite x / Inf yields 0.0
- Inf / finite x yields Inf
- Finite x / 0.0 yields Inf.  
This is division by zero and signaling exception should be raised according to IEEE754 standard, but LLVM ignores the signal and continues the execution. We follow this semantics as well.
- Otherwise, it yields an arbitrary BV with appropriate sign.
- Litmus tests are added to verify the above behaviors