### PR TITLE
Litmus tests for cmpf after extension

### DIFF
--- a/tests/litmus/fp-ops/ext_cmp.src.mlir
+++ b/tests/litmus/fp-ops/ext_cmp.src.mlir
@@ -1,0 +1,29 @@
+// VERIFY
+
+func @eq(%arg0: f32, %arg1: f32) -> i1 {
+  %lhs = arith.extf %arg0: f32 to f64
+  %rhs = arith.extf %arg1: f32 to f64
+  %e = arith.cmpf "oeq", %lhs, %rhs : f64
+  return %e: i1
+}
+
+func @ne(%arg0: f32, %arg1: f32) -> i1 {
+  %lhs = arith.extf %arg0: f32 to f64
+  %rhs = arith.extf %arg1: f32 to f64
+  %e = arith.cmpf "one", %lhs, %rhs : f64
+  return %e: i1
+}
+
+func @lt(%arg0: f32, %arg1: f32) -> i1 {
+  %lhs = arith.extf %arg0: f32 to f64
+  %rhs = arith.extf %arg1: f32 to f64
+  %e = arith.cmpf "olt", %lhs, %rhs : f64
+  return %e: i1
+}
+
+func @gt(%arg0: f32, %arg1: f32) -> i1 {
+  %lhs = arith.extf %arg0: f32 to f64
+  %rhs = arith.extf %arg1: f32 to f64
+  %e = arith.cmpf "ogt", %lhs, %rhs : f64
+  return %e: i1
+}

--- a/tests/litmus/fp-ops/ext_cmp.tgt.mlir
+++ b/tests/litmus/fp-ops/ext_cmp.tgt.mlir
@@ -1,0 +1,21 @@
+// VERIFY
+
+func @eq(%arg0: f32, %arg1: f32) -> i1 {
+  %e = arith.cmpf "oeq", %arg0, %arg1 : f32
+  return %e: i1
+}
+
+func @ne(%arg0: f32, %arg1: f32) -> i1 {
+  %e = arith.cmpf "one", %arg0, %arg1 : f32
+  return %e: i1
+}
+
+func @lt(%arg0: f32, %arg1: f32) -> i1 {
+  %e = arith.cmpf "olt", %arg0, %arg1 : f32
+  return %e: i1
+}
+
+func @gt(%arg0: f32, %arg1: f32) -> i1 {
+  %e = arith.cmpf "ogt", %arg0, %arg1 : f32
+  return %e: i1
+}


### PR DESCRIPTION
This PR adds litmus tests for extf operation
- `cmpf extf(a), extf(b)` == `cmpf a, b`