### PR TITLE
Implement missing semantics for fp div

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -793,10 +793,14 @@ Expr AbsFpEncoding::div(const Expr &_f1, const Expr &_f2) {
   // However, LLVM chooses to simply continue the execution without notifying
   Expr::mkIte(iszero(f2, false) | iszero(f2, true),
     Expr::mkIte(iszero(f1, false) | iszero(f1, true), fp_nan, fp_inf_pos),
-    // If both operands do not fall into any of the cases above,
-    // use fp_div for abstract representation.
-    div_abs_res
-  ))))));
+  // +-0.0 / x -> ?0.0, 
+  Expr::mkIte(iszero(f1, false) | iszero(f1, true), fp_zero_pos,
+  // x / x -> 1.0, x / -x -> -1.0 
+  Expr::mkIte(f1_nosign == f2_nosign, fp_id,
+  // If both operands do not fall into any of the cases above,
+  // use fp_div for abstract representation.
+  div_abs_res
+  ))))))));
 
   // And at last we replace the sign with signbit(f1) ^ signbit(f2)
   // pos / pos | neg / neg -> pos, pos / neg | neg / pos -> neg

--- a/tests/litmus/fp-ops/self_div_const.src.mlir
+++ b/tests/litmus/fp-ops/self_div_const.src.mlir
@@ -1,0 +1,14 @@
+// VERIFY
+
+func @pos() -> f32 {
+  %v = arith.constant 3.0 : f32
+  %c = arith.divf %v, %v : f32
+  return %c : f32
+}
+
+func @neg() -> f32 {
+  %v = arith.constant 3.0 : f32
+  %n = arith.constant -3.0 : f32
+  %c = arith.divf %v, %n : f32
+  return %c : f32
+}

--- a/tests/litmus/fp-ops/self_div_const.tgt.mlir
+++ b/tests/litmus/fp-ops/self_div_const.tgt.mlir
@@ -1,0 +1,10 @@
+func @pos() -> f32 {
+  %c = arith.constant 1.0 : f32
+  return %c : f32
+}
+
+func @neg() -> f32 {
+  %c = arith.constant -1.0 : f32
+  return %c : f32
+}
+

--- a/tests/litmus/fp-ops/zero_div_const.src.mlir
+++ b/tests/litmus/fp-ops/zero_div_const.src.mlir
@@ -1,8 +1,8 @@
 // VERIFY
 
 func @f() -> f32 {
-  %inf = arith.constant 0x7F800000 : f32
+  %z = arith.constant 0.0 : f32
   %v = arith.constant 3.0 : f32
-  %c = arith.divf %inf, %v : f32
+  %c = arith.divf %z, %v : f32
   return %c : f32
 }

--- a/tests/litmus/fp-ops/zero_div_const.tgt.mlir
+++ b/tests/litmus/fp-ops/zero_div_const.tgt.mlir
@@ -1,4 +1,4 @@
 func @f() -> f32 {
-  %c = arith.constant 0x7F800000 : f32
+  %c = arith.constant 0.0 : f32
   return %c : f32
 }


### PR DESCRIPTION
This PR implements two important properties of FP division (which was missing)
- +-0.0 / x -> ?0.0 (x != +-0.0)
- x / x -> 1.0, x / -x -> -1.0 (x != +-0.0 or +-Inf)

