### PR TITLE
Reset abstractlyEncodedAttrs for each fn pair

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -9,6 +9,7 @@
 using namespace smt;
 using namespace std;
 
+
 namespace {
 string freshName(string prefix) {
   static int count = 0;
@@ -52,6 +53,12 @@ optional<Expr> getIdentity(mlir::Type eltType) {
   else if (eltType.isIndex())
     return Index(0);
   return {};
+}
+
+static vector<pair<mlir::ElementsAttr, Tensor>> abstractlyEncodedAttrs;
+
+void resetAbstractlyEncodedAttrs() {
+  abstractlyEncodedAttrs.clear();
 }
 
 
@@ -1049,8 +1056,6 @@ Tensor Tensor::mkIte(
       trueValue.elemType, move(trueDims), move(indVars),
       move(retExpr), move(retInit));
 }
-
-static vector<pair<mlir::ElementsAttr, Tensor>> abstractlyEncodedAttrs;
 
 Tensor Tensor::fromElemsAttr(mlir::RankedTensorType tensorty,
       mlir::ElementsAttr attr) {

--- a/src/value.h
+++ b/src/value.h
@@ -12,6 +12,7 @@ class AccessInfo;
 std::optional<smt::Sort> convertPrimitiveTypeToSort(mlir::Type ty);
 std::optional<smt::Expr> getZero(mlir::Type eltType);
 std::optional<smt::Expr> getIdentity(mlir::Type eltType);
+void resetAbstractlyEncodedAttrs();
 
 class Float {
   smt::Expr e;

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -557,8 +557,11 @@ static Results validate(ValidationInput vinput) {
                   AbsFpAddSumEncoding::DEFAULT},
       /* useAllLogic */arg_smt_use_all_logic.getValue() });
 
-  unsigned itrCount = 0;
+
   setEncodingOptions(vinput.useMultisetForFpSum);
+  resetAbstractlyEncodedAttrs();
+
+  unsigned itrCount = 0;
   const string dumpSMTPath = vinput.dumpSMTPath;
 
   while (!queue.empty()) {


### PR DESCRIPTION
If we validate multiple source, target fn pairs, this creates iill-formed expression