### PR TITLE
Catch up with MLIR API update

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1153,7 +1153,7 @@ void encodeOp(State &st, mlir::linalg::InitTensorOp op, bool) {
 }
 
 template<>
-void encodeOp(State &st, mlir::linalg::TensorCollapseShapeOp op, bool) {
+void encodeOp(State &st, mlir::tensor::CollapseShapeOp op, bool) {
   Tensor t = st.regs.get<Tensor>(op.getOperand());
   mlir::RankedTensorType resTy = op.getResultType();
 
@@ -1183,7 +1183,7 @@ void encodeOp(State &st, mlir::linalg::TensorCollapseShapeOp op, bool) {
 }
 
 template<>
-void encodeOp(State &st, mlir::linalg::TensorExpandShapeOp op, bool) {
+void encodeOp(State &st, mlir::tensor::ExpandShapeOp op, bool) {
   Tensor t = st.regs.get<Tensor>(op.getOperand());
 
   // The fresh variables created by ShapedValue::getDims will be ignored
@@ -2617,8 +2617,6 @@ static void encodeBlock(
     ENCODE(st, op, mlir::linalg::InitTensorOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::linalg::MatmulOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::linalg::PadTensorOp, encodeMemWriteOps);
-    ENCODE(st, op, mlir::linalg::TensorCollapseShapeOp, encodeMemWriteOps);
-    ENCODE(st, op, mlir::linalg::TensorExpandShapeOp, encodeMemWriteOps);
     
     ENCODE(st, op, mlir::shape::ShapeOfOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::shape::ToExtentTensorOp, encodeMemWriteOps);
@@ -2633,6 +2631,8 @@ static void encodeBlock(
     ENCODE(st, op, mlir::tensor::FromElementsOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::tensor::GenerateOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::tensor::InsertSliceOp, encodeMemWriteOps);
+    ENCODE(st, op, mlir::tensor::CollapseShapeOp, encodeMemWriteOps);
+    ENCODE(st, op, mlir::tensor::ExpandShapeOp, encodeMemWriteOps);
 
     ENCODE(st, op, mlir::tosa::AbsOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::tosa::AddOp, encodeMemWriteOps);

--- a/tests/litmus/linalg-loops/sum-assoc-bad.src.mlir
+++ b/tests/litmus/linalg-loops/sum-assoc-bad.src.mlir
@@ -16,7 +16,7 @@ func @sum(%mat: tensor<100x100xf32>) -> tensor<f32>
   } -> tensor<100x100xf32>
 
 
-  %mat_col = linalg.tensor_collapse_shape %mat_transposed [[0, 1]] : tensor<100x100xf32> into tensor<10000xf32>
+  %mat_col = tensor.collapse_shape %mat_transposed [[0, 1]] : tensor<100x100xf32> into tensor<10000xf32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,
                        affine_map<(d0) -> ()>],

--- a/tests/litmus/linalg-loops/sum-assoc-bad.tgt.mlir
+++ b/tests/litmus/linalg-loops/sum-assoc-bad.tgt.mlir
@@ -5,7 +5,7 @@ func @sum(%mat0: tensor<100x100xf32>) -> tensor<f32>
   %i2 = arith.constant 2: index
   %mat = tensor.insert %c0 into %mat0[%i0,%i2]: tensor<100x100xf32>
   %outty = linalg.init_tensor [] : tensor<f32>
-  %mat_col = linalg.tensor_collapse_shape %mat [[0, 1]] : tensor<100x100xf32> into tensor<10000xf32>
+  %mat_col = tensor.collapse_shape %mat [[0, 1]] : tensor<100x100xf32> into tensor<10000xf32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,
                        affine_map<(d0) -> ()>],

--- a/tests/litmus/linalg-loops/sum-assoc.src.mlir
+++ b/tests/litmus/linalg-loops/sum-assoc.src.mlir
@@ -16,7 +16,7 @@ func @sum(%mat: tensor<100x100xf32>) -> tensor<f32>
   } -> tensor<100x100xf32>
 
 
-  %mat_col = linalg.tensor_collapse_shape %mat_transposed [[0, 1]] : tensor<100x100xf32> into tensor<10000xf32>
+  %mat_col = tensor.collapse_shape %mat_transposed [[0, 1]] : tensor<100x100xf32> into tensor<10000xf32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,
                        affine_map<(d0) -> ()>],

--- a/tests/litmus/linalg-loops/sum-assoc.tgt.mlir
+++ b/tests/litmus/linalg-loops/sum-assoc.tgt.mlir
@@ -4,7 +4,7 @@ func @sum(%mat: tensor<100x100xf32>) -> tensor<f32>
   %i0 = arith.constant 0: index
   %i2 = arith.constant 2: index
   %outty = linalg.init_tensor [] : tensor<f32>
-  %mat_col = linalg.tensor_collapse_shape %mat [[0, 1]] : tensor<100x100xf32> into tensor<10000xf32>
+  %mat_col = tensor.collapse_shape %mat [[0, 1]] : tensor<100x100xf32> into tensor<10000xf32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,
                        affine_map<(d0) -> ()>],

