### PR TITLE
Reserve max VALUE_BITS for float::MAX

### DIFF
--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -1301,7 +1301,7 @@ Expr AbsFpEncoding::getFpConstantPrecondition() {
   bool firstItr = true;
 
   for (const auto &[fp, absrepr] : fpconst_absrepr) {
-    assert(!fp.isInfinity() && !fp.isZero());
+    assert(!fp.isInfinity() && !fp.isZero() && !fp.isLargest());
 
     if (!fp.isNegative()) {
       // SMT encoding of x and -x is equivalent modulo sign bit; exit early

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -135,14 +135,16 @@ void setAbstraction(
       abs.fpAddSumEncoding == AbsFpAddSumEncoding::USE_SUM_ONLY);
 
   // without suffix f, it will become llvm::APFloat with double semantics
-  // Note that 0.0 and 1.0 may already have been added during analysis.
-  // 0.0 and 1.0 are necessary to prove several arithmetic properties,
-  // so we're manually inserting 0.0 and 1.0
+  // Note that 0.0, 1.0, and fMAX may already have been added during analysis.
+  // Above three numbers are necessary to prove several arithmetic properties,
+  // so we're manually inserting them into constant sets
   // just in case they are not added during the analysis.
   floatConsts.emplace(0.0f);
   floatConsts.emplace(1.0f);
+  floatConsts.emplace(llvm::APFloat::getLargest(llvm::APFloat::IEEEsingle()));
   doubleConsts.emplace(0.0);
   doubleConsts.emplace(1.0);
+  doubleConsts.emplace(llvm::APFloat::getLargest(llvm::APFloat::IEEEdouble()));
 
   // + 2: reserved for +NaN, +Inf; separately counted because they cannot be
   // included in set<APFloat>
@@ -270,6 +272,8 @@ AbsFpEncoding::AbsFpEncoding(const llvm::fltSemantics &semantics,
   fpconst_inf_neg = Expr::mkBV(signed_value + inf_value, fp_bitwidth);
   fpconst_zero_pos = Expr::mkBV(0, fp_bitwidth);
   fpconst_zero_neg = Expr::mkBV(signed_value + 0, fp_bitwidth);
+  fpconst_max = Expr::mkBV(inf_value - 1, fp_bitwidth);
+  fpconst_min = Expr::mkBV(signed_value + inf_value - 1, fp_bitwidth);
 
   fp_sumfn.reset();
   fp_assoc_sumfn.reset();
@@ -408,6 +412,9 @@ void AbsFpEncoding::addConstants(const set<llvm::APFloat>& const_set) {
     if (fp_const.isZero()) {
       // 0.0 should not be added to absrepr
       continue;
+    } else if (fp_const.isLargest()) {
+      // fp::MAX should not be added to absrepr
+      continue;
     }
 
     optional<Expr> e_value;
@@ -500,6 +507,9 @@ Expr AbsFpEncoding::constant(const llvm::APFloat &f) const {
     return *fpconst_zero_pos;
   else if (f.isNegZero())
     return *fpconst_zero_neg;
+  else if (f.isLargest()) {
+    return f.isNegative() ? *fpconst_min : *fpconst_max;
+  }
 
   // all other constant values in src and tgt IRs are added at analysis stage,
   // so this expression should never fail!
@@ -526,6 +536,12 @@ vector<pair<llvm::APFloat, Expr>> AbsFpEncoding::getAllConstants() const {
   if (fpconst_inf_neg)
     constants.emplace_back(llvm::APFloat::getInf(semantics, true),
         *fpconst_inf_neg);
+  if (fpconst_max)
+    constants.emplace_back(llvm::APFloat::getLargest(semantics, false),
+        *fpconst_max);
+  if (fpconst_min)
+    constants.emplace_back(llvm::APFloat::getLargest(semantics, true),
+        *fpconst_min);
 
   return constants;
 }
@@ -550,6 +566,10 @@ void AbsFpEncoding::evalConsts(smt::Model model) {
   if (fpconst_inf_neg) {
     *fpconst_inf_neg = model.eval(*fpconst_inf_neg);
   }
+  if (fpconst_max)
+    *fpconst_max = model.eval(*fpconst_max);
+  if (fpconst_min)
+    *fpconst_min = model.eval(*fpconst_min);
 }
 
 vector<llvm::APFloat> AbsFpEncoding::possibleConsts(const Expr &e) const {
@@ -577,6 +597,10 @@ vector<llvm::APFloat> AbsFpEncoding::possibleConsts(const Expr &e) const {
     vec.push_back(llvm::APFloat::getInf(semantics));
   } else if (fpconst_inf_neg && fpconst_inf_neg->isIdentical(e_simp)) {
     vec.push_back(llvm::APFloat::getInf(semantics, true));
+  } else if (fpconst_max && fpconst_max->isIdentical(e_simp)) {
+    vec.push_back(llvm::APFloat::getLargest(semantics, false));
+  } else if (fpconst_min && fpconst_min->isIdentical(e_simp)) {
+    vec.push_back(llvm::APFloat::getLargest(semantics, true));
   }
 
   return vec;
@@ -599,6 +623,10 @@ Expr AbsFpEncoding::infinity(bool isNegative) const {
 
 Expr AbsFpEncoding::nan() const {
   return constant(llvm::APFloat::getNaN(semantics));
+}
+
+Expr AbsFpEncoding::largest(bool isNegative) const {
+  return constant(llvm::APFloat::getLargest(semantics, isNegative));
 }
 
 Expr AbsFpEncoding::isnan(const Expr &f) {

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -1295,7 +1295,7 @@ Expr AbsFpEncoding::getFpConstantPrecondition() {
   Expr precond = Expr::mkBool(true);
   
   auto prev_fp = llvm::APFloat::getInf(semantics, true);
-  // both largest() and infinity() are hardcoded hardcoded value,
+  // both largest() and infinity() are hardcoded value,
   // so we don't have to explicitly encode the relationship between them
   auto prev_absrepr = largest(true);
   bool firstItr = true;

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -1295,7 +1295,9 @@ Expr AbsFpEncoding::getFpConstantPrecondition() {
   Expr precond = Expr::mkBool(true);
   
   auto prev_fp = llvm::APFloat::getInf(semantics, true);
-  auto prev_absrepr = infinity(true);
+  // both largest() and infinity() are hardcoded hardcoded value,
+  // so we don't have to explicitly encode the relationship between them
+  auto prev_absrepr = largest(true);
   bool firstItr = true;
 
   for (const auto &[fp, absrepr] : fpconst_absrepr) {

--- a/src/abstractops.cpp
+++ b/src/abstractops.cpp
@@ -1294,7 +1294,7 @@ Expr AbsFpEncoding::getFpTruncatePrecondition(aop::AbsFpEncoding &tgt) {
 Expr AbsFpEncoding::getFpConstantPrecondition() {
   Expr precond = Expr::mkBool(true);
   
-  auto prev_fp = llvm::APFloat::getInf(semantics, true);
+  auto prev_fp = llvm::APFloat::getLargest(semantics, true);
   // both largest() and infinity() are hardcoded value,
   // so we don't have to explicitly encode the relationship between them
   auto prev_absrepr = largest(true);

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -102,9 +102,9 @@ private:
   std::optional<smt::Expr> fpconst_inf_neg;
   // float::MIN/MAX are stored in separate variable
   // as they must be reserved a fixed value for correct validation
-  std::optional<smt::Expr> fpconst_min;
+  std::optional<smt::Expr> fpconst_min; // -float::MAX
   std::optional<smt::Expr> fpconst_max;
-  // Abstract representation of valid fp constants.
+  // Abstract representation of valid fp constants (except +-0.0, min, max).
   std::map<llvm::APFloat, smt::Expr> fpconst_absrepr;
 
   const static unsigned SIGN_BITS = 1;

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -100,6 +100,10 @@ private:
   std::optional<smt::Expr> fpconst_nan;
   std::optional<smt::Expr> fpconst_inf_pos;
   std::optional<smt::Expr> fpconst_inf_neg;
+  // float::MIN/MAX are stored in separate variable
+  // as they must be reserved a fixed value for correct validation
+  std::optional<smt::Expr> fpconst_min;
+  std::optional<smt::Expr> fpconst_max;
   // Abstract representation of valid fp constants.
   std::map<llvm::APFloat, smt::Expr> fpconst_absrepr;
 
@@ -190,6 +194,7 @@ public:
   smt::Expr one(bool isNegative = false) const;
   smt::Expr infinity(bool isNegative = false) const;
   smt::Expr nan() const;
+  smt::Expr largest(bool isNegative = false) const;
 
   std::vector<std::pair<llvm::APFloat, smt::Expr>> getAllConstants() const;
   void evalConsts(smt::Model model);


### PR DESCRIPTION
This PR assigns the largest possible VALUE_BITS for the float::MAX (f32::MAX, f64::MAX, ...) to ensure that no other finite numbers are larger than it.
Although the term is float::MAX, this also applies to -float::MAX (note that this is different from float::MIN : the latter means the float number with smallest magnitude)