### PR TITLE
Only use stable tags for solvers

### DIFF
--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Z3Prover/z3
+          ref: z3-4.8.13
           path: src/z3
 
       - name: Get Z3 SHA
@@ -89,6 +90,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: cvc5/cvc5
+          ref: cvc5-0.0.4
           path: src/cvc5
 
       - name: Get CVC5 SHA


### PR DESCRIPTION
This PR updates the CI script to only use the stabilized version of smt solvers.