### PR TITLE
Add zero-dimension tensor support for `mlir::tensor::FromElementsOp`

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1938,14 +1938,8 @@ void encodeOp(State &st, mlir::tensor::FromElementsOp op, bool) {
   auto elemTy = op.getType().getElementType();
   if (elems.size() == 0) {
     // Zero-dim tensor: derive Sort from Op return type
-    optional<Sort> elemSort;
-    if (elemTy.isa<mlir::FloatType>())
-      elemSort = Float::sort(elemTy);
-    else if (elemTy.isIndex())
-      elemSort = Index::sort();
-    else if (elemTy.isInteger(elemTy.getIntOrFloatBitWidth()))
-      elemSort = Integer::sort(elemTy.getIntOrFloatBitWidth());
-    else
+    auto elemSort = convertPrimitiveTypeToSort(elemTy);
+    if (!elemSort)
       throw UnsupportedException(op.getOperation(), "Unsupported type");
     st.regs.add(op.getResult(), Tensor(elemTy, move(*elemSort)));
   }

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1937,9 +1937,8 @@ void encodeOp(State &st, mlir::tensor::FromElementsOp op, bool) {
   for (unsigned i = 0; i < op.getNumOperands(); ++i)
     elems.push_back(st.regs.getExpr(op.getOperand(i)));
 
-  if (resTy.getRank() == 0) {
+  if (resTy.getRank() == 0)
     dims.push_back(1);
-  }
   for (unsigned i = 0; i < resTy.getRank(); ++i)
     dims.push_back(resTy.getDimSize(i));
 

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1937,21 +1937,14 @@ void encodeOp(State &st, mlir::tensor::FromElementsOp op, bool) {
   for (unsigned i = 0; i < op.getNumOperands(); ++i)
     elems.push_back(st.regs.getExpr(op.getOperand(i)));
 
-  auto elemTy = op.getType().getElementType();
-  if (elems.size() == 0) {
-    // Zero-dim tensor: derive Sort from Op return type
-    auto elemSort = convertPrimitiveTypeToSort(elemTy);
-    if (!elemSort)
-      throw UnsupportedException(op.getOperation(), "Unsupported type");
-    st.regs.add(op.getResult(), Tensor(elemTy, move(*elemSort)));
-  } else {
-    if (resTy.getRank() == 0) {
-      dims.push_back(1);
-    }
-    for (unsigned i = 0; i < resTy.getRank(); ++i)
-      dims.push_back(resTy.getDimSize(i));
-    st.regs.add(op.getResult(), Tensor(elemTy, move(elems), dims));
+  if (resTy.getRank() == 0) {
+    dims.push_back(1);
   }
+  for (unsigned i = 0; i < resTy.getRank(); ++i)
+    dims.push_back(resTy.getDimSize(i));
+
+  auto elemTy = op.getType().getElementType();
+  st.regs.add(op.getResult(), Tensor(elemTy, move(elems), dims));
 }
 
 template<>

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -432,6 +432,13 @@ Tensor::Tensor(mlir::Type elemType, vector<Expr> &&elems1d):
     arr = arr.store(i, elems1d[i]);
 }
 
+// A zero-dim tensor
+Tensor::Tensor(mlir::Type elemType, Sort &&sort):
+    ShapedValue(elemType),
+    dims({ (Expr)Index::zero() }),
+    arr(Expr::mkFreshVar(arraySortForTensor(move(sort)), "tensor_val")),
+    initialized(splatArrayForTensor(Expr::mkBool(true))) {}
+
 // A fresh tensor
 Tensor Tensor::var(
     mlir::Type elemType, string &&name, const vector<uint64_t> &dimvec,

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -432,17 +432,11 @@ Tensor::Tensor(mlir::Type elemType, vector<Expr> &&elems1d):
     arr = arr.store(i, elems1d[i]);
 }
 
-// A zero-dim tensor
-Tensor::Tensor(mlir::Type elemType, Sort &&sort):
-    ShapedValue(elemType),
-    dims({ (Expr)Index::zero() }),
-    arr(Expr::mkFreshVar(arraySortForTensor(move(sort)), "tensor_val")),
-    initialized(splatArrayForTensor(Expr::mkBool(true))) {}
-
 Tensor::Tensor(mlir::Type elemType, vector<Expr> &&elems1d, vector<uint64_t> &dim):
     ShapedValue(elemType),
     dims({}),
-    arr(Expr::mkFreshVar(arraySortForTensor(elems1d[0].sort()), "tensor_val")),
+    arr(Expr::mkFreshVar(
+      arraySortForTensor(*convertPrimitiveTypeToSort(elemType)), "tensor_val")),
     initialized(splatArrayForTensor(Expr::mkBool(true))) {
   for (unsigned i = 0; i < elems1d.size(); ++i)
     arr = arr.store(i, elems1d[i]);

--- a/src/value.h
+++ b/src/value.h
@@ -138,6 +138,8 @@ public:
          const std::vector<uint64_t> &dims, const smt::Expr &zero);
   // A dense tensor (1 dimensional).
   Tensor(mlir::Type elemType, std::vector<smt::Expr> &&elems);
+  // A zero-dim tensor
+  Tensor(mlir::Type elemType, smt::Sort &&sort);
 
 
   smt::Expr asArray() const { return arr; }

--- a/src/value.h
+++ b/src/value.h
@@ -138,9 +138,7 @@ public:
          const std::vector<uint64_t> &dims, const smt::Expr &zero);
   // A dense tensor (1 dimensional).
   Tensor(mlir::Type elemType, std::vector<smt::Expr> &&elems);
-  // A zero-dim tensor
-  Tensor(mlir::Type elemType, smt::Sort &&sort);
-
+  // Multidimensional tensor
   Tensor(mlir::Type elemType, std::vector<smt::Expr> &&elems, std::vector<uint64_t> &dims);
 
   smt::Expr asArray() const { return arr; }


### PR DESCRIPTION
This PR fixes the issue where encoding `mlir::tensor::FromElementsOp` crashed upon encountering zero-dim tensor situation.
If the operand is not given and the return type is 0-dim tensor, 0-dim `Tensor` of Op return type is created