--- a/tests/litmus/linalg-ops/tensor_expand_shape.src.mlir
+++ b/tests/litmus/linalg-ops/tensor_expand_shape.src.mlir
@@ -3,6 +3,6 @@
 // tensor_expand_shape raises UB if casting to the dest type is infeasible.
 
 func @f(%arg0 : tensor<?xf32>) -> tensor<?x2xf32> {
-	%v = linalg.tensor_expand_shape %arg0 [[0, 1]] : tensor<?xf32> into tensor<?x2xf32>
+	%v = tensor.expand_shape %arg0 [[0, 1]] : tensor<?xf32> into tensor<?x2xf32>
 	return %v: tensor<?x2xf32>
 }

--- a/tests/litmus/linalg-ops/tensor_expand_shape.tgt.mlir
+++ b/tests/litmus/linalg-ops/tensor_expand_shape.tgt.mlir
@@ -1,5 +1,5 @@
 func @f(%arg0 : tensor<?xf32>) -> tensor<?x2xf32> {
-	%dummy = linalg.tensor_expand_shape %arg0 [[0, 1]] : tensor<?xf32> into tensor<?x3xf32>
-	%v = linalg.tensor_expand_shape %arg0 [[0, 1]] : tensor<?xf32> into tensor<?x2xf32>
+	%dummy = tensor.expand_shape %arg0 [[0, 1]] : tensor<?xf32> into tensor<?x3xf32>
+	%v = tensor.expand_shape %arg0 [[0, 1]] : tensor<?xf32> into tensor<?x2xf32>
 	return %v: tensor<?x2xf32>
 }

--- a/tests/litmus/tensor-ops/fold_collapse_collapse.src.mlir
+++ b/tests/litmus/tensor-ops/fold_collapse_collapse.src.mlir
@@ -2,7 +2,7 @@
 
 func @fold_two_collapses(%arg0 : tensor<?x?x?xf32>) -> tensor<?xf32>
 {
-  %f1 = linalg.tensor_collapse_shape %arg0 [[0, 1, 2]]
+  %f1 = tensor.collapse_shape %arg0 [[0, 1, 2]]
       : tensor<?x?x?xf32> into tensor<?xf32>
   return %f1 : tensor<?xf32>
 }

--- a/tests/litmus/tensor-ops/fold_collapse_collapse.tgt.mlir
+++ b/tests/litmus/tensor-ops/fold_collapse_collapse.tgt.mlir
@@ -1,8 +1,8 @@
 func @fold_two_collapses(%arg0 : tensor<?x?x?xf32>) -> tensor<?xf32>
 {
-  %f1 = linalg.tensor_collapse_shape %arg0 [[0, 1], [2]]
+  %f1 = tensor.collapse_shape %arg0 [[0, 1], [2]]
       : tensor<?x?x?xf32> into tensor<?x?xf32>
-  %f2 = linalg.tensor_collapse_shape %f1 [[0, 1]]
+  %f2 = tensor.collapse_shape %f1 [[0, 1]]
       : tensor<?x?xf32> into tensor<?xf32>
   return %f2 : tensor<?xf32>
 }

