### PR TITLE
Fix cvc5 implementation of `Expr::operator^`

### DIFF
--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -898,7 +898,11 @@ EXPR_BVOP_UINT64(operator^)
 Expr Expr::operator^(const Expr &rhs) const {
   Expr e;
   SET_Z3_USEOP(e, rhs, operator^);
-  SET_CVC5_USEOP(e, rhs, BITVECTOR_XOR);
+  if (sort().isBV()) {
+    SET_CVC5_USEOP(e, rhs, BITVECTOR_XOR);
+  } else {
+    SET_CVC5_USEOP(e, rhs, XOR);
+  }
   return e;
 }
 


### PR DESCRIPTION
cvc5 distinguishes logical and BV xor, but `Expr::operator^` only uses BV xor.
This PR fixes the implementation so that it uses the correct operator for each case.