### PR TITLE
Fix insert_slice canonicalize unittest

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1696,10 +1696,13 @@ void encodeOp(State &st, mlir::tensor::ExtractSliceOp op, bool) {
     bool isDimSizeOne = idx >= resType.getRank() ||
         ((((Expr)sizes[i]).isUInt(v) && v == 1) && resType.getDimSize(idx) != v);
 
-    if (isDimSizeOne)
+    if (isDimSizeOne) {
       outIdxs.push_back((Expr)offsets[i]);
-    else
+    } else {
+      // sizes operand should match with target tensor dimension
+      st.wellDefined(op,  (sizes[i] == dims[idx]));
       outIdxs.push_back((Expr)((inIdxs[idx++] * strides[i])) + offsets[i]);
+    }
   }
   st.wellDefined(op, src.isFullyInitialized());
   st.regs.add(res,
@@ -1732,12 +1735,10 @@ void encodeOp(State &st, mlir::tensor::InsertSliceOp op, bool) {
   vector<Expr> srcIdxs;
 
     // Add out-of-bounds check
-  for (unsigned i = 0; i < sizes.size(); ++i) {
+  for (unsigned i = 0; i < rank; ++i) {
     auto dim = tgt.getDim(i);
     Expr ofs = offsets[i], size = sizes[i];
     st.wellDefined(op, ofs.ult(dim) & size.ule(dim) & (ofs + sizes[i]).ule(dim));
-    verbose("InsertSliceOp out-of-bounds check")
-      << (ofs.ult(dim) & size.ule(dim) & (ofs + sizes[i]).ule(dim)) << "\n";
   }
 
   Expr cond = Expr::mkBool(true);
@@ -1746,6 +1747,8 @@ void encodeOp(State &st, mlir::tensor::InsertSliceOp op, bool) {
     srcIdxs.push_back((indVars[i] - offsets[i]).udiv(strides[i]));
     cond &= ((indVars[i] - offsets[i]).urem(strides[i])).isZero() &
             (indVars[i] - offsets[i]).ult(sizes[i] * strides[i]);
+    // sizes operand should match with source tensor dimension
+    st.wellDefined(op,  (sizes[i] == src.getDim(i)));
   }
 
   // Picking the value from src1 must not be out of bounds.

--- a/tests/litmus/tensor-ops/insert_slice5.src.mlir
+++ b/tests/litmus/tensor-ops/insert_slice5.src.mlir
@@ -1,0 +1,14 @@
+// VERIFY
+
+func @insert_slice_canonicalize(%arg0 : tensor<?x?x?xf32>, %arg1 : index,
+    %arg2 : index, %arg3 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+{
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %0 = tensor.insert_slice %arg0 into %arg3[%c0, %arg1, %c1] [%c4, %c1, %arg2] [%c1, %c1, %c1] : tensor<?x?x?xf32> into tensor<?x?x?xf32>
+  return %0 : tensor<?x?x?xf32>
+}
+
+// How to reproduce tgt:
+// mlir-opt -canonicalize <src>

--- a/tests/litmus/tensor-ops/insert_slice5.tgt.mlir
+++ b/tests/litmus/tensor-ops/insert_slice5.tgt.mlir
@@ -1,0 +1,7 @@
+module  {
+  func @insert_slice_canonicalize(%arg0: tensor<?x?x?xf32>, %arg1: index, %arg2: index, %arg3: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+    %0 = tensor.cast %arg0 : tensor<?x?x?xf32> to tensor<4x1x?xf32>
+    %1 = tensor.insert_slice %0 into %arg3[0, %arg1, 1] [4, 1, %arg2] [1, 1, 1] : tensor<4x1x?xf32> into tensor<?x?x?xf32>
+    return %1 : tensor<?x?x?xf32>
+  }
+}


### PR DESCRIPTION
### Fixed
- `extract_slice`, `insert_slice` has been updated to match size's operand with source/target tensor's dimension.

For example,  `tensor.insert_slice %arg0 into %arg3[%c0, %arg1, %c1] [%c4, %c1, %arg2] [%c1, %c1, %c1] : tensor<?x?x?xf32> into tensor<?x?x?xf32>` means `%arg0`'s dimension should be <4x1x?>.

\<src\>
```
// VERIFY

func @insert_slice_canonicalize(%arg0 : tensor<?x?x?xf32>, %arg1 : index,
    %arg2 : index, %arg3 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
{
  %c0 = arith.constant 0 : index
  %c1 = arith.constant 1 : index
  %c4 = arith.constant 4 : index
  %0 = tensor.insert_slice %arg0 into %arg3[%c0, %arg1, %c1] [%c4, %c1, %arg2] [%c1, %c1, %c1] : tensor<?x?x?xf32> into tensor<?x?x?xf32>
  return %0 : tensor<?x?x?xf32>
}

// How to reproduce tgt:
// mlir-opt -canonicalize <src>
```

\<tgt\>
```
module  {
  func @insert_slice_canonicalize(%arg0: tensor<?x?x?xf32>, %arg1: index, %arg2: index, %arg3: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
    %0 = tensor.cast %arg0 : tensor<?x?x?xf32> to tensor<4x1x?xf32>
    %1 = tensor.insert_slice %0 into %arg3[0, %arg1, 1] [4, 1, %arg2] [1, 1, 1] : tensor<4x1x?xf32> into tensor<?x?x?xf32>
    return %1 : tensor<?x?x?xf32>
  }
}
```