--- a/tests/litmus/tensor-ops/fold_expand_collapse.src.mlir
+++ b/tests/litmus/tensor-ops/fold_expand_collapse.src.mlir
@@ -2,9 +2,9 @@
 
 func @fold_expand_collapse(%arg0 : tensor<?x4xf32>) -> tensor<?x4xf32>
 {
-  %0 = linalg.tensor_expand_shape %arg0 [[0, 1], [2]]
+  %0 = tensor.expand_shape %arg0 [[0, 1], [2]]
       : tensor<?x4xf32> into tensor<?x3x4xf32>
-  %1 = linalg.tensor_collapse_shape %0 [[0, 1], [2]]
+  %1 = tensor.collapse_shape %0 [[0, 1], [2]]
       : tensor<?x3x4xf32> into tensor<?x4xf32>
   return %1 : tensor<?x4xf32>
 }

--- a/tests/litmus/tosa-ops/reduce_sum-bad.src.mlir
+++ b/tests/litmus/tosa-ops/reduce_sum-bad.src.mlir
@@ -4,6 +4,6 @@
 
 func @f(%t: tensor<3x3x3xf32>) -> tensor<3x3xf32> {
   %0 = "tosa.reduce_sum"(%t) {axis = 0 : i64} : (tensor<3x3x3xf32>) -> tensor<1x3x3xf32>
-  %res = linalg.tensor_collapse_shape %0 [[0, 1], [2]] : tensor<1x3x3xf32> into tensor<3x3xf32>
+  %res = tensor.collapse_shape %0 [[0, 1], [2]] : tensor<1x3x3xf32> into tensor<3x3xf32>
 	return %res: tensor<3x3xf32>
 }

--- a/tests/litmus/tosa-ops/reduce_sum-bad.tgt.mlir
+++ b/tests/litmus/tosa-ops/reduce_sum-bad.tgt.mlir
@@ -1,5 +1,5 @@
 func @f(%t: tensor<3x3x3xf32>) -> tensor<3x3xf32> {
   %0 = "tosa.reduce_sum"(%t) {axis = 1 : i64} : (tensor<3x3x3xf32>) -> tensor<3x1x3xf32>
-  %res = linalg.tensor_collapse_shape %0 [[0, 1], [2]] : tensor<3x1x3xf32> into tensor<3x3xf32>
+  %res = tensor.collapse_shape %0 [[0, 1], [2]] : tensor<3x1x3xf32> into tensor<3x3xf32>
 	return %res: tensor<3x3xf32>
 }

--- a/tests/litmus/tosa-ops/reduce_sum_int-bad.src.mlir
+++ b/tests/litmus/tosa-ops/reduce_sum_int-bad.src.mlir
@@ -4,6 +4,6 @@
 
 func @f(%t: tensor<3x3x3xi32>) -> tensor<3x3xi32> {
   %0 = "tosa.reduce_sum"(%t) {axis = 0 : i64} : (tensor<3x3x3xi32>) -> tensor<1x3x3xi32>
-  %res = linalg.tensor_collapse_shape %0 [[0, 1], [2]] : tensor<1x3x3xi32> into tensor<3x3xi32>
+  %res = tensor.collapse_shape %0 [[0, 1], [2]] : tensor<1x3x3xi32> into tensor<3x3xi32>
 	return %res: tensor<3x3xi32>
 }

--- a/tests/litmus/tosa-ops/reduce_sum_int-bad.tgt.mlir
+++ b/tests/litmus/tosa-ops/reduce_sum_int-bad.tgt.mlir
@@ -1,5 +1,5 @@
 func @f(%t: tensor<3x3x3xi32>) -> tensor<3x3xi32> {
   %0 = "tosa.reduce_sum"(%t) {axis = 1 : i64} : (tensor<3x3x3xi32>) -> tensor<3x1x3xi32>
-  %res = linalg.tensor_collapse_shape %0 [[0, 1], [2]] : tensor<3x1x3xi32> into tensor<3x3xi32>
+  %res = tensor.collapse_shape %0 [[0, 1], [2]] : tensor<3x1x3xi32> into tensor<3x3xi32>
 	return %res: tensor<3x3xi32>
 }

