### PR TITLE
Implement precise FP rounding

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -427,9 +427,9 @@ void AbsFpEncoding::addConstants(const set<llvm::APFloat>& const_set) {
       }
     }
 
-    Expr e_pos = Expr::mkBV(0, SIGN_BITS).concat(e_value).simplify();
+    Expr e_pos = Expr::mkBV(0, SIGN_BITS).concat(e_value);
     fpconst_absrepr.emplace(fp_const, e_pos);
-    Expr e_neg = Expr::mkBV(1, SIGN_BITS).concat(e_value).simplify();
+    Expr e_neg = Expr::mkBV(1, SIGN_BITS).concat(e_value);
     fpconst_absrepr.emplace(-fp_const, e_neg);
   }
 }

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -310,7 +310,7 @@ FnDecl AbsFpEncoding::getExtendFn(const AbsFpEncoding &tgt) {
 
 FnDecl AbsFpEncoding::getTruncateFn(const AbsFpEncoding &tgt) {
   if (!fp_truncatefn) {
-    auto src_fty = sort();
+    auto src_fty = Sort::bvSort(fp_bitwidth);
     auto tgt_fty = Sort::bvSort(tgt.fp_bitwidth);
     fp_truncatefn.emplace({src_fty}, tgt_fty, "fp_truncate_" + fn_suffix);
   }

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -61,6 +61,7 @@ FnDecl getIntDotFn(unsigned bitwidth) {
 struct FPCastingInfo {
   bool zero_limit_bits;
   bool zero_prec_bits;
+  bool is_rounded_upward;
 };
 optional<FPCastingInfo> getCastingInfo(llvm::APFloat fp_const) {
   auto semantics = llvm::APFloat::SemanticsToEnum(fp_const.getSemantics());
@@ -68,16 +69,24 @@ optional<FPCastingInfo> getCastingInfo(llvm::APFloat fp_const) {
   if (semantics == llvm::APFloat::Semantics::S_IEEEsingle) {
     return nullopt;
   } else if (semantics == llvm::APFloat::Semantics::S_IEEEdouble) {
+    auto fp_const_floor = fp_const;
+    fp_const_floor.convert(llvm::APFloat::IEEEsingle(),
+                      // floor to analyze rounding direction
+                      llvm::APFloat::rmTowardZero, &lost_info);
+
     auto op_status = fp_const.convert(llvm::APFloat::IEEEsingle(),
-                    // floor in case of truncation (ordering issue)
-                    llvm::APFloat::rmTowardZero, &lost_info);
+                      // round to correctly analyze overflow
+                      llvm::APFloat::rmNearestTiesToEven, &lost_info);
     if (op_status & llvm::APFloat::opOverflow) {
       zero_limit_bits = false;
     }
     bool zero_prec_bits = !lost_info;
-    return FPCastingInfo{zero_limit_bits, zero_prec_bits};
+    bool is_rounded_upward = (fp_const_floor != fp_const);
+
+    return FPCastingInfo {zero_limit_bits, zero_prec_bits, is_rounded_upward};
   } else {
-    throw UnsupportedException("Cannot analyze casting information for this type");
+    throw UnsupportedException(
+      "Cannot analyze casting information for this type");
   }
 }
 }
@@ -99,6 +108,10 @@ void setAbstraction(
   isFpAddAssociative = addAssoc;
 
   // without suffix f, it will become llvm::APFloat with double semantics
+  // Note that 0.0 and 1.0 may already have been added during analysis.
+  // 0.0 and 1.0 are necessary to prove several arithmetic properties,
+  // so we're manually inserting 0.0 and 1.0
+  // just in case they are not added during the analysis.
   floatConsts.emplace(0.0f);
   floatConsts.emplace(1.0f);
   doubleConsts.emplace(0.0);
@@ -134,8 +147,8 @@ void setAbstraction(
     const_max_nonzero_precs = max(const_nonzero_precs, const_max_nonzero_precs);
 
     // all double variables may have same SVB but have different PBs
-    const unsigned min_prec_bitwidth =
-        max(log2_ceil(doubleNonConstsCnt), log2_ceil(const_max_nonzero_precs));
+    const unsigned min_prec_bitwidth = max((uint64_t)1,
+      max(log2_ceil(const_max_nonzero_precs), log2_ceil(doubleNonConstsCnt)));
 
     // Decide min_limit_bitwidth.
     // We're not going to simply use log2(consts_nonzero_limit) as limit bit
@@ -183,6 +196,8 @@ void setEncodingOptions(bool use_multiset) {
 
 bool getFpAddAssociativity() { return isFpAddAssociative; }
 
+bool getFpCastIsPrecise() { return alFpCast == AbsLevelFpCast::PRECISE; }
+
 AbsFpEncoding &getFloatEncoding() { return *floatEnc; }
 AbsFpEncoding &getDoubleEncoding() { return *doubleEnc; }
 AbsFpEncoding &getFpEncoding(mlir::Type ty) {
@@ -197,7 +212,8 @@ AbsFpEncoding &getFpEncoding(mlir::Type ty) {
 AbsFpEncoding::AbsFpEncoding(const llvm::fltSemantics &semantics,
       unsigned limit_bw, unsigned smaller_value_bw, unsigned prec_bw,
        std::string &&fn_suffix)
-     :semantics(semantics), fn_suffix(move(fn_suffix)) {
+     :semantics(semantics), fn_suffix(move(fn_suffix)),
+      fpTruncatePrecondition(Expr::mkBool(true)) {
   assert(smaller_value_bw > 0);
   // BWs for casting
   value_bit_info = { limit_bw, smaller_value_bw, prec_bw };
@@ -334,8 +350,7 @@ uint64_t AbsFpEncoding::getSignBit() const {
 }
 
 void AbsFpEncoding::addConstants(const set<llvm::APFloat>& const_set) {
-  // 0 is reserved for zero
-  uint64_t value_id = 1;
+  uint64_t value_id = 0;
   // prec_offset_map[smaller value]: next precision bit
   map<uint64_t, uint64_t> prec_offset_map;
 
@@ -348,14 +363,15 @@ void AbsFpEncoding::addConstants(const set<llvm::APFloat>& const_set) {
       continue;
     }
 
-    unsigned limit_value_bitwidth =
+    const unsigned limit_value_bitwidth =
         value_bit_info.limit_bitwidth + value_bit_info.smaller_value_bitwidth;
-    Expr e_value = Expr::mkBV(value_id, limit_value_bitwidth);
+    Expr e_value = Expr::mkBV(value_id, limit_value_bitwidth); // dummy
 
     if (value_bit_info.limit_bitwidth == 0 &&
         value_bit_info.prec_bitwidth == 0) {
       // this encoding is the smallest encoding or does not support casting
       value_id += 1;
+      e_value = Expr::mkBV(value_id, limit_value_bitwidth);
     } else {
       auto casting_info = getCastingInfo(fp_const);
       assert(casting_info.has_value() &&
@@ -364,13 +380,13 @@ void AbsFpEncoding::addConstants(const set<llvm::APFloat>& const_set) {
       if (!casting_info->zero_limit_bits) {
         // these values should be mapped to Inf when truncated.
         // In the higher precision, freshly start value_id with limit bit set
-        unsigned value_prec_bitwidth = 
+        const unsigned value_prec_bitwidth = 
           value_bit_info.smaller_value_bitwidth + value_bit_info.prec_bitwidth;
         value_id = max(value_id, (uint64_t)1 << value_prec_bitwidth);
         e_value = Expr::mkBV(value_id, value_bitwidth);
         value_id += 1;
       } else if (!casting_info->zero_prec_bits) {
-        // this value will be *floored* to same value,
+        // this value will be rounded to same value,
         // so do not change smaller_value and increment prec bit.
         auto itr = prec_offset_map.insert({value_id, 1}).first;
         uint64_t prec = itr->second;
@@ -380,21 +396,22 @@ void AbsFpEncoding::addConstants(const set<llvm::APFloat>& const_set) {
         // Increase the next precision bit.
         itr->second++;
       } else {
+        // this value will be rounded to different value,
+        // so assign different smaller_value
+        value_id += 1;
+        e_value = Expr::mkBV(value_id, limit_value_bitwidth);
+
         // this encoding may not have prec bits
         if (value_bit_info.prec_bitwidth > 0) {
           Expr e_prec = Expr::mkBV(0, value_bit_info.prec_bitwidth);
           e_value = e_value.concat(e_prec);
         }
-
-        // this value will be *floored* to different value,
-        // so assign different smaller_value
-        value_id += 1;
       }
     }
 
-    Expr e_pos = Expr::mkBV(0, SIGN_BITS).concat(e_value);
+    Expr e_pos = Expr::mkBV(0, SIGN_BITS).concat(e_value).simplify();
     fpconst_absrepr.emplace(fp_const, e_pos);
-    Expr e_neg = Expr::mkBV(1, SIGN_BITS).concat(e_value);
+    Expr e_neg = Expr::mkBV(1, SIGN_BITS).concat(e_value).simplify();
     fpconst_absrepr.emplace(-fp_const, e_neg);
   }
 }
@@ -754,37 +771,38 @@ Expr AbsFpEncoding::extend(const smt::Expr &f, aop::AbsFpEncoding &tgt) {
 Expr AbsFpEncoding::truncate(const smt::Expr &f, aop::AbsFpEncoding &tgt) {
   usedOps.fpCastRound = true;
 
-  if (value_bit_info.limit_bitwidth == 0 && value_bit_info.prec_bitwidth == 0) {
-    // Fully abstract encoding 
-    return getExtendFn(tgt).apply(f);
-  }
-
-  assert(value_bitwidth > tgt.value_bitwidth &&
+  if (getFpCastIsPrecise()) {
+    assert(value_bitwidth > tgt.value_bitwidth &&
          "tgt cannot have bigger value_bitwidth than src");
 
-  if (tgt.value_bit_info.limit_bitwidth != 0 || tgt.value_bit_info.prec_bitwidth != 0)
-    throw UnsupportedException("Truncating from large-size type to middle-size "
-        "type is not supported");
+    if (tgt.value_bit_info.limit_bitwidth != 0 ||
+          tgt.value_bit_info.prec_bitwidth != 0)
+      throw UnsupportedException(
+        "Truncating from large-size type to middle-size type is not supported");
 
-  auto sign_bit = f.extract(fp_bitwidth - 1, value_bitwidth);
-  auto sign_pos = Expr::mkBV(0, SIGN_BITS);
-  auto value_bits = f.extract(value_bitwidth - 1, 0);
-  auto limit_bits = value_bits.extract(
-    value_bitwidth - 1, value_bitwidth - value_bit_info.limit_bitwidth);
-  auto limit_zero = Expr::mkBV(0, value_bit_info.limit_bitwidth);
+    auto sign_bit = f.extract(fp_bitwidth - 1, value_bitwidth);
+    auto sign_pos = Expr::mkBV(0, SIGN_BITS);
+    auto value_bits = f.extract(value_bitwidth - 1, 0);
+    auto limit_bits = value_bits.extract(
+      value_bitwidth - 1, value_bitwidth - value_bit_info.limit_bitwidth);
+    auto limit_zero = Expr::mkBV(0, value_bit_info.limit_bitwidth);
 
-  auto truncated_float = value_bits.extract(
-      value_bitwidth - 1 - value_bit_info.limit_bitwidth,
-      value_bit_info.prec_bitwidth);
-  truncated_float = sign_bit.concat(truncated_float);
-  assert(truncated_float.bitwidth() == tgt.sort().bitwidth());
-  
-  return Expr::mkIte(isnan(f), tgt.nan(),
-      Expr::mkIte(f == infinity(), tgt.infinity(),
-      Expr::mkIte(f == infinity(true), tgt.infinity(true),
-      Expr::mkIte(limit_bits != limit_zero,
-        Expr::mkIte(sign_bit == sign_pos, tgt.infinity(), tgt.infinity(true)),
-        truncated_float.simplify()))));
+    const auto floored_small_value = value_bits.extract(
+        value_bitwidth - 1 - value_bit_info.limit_bitwidth,
+        value_bit_info.prec_bitwidth);
+    const auto ceiled_small_value = floored_small_value + 1;
+    const auto floored_float = sign_bit.concat(floored_small_value);
+    const auto ceiled_float = sign_bit.concat(ceiled_small_value);
+    assert(floored_float.bitwidth() == tgt.sort().bitwidth());
+
+    fpTruncatePrecondition &= Expr::mkIte(
+        isnan(f) | f == infinity() | f == infinity(true),
+        Expr::mkBool(true),
+        (getTruncateFn(tgt).apply(f) == floored_float.simplify()) ^
+            (getTruncateFn(tgt).apply(f) == ceiled_float.simplify()));
+  }
+
+  return getTruncateFn(tgt).apply(f);
 }
 
 Expr AbsFpEncoding::getFpAssociativePrecondition() {
@@ -831,7 +849,43 @@ Expr AbsFpEncoding::getFpAssociativePrecondition() {
   return precond;
 }
 
+Expr AbsFpEncoding::getFpTruncatePrecondition(aop::AbsFpEncoding &tgt) {
+  const unsigned int small_value_msb =
+      value_bitwidth - value_bit_info.limit_bitwidth - 1;
+  const unsigned int small_value_lsb =
+      small_value_msb - value_bit_info.smaller_value_bitwidth + 1;
+  const Expr sign_true = Expr::mkBV(1, SIGN_BITS);
 
+  Expr precond = fpTruncatePrecondition;
+  // Handle constants not in absrepr
+  precond &= (getTruncateFn(tgt).apply({nan()}) == tgt.nan());
+  precond &= (getTruncateFn(tgt).apply({infinity()}) == tgt.infinity());
+  precond &= (getTruncateFn(tgt).apply({infinity(true)}) == tgt.infinity(true));
+  precond &= (getTruncateFn(tgt).apply({zero()}) == tgt.zero());
+  precond &= (getTruncateFn(tgt).apply({zero(true)}) == tgt.zero(true));
+
+  for (auto &[fp, absrepr] : fpconst_absrepr) {
+    auto casting_info = *getCastingInfo(fp);
+    if (!casting_info.zero_limit_bits) {
+      precond &= (getTruncateFn(tgt).apply({absrepr}) == 
+        Expr::mkIte(absrepr.getMSB() == sign_true,
+          tgt.infinity(true), tgt.infinity()));
+    } else {
+      Expr rounded_abs_value =
+          absrepr.extract(small_value_msb, small_value_lsb).simplify();
+      if (casting_info.is_rounded_upward) {
+        rounded_abs_value = rounded_abs_value + 1;
+      }
+
+      const Expr rounded_value =
+        absrepr.getMSB().concat(rounded_abs_value).simplify();
+      precond &= (getTruncateFn(tgt).apply({absrepr}) == rounded_value);
+    }
+  }
+
+  precond = precond.simplify();
+  return precond;
+}
 
 Expr getFpAssociativePrecondition() {
   // Calling this function doesn't make sense if add is not associative
@@ -861,6 +915,15 @@ Expr getFpUltPrecondition() {
   }
   // TODO: double
 
+  return cond;
+}
+
+Expr getFpTruncatePrecondition() {
+  // Calling this function doesn't make sense if casting is imprecise
+  assert(alFpCast == AbsLevelFpCast::PRECISE);
+
+  // if alFpCast is true, floatEnc and doubleEnc will exist
+  Expr cond = doubleEnc->getFpTruncatePrecondition(*floatEnc);
   return cond;
 }
 

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -120,9 +120,8 @@ private:
   std::optional<smt::FnDecl> fp_truncatefn;
   std::optional<smt::FnDecl> fp_expfn;
   std::optional<smt::FnDecl> fp_hashfn;
+  std::optional<smt::FnDecl> fp_rounddirfn;
   std::string fn_suffix;
-
-  smt::Expr fpTruncatePrecondition;
 
 private:
   AbsFpEncoding(const llvm::fltSemantics &semantics,
@@ -160,6 +159,7 @@ private:
   smt::FnDecl getTruncateFn(const AbsFpEncoding &tgt);
   smt::FnDecl getExpFn();
   smt::FnDecl getHashFnForAddAssoc();
+  smt::FnDecl getRoundDirFn();
 
   size_t getHashRangeBits() const;
   uint64_t getSignBit() const;

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -54,7 +54,9 @@ void setAbstraction(AbsLevelFpDot, AbsLevelFpCast, AbsLevelIntDot,
 void setEncodingOptions(bool useMultiset);
 
 bool getFpAddAssociativity();
+bool getFpCastIsPrecise();
 
+smt::Expr getFpTruncatePrecondition();
 smt::Expr getFpAssociativePrecondition();
 smt::Expr getFpUltPrecondition();
 
@@ -109,6 +111,8 @@ private:
   std::optional<smt::FnDecl> fp_expfn;
   std::optional<smt::FnDecl> fp_hashfn;
   std::string fn_suffix;
+
+  smt::Expr fpTruncatePrecondition;
 
 private:
   AbsFpEncoding(const llvm::fltSemantics &semantics,
@@ -172,6 +176,7 @@ public:
   smt::Expr extend(const smt::Expr &f, aop::AbsFpEncoding &tgt);
   smt::Expr truncate(const smt::Expr &f, aop::AbsFpEncoding &tgt);
   smt::Expr getFpAssociativePrecondition();
+  smt::Expr getFpTruncatePrecondition(aop::AbsFpEncoding &tgt);
 
 private:
   smt::Expr lambdaSum(const smt::Expr &a, const smt::Expr &n);

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -27,8 +27,8 @@ static void analyzeAPFloat(
     // They will be specially treated in setAbstraction() (abstractops.cpp)
     return;
 
-  auto val_f32 = val;
-  auto val_f64 = val;
+  auto val_f32_floor = val, val_f32_round = val;
+  auto val_f64 = val, val_f64_floor = val, val_f64_round = val;
   bool lost_info; // dummy
 
   llvm::APFloat::opStatus op_status;
@@ -37,21 +37,42 @@ static void analyzeAPFloat(
                     // doesn't really matter in extension
                     llvm::APFloat::rmTowardZero, &lost_info);
   } else if (ty.isF64()) {
-    op_status = val_f32.convert(llvm::APFloat::IEEEsingle(),
-                    // floor in case of truncation (ordering issue)
-                    llvm::APFloat::rmTowardZero, &lost_info);
+    op_status = val_f32_round.convert(llvm::APFloat::IEEEsingle(),
+                    // round for correct analysis
+                    llvm::APFloat::rmNearestTiesToEven, &lost_info);
+    val_f32_floor.convert(llvm::APFloat::IEEEsingle(),
+                          // floor for correct BV mapping (ordering issue)
+                          llvm::APFloat::rmTowardZero, &lost_info);
   } else {
-      throw UnsupportedException(ty, "Unsupported type");
+    throw UnsupportedException(ty, "Unsupported type");
   }
 
-  if (val_f32.isNegative())
-    val_f32.clearSign();
-  if (val_f64.isNegative())
+  val_f64_round = val_f32_round;
+  val_f64_round.convert(llvm::APFloat::IEEEdouble(),
+                        // doesn't really matter in extension
+                        llvm::APFloat::rmTowardZero, &lost_info);
+  val_f64_floor = val_f32_floor;
+  val_f64_floor.convert(llvm::APFloat::IEEEdouble(),
+                        // doesn't really matter in extension
+                        llvm::APFloat::rmTowardZero, &lost_info);
+
+  // Signs are preserved regardless of the conversion
+  if (val_f64.isNegative()) {
+    val_f32_round.clearSign();
+    val_f32_floor.clearSign();
     val_f64.clearSign();
+    val_f64_round.clearSign();
+    val_f64_floor.clearSign();
+  }
 
   // Values beyond the float range are mapped to Inf
   if (!(op_status & llvm::APFloat::opOverflow)) {
-    res.F32.constSet.insert(val_f32);
+    res.F32.constSet.insert(val_f32_round);
+    res.F32.constSet.insert(val_f32_floor);
+    // Rounded and floored values should be added to F64 as well
+    // for correct mapping
+    res.F64.constSet.insert(val_f64_round);
+    res.F64.constSet.insert(val_f64_floor);
   }
   res.F64.constSet.insert(val_f64);
 }

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -27,8 +27,8 @@ static void analyzeAPFloat(
     // They will be specially treated in setAbstraction() (abstractops.cpp)
     return;
 
-  auto val_f32_floor = val, val_f32_round = val;
-  auto val_f64 = val, val_f64_floor = val, val_f64_round = val;
+  auto val_f32_round = val, val_f32_floor = val, val_f32_ceil = val;
+  auto val_f64 = val, val_f64_floor = val, val_f64_ceil = val;
   bool lost_info; // dummy
 
   llvm::APFloat::opStatus op_status;
@@ -43,35 +43,42 @@ static void analyzeAPFloat(
     val_f32_floor.convert(llvm::APFloat::IEEEsingle(),
                           // floor for correct BV mapping (ordering issue)
                           llvm::APFloat::rmTowardZero, &lost_info);
+    // ceiled value should also be added
+    // as unknown variable(s) may have to be rounded upward
+    if (val.isNegative()) {
+      val_f32_ceil.convert(llvm::APFloat::IEEEsingle(),
+                          llvm::APFloat::rmTowardNegative, &lost_info);
+    } else {
+      val_f32_ceil.convert(llvm::APFloat::IEEEsingle(),
+                          llvm::APFloat::rmTowardPositive, &lost_info);
+    }
   } else {
     throw UnsupportedException(ty, "Unsupported type");
   }
 
-  val_f64_round = val_f32_round;
-  val_f64_round.convert(llvm::APFloat::IEEEdouble(),
+  // clear signs, as constSet only includes positive FPs
+  if (val_f64.isNegative()) {
+    val_f32_floor.clearSign();
+    val_f32_ceil.clearSign();
+    val_f64.clearSign();
+  }
+
+  val_f64_ceil = val_f32_ceil;
+  val_f64_ceil.convert(llvm::APFloat::IEEEdouble(),
                         // doesn't really matter in extension
                         llvm::APFloat::rmTowardZero, &lost_info);
   val_f64_floor = val_f32_floor;
   val_f64_floor.convert(llvm::APFloat::IEEEdouble(),
                         // doesn't really matter in extension
-                        llvm::APFloat::rmTowardZero, &lost_info);
-
-  // Signs are preserved regardless of the conversion
-  if (val_f64.isNegative()) {
-    val_f32_round.clearSign();
-    val_f32_floor.clearSign();
-    val_f64.clearSign();
-    val_f64_round.clearSign();
-    val_f64_floor.clearSign();
-  }
+                        llvm::APFloat::rmTowardZero, &lost_info);  
 
   // Values beyond the float range are mapped to Inf
   if (!(op_status & llvm::APFloat::opOverflow)) {
-    res.F32.constSet.insert(val_f32_round);
+    res.F32.constSet.insert(val_f32_ceil);
     res.F32.constSet.insert(val_f32_floor);
-    // Rounded and floored values should be added to F64 as well
-    // for correct mapping
-    res.F64.constSet.insert(val_f64_round);
+    // Ceiled and floored values should be added to F64 as well
+    // to map values correctly between different precisions
+    res.F64.constSet.insert(val_f64_ceil);
     res.F64.constSet.insert(val_f64_floor);
   }
   res.F64.constSet.insert(val_f64);

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -664,6 +664,7 @@ EXPR_BVOP_UINT64(operator^)
 Expr Expr::operator^(const Expr &rhs) const {
   Expr e;
   SET_Z3_USEOP(e, rhs, operator^);
+  // TOFIX: ^ may be bool!
   SET_CVC5_USEOP(e, rhs, BITVECTOR_XOR);
   return e;
 }

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -664,7 +664,6 @@ EXPR_BVOP_UINT64(operator^)
 Expr Expr::operator^(const Expr &rhs) const {
   Expr e;
   SET_Z3_USEOP(e, rhs, operator^);
-  // TOFIX: ^ may be bool!
   SET_CVC5_USEOP(e, rhs, BITVECTOR_XOR);
   return e;
 }

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -379,6 +379,9 @@ static tuple<State, State, Expr> encodeFinalStates(
   if(aop::getUsedAbstractOps().fpUlt)
     preconds.push_back(aop::getFpUltPrecondition());
 
+  if (aop::getFpCastIsPrecise())
+    preconds.push_back(aop::getFpTruncatePrecondition());
+
   Expr precond =
       exprAnd(preconds) & st_src.precondition() & st_tgt.precondition();
   precond = precond.simplify();

--- a/tests/litmus/fp-ops/trunc_const_rounding.src.mlir
+++ b/tests/litmus/fp-ops/trunc_const_rounding.src.mlir
@@ -1,0 +1,13 @@
+// VERIFY
+
+func @ceil() -> f32 {
+  %a = arith.constant 3.0000002 : f64
+  %t = arith.truncf %a: f64 to f32
+  return %t: f32
+}
+
+func @floor() -> f32 {
+  %a = arith.constant 3.0000001 : f64
+  %t = arith.truncf %a: f64 to f32
+  return %t: f32
+}

--- a/tests/litmus/fp-ops/trunc_const_rounding.tgt.mlir
+++ b/tests/litmus/fp-ops/trunc_const_rounding.tgt.mlir
@@ -1,0 +1,9 @@
+func @ceil() -> f32 {
+  %a = arith.constant 3.00000023842 : f32
+  return %a: f32
+}
+
+func @floor() -> f32 {
+  %a = arith.constant 3.0 : f32
+  return %a: f32
+}

--- a/tests/litmus/fp-ops/trunc_const_to_inf.src.mlir
+++ b/tests/litmus/fp-ops/trunc_const_to_inf.src.mlir
@@ -1,0 +1,7 @@
+// VERIFY
+
+func @f() -> f32 {
+  %a = arith.constant 3.4028236e+38 : f64
+  %t = arith.truncf %a: f64 to f32
+  return %t: f32
+}

--- a/tests/litmus/fp-ops/trunc_const_to_inf.tgt.mlir
+++ b/tests/litmus/fp-ops/trunc_const_to_inf.tgt.mlir
@@ -1,0 +1,4 @@
+func @f() -> f32 {
+  %a = arith.constant 0x7F800000 : f32
+  return %a: f32
+}


### PR DESCRIPTION
This PR implements precondition-based rounding FP truncation.

- The values being truncated are now properly 'rounded' instead of being 'floored`.
- FP truncation is now implemented based on UF and preconditions
  - FP constant analysis adds preconditions, which limits the possible value of each truncated constant to a single value
  - `AbsFpEncoding::truncate()` adds preconditions, which limits the possible value of each truncated variable to 'floored' and 'ceiled' value. 
  - In case there are more than one possible truncation result, other preconditions may be added in the future to choose one of them.
- Fixed several bugs in previous truncation behaviors
- Litmus tests are added to verify the behaviors described above