### PR TITLE
Implement cmpf operator

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -943,7 +943,7 @@ Expr AbsFpEncoding::dot(const Expr &a, const Expr &b, const Expr &n) {
   llvm_unreachable("Unknown abstraction level for fp dot");
 }
 
-Expr AbsFpEncoding::cmp(const CmpPredicate pred,
+Expr AbsFpEncoding::cmp(mlir::arith::CmpFPredicate pred,
                         const Expr &f1, const Expr &f2) {
   const Expr trueBV = Expr::mkBV(1, 1);
   const Expr falseBV = Expr::mkBV(0, 1);
@@ -966,37 +966,37 @@ Expr AbsFpEncoding::cmp(const CmpPredicate pred,
                         trueBV, falseBV))));
 
   switch (pred) {
-  case CmpPredicate::OEQ:
+  case mlir::arith::CmpFPredicate::OEQ:
     return Expr::mkIte(hasNaN, falseBV, cmpEQ);
-  case CmpPredicate::ONE:
+  case mlir::arith::CmpFPredicate::ONE:
     return Expr::mkIte(hasNaN, falseBV, cmpNE);
-  case CmpPredicate::OLE:
+  case mlir::arith::CmpFPredicate::OLE:
     return Expr::mkIte(hasNaN, falseBV, cmpEQ | cmpLT);
-  case CmpPredicate::OLT:
+  case mlir::arith::CmpFPredicate::OLT:
     return Expr::mkIte(hasNaN, falseBV, cmpLT);
-  case CmpPredicate::OGE:
+  case mlir::arith::CmpFPredicate::OGE:
     return Expr::mkIte(hasNaN, falseBV, cmpEQ | cmpGT);
-  case CmpPredicate::OGT:
+  case mlir::arith::CmpFPredicate::OGT:
     return Expr::mkIte(hasNaN, falseBV, cmpGT);
-  case CmpPredicate::UEQ:
+  case mlir::arith::CmpFPredicate::UEQ:
     return Expr::mkIte(hasNaN, trueBV, cmpEQ);
-  case CmpPredicate::UNE:
+  case mlir::arith::CmpFPredicate::UNE:
     return Expr::mkIte(hasNaN, trueBV, cmpNE);
-  case CmpPredicate::ULE:
+  case mlir::arith::CmpFPredicate::ULE:
     return Expr::mkIte(hasNaN, trueBV, cmpEQ | cmpLT);
-  case CmpPredicate::ULT:
+  case mlir::arith::CmpFPredicate::ULT:
     return Expr::mkIte(hasNaN, trueBV, cmpLT);
-  case CmpPredicate::UGE:
+  case mlir::arith::CmpFPredicate::UGE:
     return Expr::mkIte(hasNaN, trueBV, cmpEQ | cmpGT);
-  case CmpPredicate::UGT:
+  case mlir::arith::CmpFPredicate::UGT:
     return Expr::mkIte(hasNaN, trueBV, cmpGT);
-  case CmpPredicate::ORD:
+  case mlir::arith::CmpFPredicate::ORD:
     return Expr::mkIte(hasNaN, falseBV, trueBV);
-  case CmpPredicate::UNO:
+  case mlir::arith::CmpFPredicate::UNO:
     return Expr::mkIte(hasNaN, trueBV, falseBV);
-  case CmpPredicate::TRUE:
+  case mlir::arith::CmpFPredicate::AlwaysTrue:
     return trueBV;
-  case CmpPredicate::FALSE:
+  case mlir::arith::CmpFPredicate::AlwaysFalse:
     return falseBV;
   default:
     throw UnsupportedException("Invalid cmpf predicate");

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -949,11 +949,14 @@ Expr AbsFpEncoding::cmp(mlir::arith::CmpFPredicate pred,
   const Expr falseBV = Expr::mkBV(0, 1);
 
   const Expr hasNaN = isnan(f1) | isnan(f2);
-  const Expr cmpEQ = Expr::mkIte(f1 == f2, trueBV, falseBV);
-  const Expr cmpNE = Expr::mkIte(f1 != f2, trueBV, falseBV);
 
   const Expr f1Sign = getSignBit(f1), f2Sign = getSignBit(f2);
   const Expr f1Magn = getMagnitudeBits(f1), f2Magn = getMagnitudeBits(f2);
+
+  const Expr cmpEQ = Expr::mkIte(f1 == f2 | (f1Magn.isZero() & f2Magn.isZero()),
+                        trueBV, falseBV);
+  const Expr cmpNE = Expr::mkIte(f1 != f2 & !(f1Magn.isZero() & f2Magn.isZero()),
+                        trueBV, falseBV);
   const Expr cmpLT = Expr::mkIte(f1Sign.ugt(f2Sign), trueBV,
                       Expr::mkIte(f1Sign.ult(f2Sign), falseBV,
                       Expr::mkIte(f1Magn == f2Magn, falseBV,

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -8,6 +8,15 @@
 
 namespace aop {
 
+enum class CmpPredicate {
+  // Ordered comparison: 
+  OEQ, ONE, OLE, OLT, OGE, OGT,
+  // Unordered comparison
+  UEQ, UNE, ULE, ULT, UGE, UGT,
+  // ETC
+  ORD, UNO, TRUE, FALSE,
+};
+
 struct UsedAbstractOps {
   // Float ops
   bool fpDot;
@@ -130,7 +139,6 @@ private:
   std::optional<smt::FnDecl> fp_addfn;
   std::optional<smt::FnDecl> fp_mulfn;
   std::optional<smt::FnDecl> fp_divfn;
-  std::optional<smt::FnDecl> fp_ultfn;
   std::optional<smt::FnDecl> fp_extendfn;
   std::optional<smt::FnDecl> fp_truncatefn;
   std::optional<smt::FnDecl> fp_expfn;
@@ -172,7 +180,6 @@ private:
   smt::FnDecl getAssocSumFn();
   smt::FnDecl getSumFn();
   smt::FnDecl getDotFn();
-  smt::FnDecl getUltFn();
   smt::FnDecl getExtendFn(const AbsFpEncoding &tgt);
   smt::FnDecl getTruncateFn(const AbsFpEncoding &tgt);
   smt::FnDecl getExpFn();
@@ -205,9 +212,9 @@ public:
   smt::Expr sum(const smt::Expr &a, const smt::Expr &n);
   smt::Expr exp(const smt::Expr &x);
   smt::Expr dot(const smt::Expr &a, const smt::Expr &b, const smt::Expr &n);
-  smt::Expr fult(const smt::Expr &f1, const smt::Expr &f2);
   smt::Expr extend(const smt::Expr &f, aop::AbsFpEncoding &tgt);
   smt::Expr truncate(const smt::Expr &f, aop::AbsFpEncoding &tgt);
+  smt::Expr cmp(const CmpPredicate pred, const smt::Expr &f1, const smt::Expr &f2);
   smt::Expr getFpAssociativePrecondition();
   smt::Expr getFpTruncatePrecondition(aop::AbsFpEncoding &tgt);
   smt::Expr getFpConstantPrecondition();

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -2,20 +2,12 @@
 
 #include "smt.h"
 #include "llvm/ADT/APFloat.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/IR/BuiltinOps.h"
 #include <vector>
 #include <set>
 
 namespace aop {
-
-enum class CmpPredicate {
-  // Ordered comparison: 
-  OEQ, ONE, OLE, OLT, OGE, OGT,
-  // Unordered comparison
-  UEQ, UNE, ULE, ULT, UGE, UGT,
-  // ETC
-  ORD, UNO, TRUE, FALSE,
-};
 
 struct UsedAbstractOps {
   // Float ops
@@ -218,7 +210,8 @@ public:
   smt::Expr dot(const smt::Expr &a, const smt::Expr &b, const smt::Expr &n);
   smt::Expr extend(const smt::Expr &f, aop::AbsFpEncoding &tgt);
   smt::Expr truncate(const smt::Expr &f, aop::AbsFpEncoding &tgt);
-  smt::Expr cmp(const CmpPredicate pred, const smt::Expr &f1, const smt::Expr &f2);
+  smt::Expr cmp(mlir::arith::CmpFPredicate pred, const smt::Expr &f1,
+      const smt::Expr &f2);
   smt::Expr getFpAssociativePrecondition();
   smt::Expr getFpTruncatePrecondition(aop::AbsFpEncoding &tgt);
   smt::Expr getFpConstantPrecondition();

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -415,61 +415,7 @@ void encodeOp(State &st, mlir::arith::XOrIOp op, bool) {
 
 template<>
 void encodeOp(State &st, mlir::arith::CmpFOp op, bool) {
-  aop::CmpPredicate pred;
-  switch (op.getPredicate()) {
-    case mlir::arith::CmpFPredicate::OEQ:
-      pred = aop::CmpPredicate::OEQ;
-      break;
-    case mlir::arith::CmpFPredicate::ONE:
-      pred = aop::CmpPredicate::ONE;
-      break;
-    case mlir::arith::CmpFPredicate::OLE:
-      pred = aop::CmpPredicate::OLE;
-      break;
-    case mlir::arith::CmpFPredicate::OLT:
-      pred = aop::CmpPredicate::OLT;
-      break;
-    case mlir::arith::CmpFPredicate::OGE:
-      pred = aop::CmpPredicate::OGE;
-      break;
-    case mlir::arith::CmpFPredicate::OGT:
-      pred = aop::CmpPredicate::OGT;
-      break;
-    case mlir::arith::CmpFPredicate::UEQ:
-      pred = aop::CmpPredicate::UEQ;
-      break;
-    case mlir::arith::CmpFPredicate::UNE:
-      pred = aop::CmpPredicate::UNE;
-      break;
-    case mlir::arith::CmpFPredicate::ULE:
-      pred = aop::CmpPredicate::ULE;
-      break;
-    case mlir::arith::CmpFPredicate::ULT:
-      pred = aop::CmpPredicate::ULT;
-      break;
-    case mlir::arith::CmpFPredicate::UGE:
-      pred = aop::CmpPredicate::UGE;
-      break;
-    case mlir::arith::CmpFPredicate::UGT:
-      pred = aop::CmpPredicate::UGT;
-      break;
-    case mlir::arith::CmpFPredicate::ORD:
-      pred = aop::CmpPredicate::ORD;
-      break;
-    case mlir::arith::CmpFPredicate::UNO:
-      pred = aop::CmpPredicate::UNO;
-      break;
-    case mlir::arith::CmpFPredicate::AlwaysTrue:
-      pred = aop::CmpPredicate::TRUE;
-      break;
-    case mlir::arith::CmpFPredicate::AlwaysFalse:
-      pred = aop::CmpPredicate::FALSE;
-      break;
-    default:
-      throw UnsupportedException(op.getOperation(),
-                                  "Unsupported cmpf predicate");
-  }
-  
+  auto pred = op.getPredicate();
   auto op1Type = op.getOperand(0).getType();
   auto op2Type = op.getOperand(1).getType();
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -1,4 +1,3 @@
-#include "abstractops.h"
 #include "memory.h"
 #include "smt.h"
 #include "smtmatchers.h"
@@ -203,8 +202,8 @@ Float Float::div(const Float &b) const {
   return Float(aop::getFpEncoding(type).div(e, b.e), type);
 }
 
-Integer Float::fult(const Float &b) const {
-  return Integer(aop::getFpEncoding(type).fult(e, b.e));
+Integer Float::cmp(const aop::CmpPredicate pred, const Float &b) const {
+  return Integer(aop::getFpEncoding(type).cmp(pred, e, b.e));
 }
 
 Float Float::abs() const {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -202,7 +202,8 @@ Float Float::div(const Float &b) const {
   return Float(aop::getFpEncoding(type).div(e, b.e), type);
 }
 
-Integer Float::cmp(const aop::CmpPredicate pred, const Float &b) const {
+Integer Float::cmp(const mlir::arith::CmpFPredicate pred, const Float &b)
+    const {
   return Integer(aop::getFpEncoding(type).cmp(pred, e, b.e));
 }
 

--- a/src/value.h
+++ b/src/value.h
@@ -35,7 +35,7 @@ public:
   Float add(const Float &b) const;
   Float mul(const Float &b) const;
   Float div(const Float &b) const;
-  Integer cmp(const aop::CmpPredicate pred, const Float &b) const;
+  Integer cmp(const mlir::arith::CmpFPredicate pred, const Float &b) const;
   Float abs() const;
   Float neg() const;
   Float extend(const mlir::Type &tgt_type) const;

--- a/src/value.h
+++ b/src/value.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "abstractops.h"
 #include "simplevalue.h"
 #include "llvm/ADT/APFloat.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -9,7 +10,6 @@ class Memory;
 
 std::optional<smt::Sort> convertPrimitiveTypeToSort(mlir::Type ty);
 std::optional<smt::Expr> getZero(mlir::Type eltType);
-
 
 class Float {
   smt::Expr e;
@@ -35,7 +35,7 @@ public:
   Float add(const Float &b) const;
   Float mul(const Float &b) const;
   Float div(const Float &b) const;
-  Integer fult(const Float &b) const;
+  Integer cmp(const aop::CmpPredicate pred, const Float &b) const;
   Float abs() const;
   Float neg() const;
   Float extend(const mlir::Type &tgt_type) const;

--- a/tests/litmus/fp-ops/cmp_const-bad.src.mlir
+++ b/tests/litmus/fp-ops/cmp_const-bad.src.mlir
@@ -1,0 +1,7 @@
+// VERIFY-INCORRECT
+
+func @olt(%arg0: f32) -> i1 {
+  %i = arith.constant 3.0 : f32
+  %c = arith.cmpf "olt", %i, %arg0 : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_const-bad.tgt.mlir
+++ b/tests/litmus/fp-ops/cmp_const-bad.tgt.mlir
@@ -1,0 +1,5 @@
+func @olt(%arg0: f32) -> i1 {
+  %i = arith.constant 2.0 : f32
+  %c = arith.cmpf "olt", %i, %arg0 : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_const.src.mlir
+++ b/tests/litmus/fp-ops/cmp_const.src.mlir
@@ -1,0 +1,85 @@
+// VERIFY
+
+func @oeq() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "oeq", %i, %v : f32
+  return %c : i1
+}
+
+func @one() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.cmpf "one", %i, %v : f32
+  return %c : i1
+}
+
+func @ole() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.cmpf "ole", %i, %v : f32
+  return %c : i1
+}
+
+func @olt() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.cmpf "olt", %i, %v : f32
+  return %c : i1
+}
+
+func @oge() -> i1 {
+  %i = arith.constant 3.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "oge", %i, %v : f32
+  return %c : i1
+}
+
+func @ogt() -> i1 {
+  %i = arith.constant 3.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "ogt", %i, %v : f32
+  return %c : i1
+}
+
+func @ueq() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "ueq", %i, %v : f32
+  return %c : i1
+}
+
+func @une() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.cmpf "une", %i, %v : f32
+  return %c : i1
+}
+
+func @ule() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.cmpf "ule", %i, %v : f32
+  return %c : i1
+}
+
+func @ult() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.cmpf "ult", %i, %v : f32
+  return %c : i1
+}
+
+func @uge() -> i1 {
+  %i = arith.constant 3.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "uge", %i, %v : f32
+  return %c : i1
+}
+
+func @ugt() -> i1 {
+  %i = arith.constant 3.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "ugt", %i, %v : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_const.src.mlir
+++ b/tests/litmus/fp-ops/cmp_const.src.mlir
@@ -1,8 +1,8 @@
 // VERIFY
 
 func @oeq() -> i1 {
-  %i = arith.constant 2.0 : f32
-  %v = arith.constant 2.0 : f32
+  %i = arith.constant 3.0 : f32
+  %v = arith.constant 3.0 : f32
   %c = arith.cmpf "oeq", %i, %v : f32
   return %c : i1
 }
@@ -43,8 +43,8 @@ func @ogt() -> i1 {
 }
 
 func @ueq() -> i1 {
-  %i = arith.constant 2.0 : f32
-  %v = arith.constant 2.0 : f32
+  %i = arith.constant 3.0 : f32
+  %v = arith.constant 3.0 : f32
   %c = arith.cmpf "ueq", %i, %v : f32
   return %c : i1
 }

--- a/tests/litmus/fp-ops/cmp_const.tgt.mlir
+++ b/tests/litmus/fp-ops/cmp_const.tgt.mlir
@@ -1,0 +1,83 @@
+func @oeq() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "oeq", %i, %v : f32
+  return %c : i1
+}
+
+func @one() -> i1 {
+  %i = arith.constant -2.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "one", %i, %v : f32
+  return %c : i1
+}
+
+func @ole() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "ole", %i, %v : f32
+  return %c : i1
+}
+
+func @olt() -> i1 {
+  %i = arith.constant -2.0 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.cmpf "olt", %i, %v : f32
+  return %c : i1
+}
+
+func @oge() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "oge", %i, %v : f32
+  return %c : i1
+}
+
+func @ogt() -> i1 {
+  %i = arith.constant 3.0 : f32
+  %v = arith.constant -2.0 : f32
+  %c = arith.cmpf "ogt", %i, %v : f32
+  return %c : i1
+}
+
+func @ueq() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "ueq", %i, %v : f32
+  return %c : i1
+}
+
+func @une() -> i1 {
+  %i = arith.constant -2.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "une", %i, %v : f32
+  return %c : i1
+}
+
+func @ule() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "ule", %i, %v : f32
+  return %c : i1
+}
+
+func @ult() -> i1 {
+  %i = arith.constant -2.0 : f32
+  %v = arith.constant 3.0 : f32
+  %c = arith.cmpf "ult", %i, %v : f32
+  return %c : i1
+}
+
+func @uge() -> i1 {
+  %i = arith.constant 2.0 : f32
+  %v = arith.constant 2.0 : f32
+  %c = arith.cmpf "uge", %i, %v : f32
+  return %c : i1
+}
+
+func @ugt() -> i1 {
+  %i = arith.constant 3.0 : f32
+  %v = arith.constant -2.0 : f32
+  %c = arith.cmpf "ugt", %i, %v : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_fixed.src.mlir
+++ b/tests/litmus/fp-ops/cmp_fixed.src.mlir
@@ -1,0 +1,11 @@
+// VERIFY
+
+func @true(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "true", %arg0, %arg1 : f32
+  return %c : i1
+}
+
+func @false(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "false", %arg0, %arg1 : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_fixed.tgt.mlir
+++ b/tests/litmus/fp-ops/cmp_fixed.tgt.mlir
@@ -1,0 +1,9 @@
+func @true(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.constant 1 : i1
+  return %c : i1
+}
+
+func @false(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.constant 0 : i1
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_inverse.src.mlir
+++ b/tests/litmus/fp-ops/cmp_inverse.src.mlir
@@ -1,0 +1,41 @@
+// VERIFY
+
+func @ole(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ole", %arg0, %arg1 : f32
+  return %c : i1
+}
+
+func @olt(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "olt", %arg0, %arg1 : f32
+  return %c : i1
+}
+
+func @oge(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "oge", %arg0, %arg1 : f32
+  return %c : i1
+}
+
+func @ogt(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ogt", %arg0, %arg1 : f32
+  return %c : i1
+}
+
+func @ule(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ule", %arg0, %arg1 : f32
+  return %c : i1
+}
+
+func @ult(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ult", %arg0, %arg1 : f32
+  return %c : i1
+}
+
+func @uge(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "uge", %arg0, %arg1 : f32
+  return %c : i1
+}
+
+func @ugt(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ugt", %arg0, %arg1 : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_inverse.tgt.mlir
+++ b/tests/litmus/fp-ops/cmp_inverse.tgt.mlir
@@ -1,0 +1,39 @@
+func @ole(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "oge", %arg1, %arg0 : f32
+  return %c : i1
+}
+
+func @olt(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ogt", %arg1, %arg0 : f32
+  return %c : i1
+}
+
+func @oge(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ole", %arg1, %arg0 : f32
+  return %c : i1
+}
+
+func @ogt(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "olt", %arg1, %arg0 : f32
+  return %c : i1
+}
+
+func @ule(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "uge", %arg1, %arg0 : f32
+  return %c : i1
+}
+
+func @ult(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ugt", %arg1, %arg0 : f32
+  return %c : i1
+}
+
+func @uge(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ule", %arg1, %arg0 : f32
+  return %c : i1
+}
+
+func @ugt(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ult", %arg1, %arg0 : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_nan.src.mlir
+++ b/tests/litmus/fp-ops/cmp_nan.src.mlir
@@ -71,3 +71,15 @@ func @ugt(%arg0: f32) -> i1 {
   %c = arith.cmpf "ugt", %i, %arg0 : f32
   return %c : i1
 }
+
+func @ord(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "ord", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @uno(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "uno", %i, %arg0 : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_nan.src.mlir
+++ b/tests/litmus/fp-ops/cmp_nan.src.mlir
@@ -1,0 +1,73 @@
+// VERIFY
+
+func @oeq(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "oeq", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @one(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "one", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @ole(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "ole", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @olt(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "olt", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @oge(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "oge", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @ogt(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "ogt", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @ueq(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "ueq", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @une(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "une", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @ule(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "ule", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @ult(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "ult", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @uge(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "uge", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @ugt(%arg0: f32) -> i1 {
+  %i = arith.constant 0x7FC00000 : f32
+  %c = arith.cmpf "ugt", %i, %arg0 : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_nan.tgt.mlir
+++ b/tests/litmus/fp-ops/cmp_nan.tgt.mlir
@@ -57,3 +57,13 @@ func @ugt(%arg0: f32) -> i1 {
   %c = arith.constant 1 : i1
   return %c : i1
 }
+
+func @ord(%arg0: f32) -> i1 {
+  %c = arith.constant 0 : i1
+  return %c : i1
+}
+
+func @uno(%arg0: f32) -> i1 {
+  %c = arith.constant 1 : i1
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_nan.tgt.mlir
+++ b/tests/litmus/fp-ops/cmp_nan.tgt.mlir
@@ -1,0 +1,59 @@
+func @oeq(%arg0: f32) -> i1 {
+  %c = arith.constant 0 : i1
+  return %c : i1
+}
+
+func @one(%arg0: f32) -> i1 {
+  %c = arith.constant 0 : i1
+  return %c : i1
+}
+
+func @ole(%arg0: f32) -> i1 {
+  %c = arith.constant 0 : i1
+  return %c : i1
+}
+
+func @olt(%arg0: f32) -> i1 {
+  %c = arith.constant 0 : i1
+  return %c : i1
+}
+
+func @oge(%arg0: f32) -> i1 {
+  %c = arith.constant 0 : i1
+  return %c : i1
+}
+
+func @ogt(%arg0: f32) -> i1 {
+  %c = arith.constant 0 : i1
+  return %c : i1
+}
+
+func @ueq(%arg0: f32) -> i1 {
+  %c = arith.constant 1 : i1
+  return %c : i1
+}
+
+func @une(%arg0: f32) -> i1 {
+  %c = arith.constant 1 : i1
+  return %c : i1
+}
+
+func @ule(%arg0: f32) -> i1 {
+  %c = arith.constant 1 : i1
+  return %c : i1
+}
+
+func @ult(%arg0: f32) -> i1 {
+  %c = arith.constant 1 : i1
+  return %c : i1
+}
+
+func @uge(%arg0: f32) -> i1 {
+  %c = arith.constant 1 : i1
+  return %c : i1
+}
+
+func @ugt(%arg0: f32) -> i1 {
+  %c = arith.constant 1 : i1
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_ord-bad.src.mlir
+++ b/tests/litmus/fp-ops/cmp_ord-bad.src.mlir
@@ -1,0 +1,6 @@
+// VERIFY-INCORRECT
+
+func @oeq(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "oeq", %arg0, %arg1 : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_ord-bad.tgt.mlir
+++ b/tests/litmus/fp-ops/cmp_ord-bad.tgt.mlir
@@ -1,0 +1,4 @@
+func @oeq(%arg0: f32, %arg1: f32) -> i1 {
+  %c = arith.cmpf "ueq", %arg0, %arg1 : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_zero.src.mlir
+++ b/tests/litmus/fp-ops/cmp_zero.src.mlir
@@ -1,0 +1,25 @@
+// VERIFY
+
+func @oeq(%arg0: f32) -> i1 {
+  %i = arith.constant 0.0 : f32
+  %c = arith.cmpf "oeq", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @one(%arg0: f32) -> i1 {
+  %i = arith.constant 0.0 : f32
+  %c = arith.cmpf "one", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @ueq(%arg0: f32) -> i1 {
+  %i = arith.constant 0.0 : f32
+  %c = arith.cmpf "ueq", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @une(%arg0: f32) -> i1 {
+  %i = arith.constant 0.0 : f32
+  %c = arith.cmpf "une", %i, %arg0 : f32
+  return %c : i1
+}

--- a/tests/litmus/fp-ops/cmp_zero.tgt.mlir
+++ b/tests/litmus/fp-ops/cmp_zero.tgt.mlir
@@ -1,0 +1,23 @@
+func @oeq(%arg0: f32) -> i1 {
+  %i = arith.constant -0.0 : f32
+  %c = arith.cmpf "oeq", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @one(%arg0: f32) -> i1 {
+  %i = arith.constant -0.0 : f32
+  %c = arith.cmpf "one", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @ueq(%arg0: f32) -> i1 {
+  %i = arith.constant -0.0 : f32
+  %c = arith.cmpf "ueq", %i, %arg0 : f32
+  return %c : i1
+}
+
+func @une(%arg0: f32) -> i1 {
+  %i = arith.constant -0.0 : f32
+  %c = arith.cmpf "une", %i, %arg0 : f32
+  return %c : i1
+}

--- a/tests/litmus/tensor-ops/cmp_const.src.mlir
+++ b/tests/litmus/tensor-ops/cmp_const.src.mlir
@@ -1,0 +1,16 @@
+// VERIFY
+
+func @f() -> tensor<5x3xi1> {
+  %lhs = arith.constant dense<[[0.0, 1.0, 2.0],
+    [3.0, 4.0, 5.0],
+    [6.0, 7.0, 8.0],
+    [9.0, 10.0, 11.0],
+    [12.0, 13.0, 14.0]]>: tensor<5x3xf32>
+  %rhs = arith.constant dense<[[1.0, 0.0, 3.0],
+    [2.0, 5.0, 4.0],
+    [7.0, 6.0, 9.0],
+    [8.0, 11.0, 10.0],
+    [13.0, 12.0, 14.0]]>: tensor<5x3xf32>
+  %c = arith.cmpf "olt", %lhs, %rhs : tensor<5x3xf32>
+  return %c: tensor<5x3xi1>
+}

--- a/tests/litmus/tensor-ops/cmp_const.tgt.mlir
+++ b/tests/litmus/tensor-ops/cmp_const.tgt.mlir
@@ -1,0 +1,8 @@
+func @f() -> tensor<5x3xi1> {
+  %c = arith.constant dense<[[1, 0, 1],
+    [0, 1, 0],
+    [1, 0, 1],
+    [0, 1, 0],
+    [1, 0, 0]]>: tensor<5x3xi1>
+  return %c: tensor<5x3xi1>
+}

--- a/tests/litmus/tensor-ops/cmp_inverse.src.mlir
+++ b/tests/litmus/tensor-ops/cmp_inverse.src.mlir
@@ -1,0 +1,41 @@
+// VERIFY
+
+func @ole(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "ole", %arg0, %arg1 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @olt(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "olt", %arg0, %arg1 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @oge(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "oge", %arg0, %arg1 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @ogt(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "ogt", %arg0, %arg1 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @ule(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "ule", %arg0, %arg1 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @ult(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "ult", %arg0, %arg1 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @uge(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "uge", %arg0, %arg1 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @ugt(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "ugt", %arg0, %arg1 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}

--- a/tests/litmus/tensor-ops/cmp_inverse.tgt.mlir
+++ b/tests/litmus/tensor-ops/cmp_inverse.tgt.mlir
@@ -1,0 +1,39 @@
+func @ole(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "oge", %arg1, %arg0 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @olt(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "ogt", %arg1, %arg0 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @oge(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "ole", %arg1, %arg0 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @ogt(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "olt", %arg1, %arg0 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @ule(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "uge", %arg1, %arg0 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @ult(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "ugt", %arg1, %arg0 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @uge(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "ule", %arg1, %arg0 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}
+
+func @ugt(%arg0: tensor<5x3xf32>, %arg1: tensor<5x3xf32>) -> tensor<5x3xi1> {
+  %c = arith.cmpf "ult", %arg1, %arg0 : tensor<5x3xf32>
+  return %c : tensor<5x3xi1>
+}


### PR DESCRIPTION
This PR implements comparison operator for float types.

- cmp is implemented as a set of concrete ite expressions. Each expression yields a BV(1) from two BV(fp_bitwidth)s.
- Using cmp looks like this: `cmp(pred, f1, f2)`
- `pred` is an enum class `aop::CmpPredicate`. There are 16 members in `aop::CmpPredicate`, and each represents the corresponding cmpf predicate in MLIR. (`[Ordered|Unordered][EQ|NE|LE|LT|GE|GT], Ordered, Unordered, True, False`) 
- Litmus tests are added to verify the behavior.