--- a/tests/long-opts/conv2d-to-img2col/nhwc_filter-bad.tgt.mlir
+++ b/tests/long-opts/conv2d-to-img2col/nhwc_filter-bad.tgt.mlir
@@ -7,11 +7,11 @@ module  {
     ^bb0(%arg3: f32, %arg4: f32):  // no predecessors
       linalg.yield %arg3 : f32
     } -> tensor<1x14x14x3x3x4xf32>
-    %2 = linalg.tensor_collapse_shape %1 [[0, 1, 2], [3, 4, 5]] : tensor<1x14x14x3x3x4xf32> into tensor<196x36xf32>
-    %3 = linalg.tensor_collapse_shape %arg1 [[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
-    %4 = linalg.tensor_collapse_shape %arg2 [[0, 1, 2], [3]] : tensor<1x14x14x16xf32> into tensor<196x16xf32>
+    %2 = tensor.collapse_shape %1 [[0, 1, 2], [3, 4, 5]] : tensor<1x14x14x3x3x4xf32> into tensor<196x36xf32>
+    %3 = tensor.collapse_shape %arg1 [[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
+    %4 = tensor.collapse_shape %arg2 [[0, 1, 2], [3]] : tensor<1x14x14x16xf32> into tensor<196x16xf32>
     %5 = linalg.matmul ins(%2, %3 : tensor<196x36xf32>, tensor<36x16xf32>) outs(%4 : tensor<196x16xf32>) -> tensor<196x16xf32>
-    %6 = linalg.tensor_expand_shape %5 [[0, 1, 2], [3]] : tensor<196x16xf32> into tensor<1x14x14x16xf32>
+    %6 = tensor.expand_shape %5 [[0, 1, 2], [3]] : tensor<196x16xf32> into tensor<1x14x14x16xf32>
     return %6 : tensor<1x14x14x16xf32>
   }
 }

--- a/tests/opts/conv2d-to-img2col/nhwc_filter.tgt.mlir
+++ b/tests/opts/conv2d-to-img2col/nhwc_filter.tgt.mlir
@@ -10,11 +10,11 @@ module  {
     ^bb0(%arg3: f32, %arg4: f32):  // no predecessors
       linalg.yield %arg3 : f32
     } -> tensor<1x14x14x3x3x4xf32>
-    %2 = linalg.tensor_collapse_shape %1 [[0, 1, 2], [3, 4, 5]] : tensor<1x14x14x3x3x4xf32> into tensor<196x36xf32>
-    %3 = linalg.tensor_collapse_shape %arg1 [[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
-    %4 = linalg.tensor_collapse_shape %arg2 [[0, 1, 2], [3]] : tensor<1x14x14x16xf32> into tensor<196x16xf32>
+    %2 = tensor.collapse_shape %1 [[0, 1, 2], [3, 4, 5]] : tensor<1x14x14x3x3x4xf32> into tensor<196x36xf32>
+    %3 = tensor.collapse_shape %arg1 [[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
+    %4 = tensor.collapse_shape %arg2 [[0, 1, 2], [3]] : tensor<1x14x14x16xf32> into tensor<196x16xf32>
     %5 = linalg.matmul ins(%2, %3 : tensor<196x36xf32>, tensor<36x16xf32>) outs(%4 : tensor<196x16xf32>) -> tensor<196x16xf32>
-    %6 = linalg.tensor_expand_shape %5 [[0, 1, 2], [3]] : tensor<196x16xf32> into tensor<1x14x14x16xf32>
+    %6 = tensor.expand_shape %5 [[0, 1, 2], [3]] : tensor<196x16xf32> into tensor<1x14x14x16xf32>
     return %6 : tensor<1x14x14x16xf32>
   }
 }

--- a/tests/opts/linalg-fold-unit-extent-dims/one-trip-loop.tgt.mlir
+++ b/tests/opts/linalg-fold-unit-extent-dims/one-trip-loop.tgt.mlir
@@ -2,7 +2,7 @@
 module  {
   func @f(%arg0: tensor<1x?x1x1xi32>) -> tensor<1x1xi32> {
     %cst = arith.constant 1 : i32
-    %0 = linalg.tensor_collapse_shape %arg0 [[0, 1, 2, 3]] : tensor<1x?x1x1xi32> into tensor<?xi32>
+    %0 = tensor.collapse_shape %arg0 [[0, 1, 2, 3]] : tensor<1x?x1x1xi32> into tensor<?xi32>
     %1 = linalg.init_tensor [1] : tensor<1xi32>
     %2 = linalg.fill(%cst, %1) : i32, tensor<1xi32> -> tensor<1xi32> 
     %3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%0 : tensor<?xi32>) outs(%2 : tensor<1xi32>) {
@@ -10,7 +10,7 @@ module  {
       %5 = arith.addi %arg1, %arg2 : i32
       linalg.yield %5 : i32
     } -> tensor<1xi32>
-    %4 = linalg.tensor_expand_shape %3 [[0, 1]] : tensor<1xi32> into tensor<1x1xi32>
+    %4 = tensor.expand_shape %3 [[0, 1]] : tensor<1xi32> into tensor<1x1xi32>
     return %4 : tensor<1x1xi32>
   }
 }

--- a/tests/opts/tosa-to-linalg/reduce_sum.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/reduce_sum.tgt.mlir
@@ -10,7 +10,7 @@ module  {
       %4 = arith.addf %arg1, %arg2 : f32
       linalg.yield %4 : f32
     } -> tensor<4x5xf32>
-    %3 = linalg.tensor_expand_shape %2 [[0, 1], [2]] : tensor<4x5xf32> into tensor<1x4x5xf32>
+    %3 = tensor.expand_shape %2 [[0, 1], [2]] : tensor<4x5xf32> into tensor<1x4x5xf32>
     return %3 : tensor<1x4x5xf32>
   }
 }

--- a/tests/opts/tosa-to-linalg/reduce_sum2.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/reduce_sum2.tgt.mlir
@@ -10,7 +10,7 @@ module  {
       %4 = arith.addf %arg1, %arg2 : f32
       linalg.yield %4 : f32
     } -> tensor<3x5xf32>
-    %3 = linalg.tensor_expand_shape %2 [[0, 1], [2]] : tensor<3x5xf32> into tensor<3x1x5xf32>
+    %3 = tensor.expand_shape %2 [[0, 1], [2]] : tensor<3x5xf32> into tensor<3x1x5xf32>
     return %3 : tensor<3x1x5xf32>
   }
 }

