### PR TITLE
Disable automatic CI image update

### DIFF
--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -5,8 +5,9 @@ on:
   workflow_dispatch:
 
   # daily fetch and check
-  schedule:
-    - cron: '0 0 1/3 * *'
+  # No automatic update until further notice!
+  # schedule:
+  #   - cron: '0 0 1/3 * *'
 
 jobs:
   configure-dependencies:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ Currently MLIR-TV is in an experimental stage.
 Prerequisites: [CMake](https://cmake.org/download/)(>=3.15),
 [MLIR](https://github.com/llvm/llvm-project),
 [Python3](https://www.python.org/downloads/),  
-Solvers (at least one of them must be used): [Z3-solver](https://github.com/Z3Prover/z3), [CVC5](https://github.com/cvc5/cvc5)
+Solvers (at least one of them must be used):
+[z3](https://github.com/Z3Prover/z3),
+[cvc5(limited support)](https://github.com/cvc5/cvc5)
+> Using the smt solvers of stable version is recommended, as latest commits may
+contain bugs or introduce breaking changes in their API.  
+As of now(2021/12/25), our project has been tested on
+[z3-4.8.13](https://github.com/Z3Prover/z3/releases/tag/z3-4.8.13) and
+[cvc5-0.0.4](https://github.com/cvc5/cvc5/releases/tag/cvc5-0.0.4)
+
+> We usually made our best effort to support the use of latest MLIR dialect and
+API, but we'll reside on commit [b5a0f0f](https://github.com/llvm/llvm-project/commit/b5a0f0f397c778cc7db71754c1b9c939f669568e) until further notice...
 
 - Installation of MLIR: please follow [this instruction](https://llvm.org/docs/GettingStarted.html#getting-the-source-code-and-building-llvm) & run `cmake --build . --target install`
 


### PR DESCRIPTION
In order to enhance stability and avoid possible breaking changes in the future, we'll stay on the latest(as of now) versions of LLVM, z3, and cvc5 for a while. Please refer to README for more details.