### PR TITLE
Give more precise semantics to fp add

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -656,12 +656,9 @@ Expr AbsFpEncoding::add(const Expr &_f1, const Expr &_f2) {
     // If signbit(f1) == 0 /\ signbit(f2) == 0, signbit(fpAdd(f1, f2)) = 0.
     // If signbit(f1) == 1 /\ signbit(f2) == 1, signbit(fpAdd(f1, f2)) = 1.
     // Otherwise, we can just use the arbitrary sign yielded from fp_add.
-    Expr::mkIte(((getSignBit(f1) == bv_false) & (getSignBit(f2) == bv_false)),
-      // pos + pos -> pos
-      bv_false.concat(fp_add_value),
-    Expr::mkIte(((getSignBit(f1) == bv_true) & (getSignBit(f2) == bv_true)),
-      // neg + neg -> neg
-      bv_true.concat(fp_add_value),
+    Expr::mkIte(getSignBit(f1) == getSignBit(f2),
+      // pos + pos -> pos, neg + neg -> neg
+      getSignBit(f1).concat(fp_add_value),
     Expr::mkIte(getMagnitudeBits(f1) == getMagnitudeBits(f2),
       // x + -x -> 0.0
       zero(),
@@ -671,7 +668,7 @@ Expr AbsFpEncoding::add(const Expr &_f1, const Expr &_f2) {
         getSignBit(f1),
         getSignBit(f2)
       ).concat(fp_add_value)
-  ))))))))));
+  )))))))));
 }
 
 Expr AbsFpEncoding::mul(const Expr &_f1, const Expr &_f2) {

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -665,7 +665,12 @@ Expr AbsFpEncoding::add(const Expr &_f1, const Expr &_f2) {
     Expr::mkIte(getMagnitudeBits(f1) == getMagnitudeBits(f2),
       // x + -x -> 0.0
       zero(),
-      fp_add_res
+      // |f1| > |f2| -> sign(f1 + f2) == sign(f1)
+      // |f1| < |f2| -> sign(f1 + f2) == sign(f2)
+      Expr::mkIte(getMagnitudeBits(f1).ugt(getMagnitudeBits(f2)),
+        getSignBit(f1),
+        getSignBit(f2)
+      ).concat(fp_add_value)
   ))))))))));
 }
 

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -652,10 +652,10 @@ Expr AbsFpEncoding::add(const Expr &_f1, const Expr &_f2) {
     // If both operands do not fall into any of the cases above,
     // use fp_add for abstract representation.
     // 
-    // There are two cases where we must override the sign bit of fp_add.
+    // The sign bit of fp_add should be overrided.
     // If signbit(f1) == 0 /\ signbit(f2) == 0, signbit(fpAdd(f1, f2)) = 0.
     // If signbit(f1) == 1 /\ signbit(f2) == 1, signbit(fpAdd(f1, f2)) = 1.
-    // Otherwise, we can just use the arbitrary sign yielded from fp_add.
+    // Otherwise, follow the sign of value with greater magnitude
     Expr::mkIte(getSignBit(f1) == getSignBit(f2),
       // pos + pos -> pos, neg + neg -> neg
       getSignBit(f1).concat(fp_add_value),


### PR DESCRIPTION
This PR updates the semantics of fp addition to yield the value of appropriate sign.

Thanks to recent updates regarding the cmpf, we can determine the sign of the sum between finite values of different sign: we follow the sign of the value with greater magnitude.