### PR TITLE
Remove MemRef::storeArray because it is layout-unsafe

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1305,7 +1305,7 @@ static void encodeConv(State &st, T op, ShapedValue::ConvLayout clayout) {
     auto outputIndices = output.getLayout().getInverseIndices(idx);
     auto outputExpr = expr.substitute(indices, outputIndices);
     auto outputTensor = Tensor::mkInitializedLambda(elemTy,
-        {input.get1DSize()}, {idx}, outputExpr);
+        {output.get1DSize()}, {idx}, outputExpr);
 
     // store the result to the output reference
     storeTensorTo(st, op, move(outputTensor), output, outputTy, true);

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -1376,11 +1376,6 @@ AccessInfo MemRef::store(const Expr &value,
   return info;
 }
 
-AccessInfo MemRef::storeArray(
-    const Expr &array, const Expr &startOffset, const Expr &size) const {
-  return m->storeArray(elemType, array, bid, (Expr)offset + startOffset, size);
-}
-
 Tensor MemRef::loadTensorWithoutCheck() const {
   auto dims = getDims();
   vector<Expr> idxs = Index::boundIndexVars(dims.size());
@@ -1458,30 +1453,6 @@ MemRef MemRef::subview(const vector<Expr> &offsets,
     return MemRef(m, elemType, bid, offset, sizes, subviewLayout,
         Expr::mkBool(true));
   }
-}
-
-Expr MemRef::conv(const MemRef &input,
-    const MemRef &filter,
-    const std::vector<smt::Expr> &strides,
-    const std::vector<smt::Expr> &dilations,
-    ConvLayout clayout) {
-  auto [indices, expr] = input.ShapedValue::conv(filter, strides, dilations,
-      clayout);
-
-  // we splat results into 1D memory layout
-  auto idx = Index::var("outputIdx", VarType::BOUND);
-  auto outputIndices = layout.getInverseIndices(idx);
-  auto outputExpr = expr.substitute(indices, outputIndices);
-  auto outputArray = Expr::mkLambda(idx, outputExpr);
-
-  // store output memref
-  auto info = storeArray(outputArray, Index::zero(), get1DSize());
-  auto success = info.inbounds & info.liveness & info.writable &
-      input.getLiveness() & input.isInBounds() &
-      filter.getLiveness() & filter.isInBounds() &
-      noalias(input) & noalias(filter);
-
-  return success;
 }
 
 MemRef MemRef::mkIte(smt::Expr cond,

--- a/src/value.h
+++ b/src/value.h
@@ -98,7 +98,6 @@ public:
     NHWC_FHWC  // image: nhwc, filter: fhwc, output: nhwf
   };
 
-protected:
   // Linalg convolution operation.
   // returns: (indices, expr)
   // Caller must check the validity of inputs (e.g. inbounds, initializedness)
@@ -177,7 +176,8 @@ public:
       const std::vector<smt::Expr> &dilations,
       ConvLayout layout) const;
 
-  // Return a new tensor which is depthwise convolution of this 2D tensor and filter.
+  // Return a new tensor which is depthwise convolution of this 2D tensor and
+  // filter.
   // Callers of conv must check whether filters/inputs/.. are initialized
   // (otherwise UB).
   Tensor depthwiseConv2D(const Tensor &filter,
@@ -373,8 +373,6 @@ public:
 
   AccessInfo store(const smt::Expr &value,
       const std::vector<smt::Expr> &indices) const;
-  AccessInfo storeArray(const smt::Expr &array,
-      const smt::Expr &startOffset, const smt::Expr &size) const;
 
   Tensor loadTensorWithoutCheck() const;
 
@@ -394,13 +392,6 @@ public:
       const llvm::SmallDenseSet<unsigned> &unusedDims,
       int rankDiff = 0);
 
-  // Store results which is convolution of input, filter and return wellDefined.
-  smt::Expr conv(const MemRef &input,
-      const MemRef &filter,
-      const std::vector<smt::Expr> &strides,
-      const std::vector<smt::Expr> &dilations,
-      ConvLayout convLayout);
-
   // Returns (cond ? trueValue : falseValue).
   // It is assumed that trueValue.layout is equivalent to falseValue.layout.
   // Also trueValue.dims == falseValue.dims is assumed, to be consistent with
@@ -413,6 +404,8 @@ public:
   std::pair<smt::Expr, std::vector<smt::Expr>> refines(
       const MemRef &other) const;
   MemRef eval(smt::Model m) const;
+
+  const Layout &getLayout() const { return layout; }
 
 private:
   Memory *m;


### PR DESCRIPTION
Also move MemRef::conv to encode.cpp because it is using MemRef::storeArray