### PR TITLE
Fix linalg-fill to invoke ub when readonly memblock

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -2076,7 +2076,7 @@ static void storeTensorTo(
   if (memrefTy.getLayout().isIdentity()) {
     // memref with identity map
     auto success = memref.storeArray(tensor.asArray(), Index::zero(),
-        tensor.get1DSize(), false);
+        tensor.get1DSize(), true);
     st.wellDefined(op, move(success));
 
   } else {


### PR DESCRIPTION
\<src\>

```
// VERIFY

func @generalize_fill(%output: memref<?x?xf32>, %value : f32) {
  linalg.fill(%value, %output) : f32, memref<?x?xf32>
  return
}

// How to reproduce tgt:
// mlir-opt -linalg-generalize-named-ops <src>
```

\<tgt\>

```
#map0 = affine_map<(d0, d1) -> ()>
#map1 = affine_map<(d0, d1) -> (d0, d1)>
module  {
  func @generalize_fill(%arg0: memref<?x?xf32>, %arg1: f32) {
    linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg1 : f32) outs(%arg0 : memref<?x?xf32>) {
    ^bb0(%arg2: f32, %arg3: f32):  // no predecessors
      linalg.yield %arg2 : f32
    }
    return
  }
}


```