### PR TITLE
Fix crashes from Conversion tests

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -2260,10 +2260,18 @@ void encodeOp(State &st, mlir::tosa::FullyConnectedOp op, bool) {
   auto input = op.input();   // [N, IC]
   auto weight = op.weight(); // [OC, IC]
   auto bias = op.bias();     // [OC]
-  if (!input.getType().isa<mlir::RankedTensorType>() ||
-      !weight.getType().isa<mlir::RankedTensorType>() ||
-      !bias.getType().isa<mlir::RankedTensorType>())
+  auto inputType = input.getType();
+  auto weightType = weight.getType();
+  auto biasType = bias.getType();
+
+  if (!inputType.isa<mlir::RankedTensorType>() ||
+      !weightType.isa<mlir::RankedTensorType>() ||
+      !biasType.isa<mlir::RankedTensorType>())
     throw UnsupportedException(op.getOperation(), "Unsupported operand type");
+  
+  if ((inputType != weightType) || (weightType != biasType))
+    throw UnsupportedException(op.getOperation(),
+        "Operands of different types are unsupported");
 
   auto inputTensor = st.regs.get<Tensor>(input);
   auto weightTensor = st.regs.get<Tensor>(weight);

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1348,6 +1348,11 @@ void encodeOp(State &st, mlir::tosa::AvgPool2dOp op, bool) {
   auto paddings = getFromArrayAttr<Index>(op.pad());
   auto strides = getFromArrayAttr<Index>(op.stride());
 
+  if (!op.getType().isa<mlir::FloatType>()) {
+    throw UnsupportedException(op.getOperation(),
+          "Unsupported element type");
+  }
+
   for (unsigned i = 0; i < input.getRank(); i ++) {
     uint64_t v;
     if(!paddings[i].isUInt(v))
@@ -1369,6 +1374,11 @@ void encodeOp(State &st, mlir::tosa::MaxPool2dOp op, bool) {
   auto kernelDims = getFromArrayAttr<Index>(op.kernel());
   auto paddings = getFromArrayAttr<Index>(op.pad());
   auto strides = getFromArrayAttr<Index>(op.stride());
+
+  if (!op.getType().isa<mlir::FloatType>()) {
+    throw UnsupportedException(op.getOperation(),
+          "Unsupported element type");
+  }
 
   for (unsigned i = 0; i < input.getRank(); i ++) {
     uint64_t v;


### PR DESCRIPTION
* Pooling only supports FP in mlir-tv: raise UnsupportedException for non-FP tensors
* ElementwiseBinOp only supports operation between operands of the same type: raise UnsupportedException for tosa::FullyConnectedOp with operands of different type tensors