### PR TITLE
Fix issue where truncate() may unexpectedly yield NaN

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -1100,7 +1100,8 @@ Expr AbsFpEncoding::truncate(const smt::Expr &f, aop::AbsFpEncoding &tgt) {
   return Expr::mkIte(isnan(f), tgt.nan(),
           Expr::mkIte(f == infinity(), tgt.infinity(),
           Expr::mkIte(f == infinity(true), tgt.infinity(true),
-          Expr::mkIte(limit_bits != limit_zero,
+          Expr::mkIte(limit_bits != limit_zero |
+                      floored_value.uge(tgt.getMagnitudeBits(tgt.infinity())),
             Expr::mkIte(sign_bit == sign_pos,
               tgt.infinity(), tgt.infinity(true)),
             Expr::mkIte(is_prec_zero, floored_float,

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -438,8 +438,12 @@ void AbsFpEncoding::addConstants(const set<llvm::APFloat>& const_set) {
         auto sv_prec_bits = Expr::mkFreshVar(Sort::bvSort(sv_prec_bitwidth),
                             "fp_const_sval_prec_bits_");
 
-        limit_bits = mkNonzero(
-            Expr::mkFreshVar(limit_bits, "fp_const_limit_bits_"));
+        auto inf_sv_value = (1 << sv_prec_bitwidth) -
+                            (1 << value_bit_info.prec_bitwidth);
+        auto limit_var = Expr::mkFreshVar(limit_bits, "fp_const_limit_bits_");
+        limit_bits = Expr::mkIte(sv_prec_bits.uge(inf_sv_value), 
+          limit_var,
+          mkNonzero(move(limit_var)));
         e_value = limit_bits.concat(sv_prec_bits);
 
       } else if (!casting_info->zero_prec_bits) {

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -1101,11 +1101,13 @@ Expr AbsFpEncoding::truncate(const smt::Expr &f, aop::AbsFpEncoding &tgt) {
   assert(floored_float.bitwidth() == tgt.sort().bitwidth());
   const auto is_prec_zero = prec_bits ? *prec_bits == 0 : Expr::mkBool(true);
 
+  const auto is_truncated_value_inf_or_nan =
+              floored_value.uge(tgt.getMagnitudeBits(tgt.infinity()));
   return Expr::mkIte(isnan(f), tgt.nan(),
           Expr::mkIte(f == infinity(), tgt.infinity(),
           Expr::mkIte(f == infinity(true), tgt.infinity(true),
           Expr::mkIte(limit_bits != limit_zero |
-                      floored_value.uge(tgt.getMagnitudeBits(tgt.infinity())),
+                      is_truncated_value_inf_or_nan,
             Expr::mkIte(sign_bit == sign_pos,
               tgt.infinity(), tgt.infinity(true)),
             Expr::mkIte(is_prec_zero, floored_float,


### PR DESCRIPTION
Due to a pitfall in our FP encoding, truncating a value of which TB == INT_MAX yields NaN although the original value is some finite value.
Therefore, even if LB == 0, truncate() now explicitly yields Inf if the TB >= INT_MAX - 1.
Also, constants beyond LFP's range may be assigned a BV of which LB == 0 and TB >= INT_MAX - 1.