### PR TITLE
Fix smt interface for cvc5

### DIFF
--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -102,7 +102,7 @@ public:
     cvc5_term_cache.insert({name, move(term)});
   }
 
-  void clearCachedTerm() {
+  void clearCachedTerms() {
     cvc5_term_cache.clear();
   }
 #endif // SOLVER_CVC5
@@ -1557,7 +1557,7 @@ Solver::~Solver() {
   // We can't destroy solver since it will invalidate every variable
   // it has created
   if (sctx.cvc5) {
-    sctx.clearCachedTerm();
+    sctx.clearCachedTerms();
     sctx.cvc5->pop();
   }
 #endif // SOLVER_CVC5

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -101,14 +101,14 @@ public:
   void addNamedTerm(const string &name, cvc5::api::Term &&term) {
     cvc5_term_cache.insert({name, move(term)});
   }
+
+  void clearCachedTerm() {
+    cvc5_term_cache.clear();
+  }
 #endif // SOLVER_CVC5
 
   string getFreshName(string prefix) {
     return prefix.append("#" + to_string(fresh_var_counter++));
-  }
-
-  void clearCachedTerm() {
-    cvc5_term_cache.clear();
   }
 };
 


### PR DESCRIPTION
Allowing multiple smt variables of same name is error-prone and undesirable.
This is no longer allowed when using cvc5, unless the `smt::Solver` that created the variables is destructed.