### PR TITLE
Regard memref with no dimension as scalar

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -1743,7 +1743,7 @@ MemRef MemRef::eval(Model mdl) const {
 pair<Expr, Expr> MemRef::to1DIdxWithLayout(const vector<Expr> &_idxs) const {
   auto idxs = _idxs;
   if (idxs.empty()) {
-    idxs.push_back(Index::zero());
+    idxs.push_back(Index::one());
   }
   auto Expr = layout.mapping(idxs);
   auto inbounds = layout.inbounds(idxs);


### PR DESCRIPTION
This PR fixes the issue with https://github.com/aqjune/mlir-tv/pull/288.
A memref with no explicit dimensions should be regarded as a scalar memref, not a zero-dim memref.