### PR TITLE
Fix useAllLogic is always on when vinput.isFpAddAssociative

### DIFF
--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -642,7 +642,7 @@ static Results validate(ValidationInput vinput) {
     }
 
     if (isChanged) {
-      queue.push({nextAbs, /* useAllLogic */vinput.isFpAddAssociative});
+      queue.push({nextAbs, /* useAllLogic */false});
     } else {
       /* 4. fp add, sum encoding level */
       // Since UNROLL_TO_ADD may cause big slowdown, turn in off at the end
@@ -653,7 +653,7 @@ static Results validate(ValidationInput vinput) {
       if (abs.fpAddSumEncoding == AbsFpAddSumEncoding::DEFAULT) {
         if (usedOps.fpSum) {
           nextAbs.fpAddSumEncoding = AbsFpAddSumEncoding::UNROLL_TO_ADD;
-          queue.push({nextAbs, /* useAllLogic */vinput.isFpAddAssociative});
+          queue.push({nextAbs, /* useAllLogic */false});
         }
       }
     }


### PR DESCRIPTION
In previous decision (https://github.com/aqjune/mlir-tv/pull/125),
`useAllLogic` is related with `vinput.isFpAddAssociative` because it uses "multiset theory" and "constant array".
But now, we use "QF_AUFBV" logic in Z3 and "HO_ALL" logic in CVC5 by default, we do not need to use all logic when vinput.isFpAddAssociative is given. 