--- a/tests/opts/tosa-to-linalg/tile.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/tile.tgt.mlir
@@ -7,13 +7,13 @@ module  {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
       linalg.yield %arg1 : f32
     } -> tensor<2x3x1x3xf32>
-    %2 = linalg.tensor_collapse_shape %1 [[0, 1, 2], [3]] : tensor<2x3x1x3xf32> into tensor<6x3xf32>
+    %2 = tensor.collapse_shape %1 [[0, 1, 2], [3]] : tensor<2x3x1x3xf32> into tensor<6x3xf32>
     %3 = linalg.init_tensor [1, 6, 3, 3] : tensor<1x6x3x3xf32>
     %4 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<6x3xf32>) outs(%3 : tensor<1x6x3x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
       linalg.yield %arg1 : f32
     } -> tensor<1x6x3x3xf32>
-    %5 = linalg.tensor_collapse_shape %4 [[0, 1], [2, 3]] : tensor<1x6x3x3xf32> into tensor<6x9xf32>
+    %5 = tensor.collapse_shape %4 [[0, 1], [2, 3]] : tensor<1x6x3x3xf32> into tensor<6x9xf32>
     return %5 : tensor<6x9xf32>
   }
 }


### PR DESCRIPTION
There has been a breaking change in MLIR API.
* linalg::TensorExpandShapeOp -> tensor::ExpandShapeOp
* linalg::TensorCollapseShapeOp -> tensor::CollapseShapeOp