### PR TITLE
New test keywords for `mlir-tv`

### DIFF
--- a/tests/lit/formats/mlirtest.py
+++ b/tests/lit/formats/mlirtest.py
@@ -137,7 +137,7 @@ class SrcTgtPairTest(TestFormat):
     __verify_incorrect_regex = re.compile(r"^// ?VERIFY-INCORRECT$")
     __unsupported_regex = re.compile(r"^// ?UNSUPPORTED$")
     __expect_regex = re.compile(r"^// ?EXPECT ?: ?\"(.*)\"$")
-    __no_identity_regex = re.compile(r"^// ?NO-IDENTITY$")
+    __no_identity_regex = re.compile(r"^// ?SKIP-IDENTITY-CHECKS$")
 
     def __init__(self, dir_tv: str, pass_name: str) -> None:
         self._dir_tv: str = dir_tv

--- a/tests/lit/formats/mlirtest.py
+++ b/tests/lit/formats/mlirtest.py
@@ -3,7 +3,7 @@ from lit.formats.base import TestFormat
 import lit
 from lit.Test import ResultCode
 
-from typing import Tuple
+from typing import Any, List, Optional, Tuple
 from abc import ABC, abstractmethod
 import subprocess
 import os
@@ -35,7 +35,7 @@ def remove_suffix(input_string, suffix):
 
 
 class TestKeyword(Enum):
-    NOTEST = auto()
+    INVALID = auto()
     VERIFY = auto()
     VERIFY_INCORRECT = auto()
     UNSUPPORTED = auto()
@@ -87,12 +87,12 @@ class FixedResultTestBase(TestBase):
     def __init__(self, keyword: TestKeyword) -> None:
         super().__init__(keyword)
 
-class NoTest(FixedResultTestBase):
+class InvalidTest(FixedResultTestBase):
     def __init__(self):
-        super().__init__(TestKeyword.NOTEST)
+        super().__init__(TestKeyword.INVALID)
 
     def check_exit_code(self, outs, errs, exit_code) -> Tuple[ResultCode, str]:
-        return lit.Test.UNRESOLVED, ""
+        return lit.Test.UNRESOLVED, "Ill-formed test setup!"
 
 class UnsupportedTest(FixedResultTestBase):
     def __init__(self):
@@ -122,25 +122,30 @@ class VerifyIncorrectTest(ExitCodeDependentTestBase):
             return lit.Test.XFAIL, ""
 
 class ExpectTest(ExitCodeDependentTestBase):
-    def __init__(self, msg: str):
+    def __init__(self, keywords: List[str]):
         super().__init__(TestKeyword.EXPECT)
-        self.__msg: str = msg
+        self.__keywords: list[str] = keywords
 
     def _check(self, outs: str, errs: str, exit_code: int) -> Tuple[ResultCode, str]:
-        if self.__msg in outs or self.__msg in errs:
-            return lit.Test.PASS, ""
-        else:
-            return lit.Test.FAIL, f"Expected message >>\n{self.__msg}\n\nstdout >>\n{outs}\n\nstderr >>\n{errs}"
+        for keyword in self.__keywords:
+            if keyword in outs or keyword in errs:
+                pass
+            else:
+                return lit.Test.FAIL, f"Expected message >>\n{keyword}\n\nstdout >>\n{outs}\n\nstderr >>\n{errs}"
+
+        return lit.Test.PASS, ""
 
 class SrcTgtPairTest(TestFormat):
     __suffix_src: str = ".src.mlir"
     __suffix_tgt: str = ".tgt.mlir"
-    __args_regex = re.compile(r"^// ?ARGS ?: ?(.*)$")
+    __args_regex = re.compile(r"^// ?ARGS ?: ?(.+)$")
     __verify_regex = re.compile(r"^// ?VERIFY$")
     __verify_incorrect_regex = re.compile(r"^// ?VERIFY-INCORRECT$")
     __unsupported_regex = re.compile(r"^// ?UNSUPPORTED$")
-    __expect_regex = re.compile(r"^// ?EXPECT ?: ?\"(.*)\"$")
-    __no_identity_regex = re.compile(r"^// ?SKIP-IDENTITY-CHECKS$")
+    __expect_regex = re.compile(r"^// ?EXPECT ?: ?\"(.+)\"$")
+    __expect_keyword_regex = re.compile(r"^// ?EXPECT ?: ?\"(.+)\"(?:(?: ?\&\& ?\"(.+)\")*|(?: ?\|\| ?\"(.+)\")*)$")
+    __args_identity_regex = re.compile(r"^// ?ARGS-IDCHECK ?: ?(.+)$")
+    __skip_identity_regex = re.compile(r"^// ?SKIP-IDCHECK$")
 
     def __init__(self, dir_tv: str, pass_name: str) -> None:
         self._dir_tv: str = dir_tv
@@ -160,44 +165,70 @@ class SrcTgtPairTest(TestFormat):
                 yield lit.Test.Test(testSuite, path_in_suite 
                     + (os.path.join(pass_name, remove_suffix(case_name, self.__suffix_src)),), localConfig)
 
-    def execute(self, test, litConfig) -> Tuple[ResultCode, str]:
-        test = test.getSourcePath()
-        tc_src = test + self.__suffix_src
-        tc_tgt = test + self.__suffix_tgt
+    def execute(self, test_filename, litConfig) -> Tuple[ResultCode, str]:
+        testname = test_filename.getSourcePath()
+        tc_src = testname + self.__suffix_src
+        tc_tgt = testname + self.__suffix_tgt
         if not (os.path.isfile(tc_src) and os.path.isfile(tc_tgt)):
             # src or tgt mlir file is missing
             return lit.Test.SKIPPED, ""
 
-        skip_identity_check: bool = False
-        custom_args: str = []
-        test: TestBase = NoTest()
-        with open(tc_src, 'r') as src_file:
-            for line in src_file.readlines():
-                if self.__verify_regex.match(line):
-                    test = VerifyTest()
-                elif self.__verify_incorrect_regex.match(line):
-                    test = VerifyIncorrectTest()
-                elif self.__unsupported_regex.match(line):
-                    test = UnsupportedTest()
-                    skip_identity_check = True
-                elif self.__expect_regex.match(line):
-                    msg: str = self.__expect_regex.findall(line)[0]
-                    test = ExpectTest(msg)
-                elif self.__no_identity_regex.match(line):
-                    skip_identity_check = True
-                elif self.__args_regex.match(line):
-                    custom_args = self.__args_regex.match(line).group(1).split()
-                elif not line.strip(): # empty line: no more test keyword
-                    break
+        class MutOnce:
+            def __init__(self, data: Any) -> None:
+                self.__data: Any = data
+                self.__mutable: bool = True
 
-        if not skip_identity_check:
-            src_identity: Tuple[ResultCode, str] = VerifyTest().check_exit_code(*_executeCommand(self._dir_tv, tc_src, tc_src))
+            def update(self, data: Any) -> None:
+                if self.__mutable:
+                    self.__data = data
+                    self.__mutable = False
+                else:
+                    raise RuntimeError
+
+            def get(self) -> Any:
+                return self.__data
+
+        idcheck_args = MutOnce([]) # Optional[list[str]]
+        custom_args = MutOnce([]) # list[str]
+        test = MutOnce(InvalidTest()) # TestBase
+        with open(tc_src, 'r') as src_file:
+            try:
+                for line in src_file.readlines():
+                    if self.__verify_regex.match(line):
+                        test.update(VerifyTest())
+                    elif self.__verify_incorrect_regex.match(line):
+                        test.update(VerifyIncorrectTest())
+                    elif self.__unsupported_regex.match(line):
+                        test.update(UnsupportedTest())
+                    elif self.__expect_regex.match(line):
+                        if self.__expect_keyword_regex.match(line):
+                            keywords: list[str] = list(self.__expect_keyword_regex.findall(line)[0])
+                            # print(keywords)
+                            test.update(ExpectTest(keywords))
+                        else:
+                            test.update(InvalidTest())
+                    elif self.__skip_identity_regex.match(line):
+                        idcheck_args.update(None)
+                    elif self.__args_identity_regex.match(line):
+                        keywords: list[str] = list(self.__args_identity_regex.findall(line)[0])
+                        idcheck_args.update(keywords)
+                    elif self.__args_regex.match(line):
+                        custom_args.update(self.__args_regex.match(line).group(1).split())
+                    elif not line.strip(): # empty line: no more test keyword
+                        break
+            except RuntimeError:
+                # invalid test keyword combination
+                # override with InvalidTest
+                test = MutOnce(InvalidTest())
+
+        if not (test.get() == TestKeyword.UNSUPPORTED or test.get() == TestKeyword.INVALID) and idcheck_args.get() is not None:
+            src_identity: Tuple[ResultCode, str] = VerifyTest().check_exit_code(*_executeCommand(self._dir_tv, tc_src, tc_src, idcheck_args.get()))
             if src_identity[0] != lit.Test.PASS:
                 return src_identity
 
-            tgt_identity: Tuple[ResultCode, str] = VerifyTest().check_exit_code(*_executeCommand(self._dir_tv, tc_tgt, tc_tgt))
+            tgt_identity: Tuple[ResultCode, str] = VerifyTest().check_exit_code(*_executeCommand(self._dir_tv, tc_tgt, tc_tgt, idcheck_args.get()))
             if tgt_identity[0] != lit.Test.PASS:
                 return tgt_identity
 
-        return test.check_exit_code(*_executeCommand(
-            self._dir_tv, tc_src, tc_tgt, custom_args))
+        return test.get().check_exit_code(*_executeCommand(
+            self._dir_tv, tc_src, tc_tgt, custom_args.get()))

--- a/tests/lit/formats/mlirtest.py
+++ b/tests/lit/formats/mlirtest.py
@@ -75,6 +75,9 @@ class ExitCodeDependentTestBase(TestBase):
             # 90~99:   unsupported
             # 100~109: timeout/value mismatch/etc
             return self._check(outs, errs, exit_code)
+        else:
+            # likely segfault
+            return lit.Test.FAIL, f"stdout >>\n{outs}\n\nstderr >>\n{errs}"
 
     @abstractmethod
     def _check(self, outs: str, errs: str, exit_code: int) -> Tuple[ResultCode, str]:

--- a/tests/lit/formats/mlirtest.py
+++ b/tests/lit/formats/mlirtest.py
@@ -1,5 +1,4 @@
 from enum import Enum, auto
-from operator import or_
 from lit.formats.base import TestFormat
 import lit
 from lit.Test import ResultCode

--- a/tests/litmus/diagnostics/assign-random.src.mlir
+++ b/tests/litmus/diagnostics/assign-random.src.mlir
@@ -1,6 +1,6 @@
 // ARGS: -assign-random-to-unsupported-ops
 // EXPECT: "Assigning any value to this op (linalg.batch_matvec).."
-// SKIP-IDENTITY-CHECKS
+// SKIP-IDCHECK
 
 func @f(%ta: tensor<?x?x?xf32>, %tb: tensor<?x?x?xf32>, %tc: tensor<?x?x?xf32>,
 		%tv: tensor<?x?xf32>, %tv2: tensor<?x?xf32>) {

--- a/tests/litmus/diagnostics/assign-random.src.mlir
+++ b/tests/litmus/diagnostics/assign-random.src.mlir
@@ -1,6 +1,6 @@
 // ARGS: -assign-random-to-unsupported-ops
 // EXPECT: "Assigning any value to this op (linalg.batch_matvec).."
-// NO-IDENTITY
+// SKIP-IDENTITY-CHECKS
 
 func @f(%ta: tensor<?x?x?xf32>, %tb: tensor<?x?x?xf32>, %tc: tensor<?x?x?xf32>,
 		%tv: tensor<?x?xf32>, %tv2: tensor<?x?xf32>) {

--- a/tests/litmus/linalg-ops/memref_matmul_bad.src.mlir
+++ b/tests/litmus/linalg-ops/memref_matmul_bad.src.mlir
@@ -1,5 +1,5 @@
 // EXPECT: "Source is more defined than target"
-// NO-IDENTITY
+// SKIP-IDENTITY-CHECKS
 // Source is more defined because %c have to point writable memory block in src.
 // Pass identity checks since tgt-tgt pair takes too long time.
 

--- a/tests/litmus/linalg-ops/memref_matmul_bad.src.mlir
+++ b/tests/litmus/linalg-ops/memref_matmul_bad.src.mlir
@@ -1,5 +1,5 @@
 // EXPECT: "Source is more defined than target"
-// SKIP-IDENTITY-CHECKS
+// SKIP-IDCHECK
 // Source is more defined because %c have to point writable memory block in src.
 // Pass identity checks since tgt-tgt pair takes too long time.
 

--- a/tests/litmus/memref-ops/nonidentity-layout-store-bad.src.mlir
+++ b/tests/litmus/memref-ops/nonidentity-layout-store-bad.src.mlir
@@ -1,6 +1,6 @@
 // VERIFY-INCORRECT
 // ARGS: -memref-inputs-simple
-// NO-IDENTITY
+// SKIP-IDENTITY-CHECKS
 
 func @f(%arg: memref<1x1xf32, affine_map<(d0, d1) -> (d0 * 4 + d1 + 16)>>) {
   %ts1 = arith.constant dense<1.0>: tensor<1x1xf32>

--- a/tests/litmus/memref-ops/nonidentity-layout-store-bad.src.mlir
+++ b/tests/litmus/memref-ops/nonidentity-layout-store-bad.src.mlir
@@ -1,6 +1,6 @@
 // VERIFY-INCORRECT
 // ARGS: -memref-inputs-simple
-// SKIP-IDENTITY-CHECKS
+// SKIP-IDCHECK
 
 func @f(%arg: memref<1x1xf32, affine_map<(d0, d1) -> (d0 * 4 + d1 + 16)>>) {
   %ts1 = arith.constant dense<1.0>: tensor<1x1xf32>

--- a/tests/litmus/memref-ops/nonidentity-layout-store.src.mlir
+++ b/tests/litmus/memref-ops/nonidentity-layout-store.src.mlir
@@ -1,6 +1,6 @@
 // VERIFY
 // ARGS: -memref-inputs-simple
-// NO-IDENTITY
+// SKIP-IDENTITY-CHECKS
 
 func @f(%arg: memref<1x1xf32, affine_map<(d0, d1) -> (d0 * 4 + d1 + 16)>>) {
   %ts1 = arith.constant dense<1.0>: tensor<1x1xf32>

--- a/tests/litmus/memref-ops/nonidentity-layout-store.src.mlir
+++ b/tests/litmus/memref-ops/nonidentity-layout-store.src.mlir
@@ -1,6 +1,6 @@
 // VERIFY
 // ARGS: -memref-inputs-simple
-// SKIP-IDENTITY-CHECKS
+// SKIP-IDCHECK
 
 func @f(%arg: memref<1x1xf32, affine_map<(d0, d1) -> (d0 * 4 + d1 + 16)>>) {
   %ts1 = arith.constant dense<1.0>: tensor<1x1xf32>

--- a/tests/litmus/refinement/size-mismatch.src.mlir
+++ b/tests/litmus/refinement/size-mismatch.src.mlir
@@ -1,5 +1,5 @@
 // EXPECT: "Return value mismatch"
-// NO-IDENTITY
+// SKIP-IDENTITY-CHECKS
 
 func @f() -> tensor<?xf32> {
 	%c10 = arith.constant 10: index

--- a/tests/litmus/refinement/size-mismatch.src.mlir
+++ b/tests/litmus/refinement/size-mismatch.src.mlir
@@ -1,5 +1,5 @@
 // EXPECT: "Return value mismatch"
-// SKIP-IDENTITY-CHECKS
+// SKIP-IDCHECK
 
 func @f() -> tensor<?xf32> {
 	%c10 = arith.constant 10: index

--- a/tests/opts/README.md
+++ b/tests/opts/README.md
@@ -17,7 +17,7 @@ Use suffix `-bad` for `// VERIFY-INCORRECT` test cases
 `// EXPECT "<message>"` : check if the stdout/stderr includes the provided message  
 
 ## Test options
-`// NO-IDENTITY` : skip identity checks for `src.mlir` and `tgt.mlir`
+`// SKIP-IDENTITY-CHECKS` : skip identity checks for `src.mlir` and `tgt.mlir`
 
 ## Writing keywords and options
 All `src.mlir` must start with test keyword or test option. They must include one and only test keyword, and may include one or more test options.   

--- a/tests/opts/README.md
+++ b/tests/opts/README.md
@@ -22,7 +22,7 @@ Use suffix `-bad` for `// VERIFY-INCORRECT` test cases
 ## Test options
 `// ARGS: <arg>[( <arg>)+]` : Pass given arguments to `mlir-tv` for given test, except for identity checks.  
 `// SKIP-IDCHECK` : Skip identity checks for given test. **Cannot be used with `ARGS-IDCHECK`!**  
-`// ARGS-IDCHECK` : Pass given arguments to `mlir-tv` when running identity checks for given test. **Cannot be used with `SKIP-IDCHECK`!**
+`// ARGS-IDCHECK: <arg>[( <arg>)+]` : Pass given arguments to `mlir-tv` when running identity checks for given test. **Cannot be used with `SKIP-IDCHECK`!**
 
 ## Writing keywords and options
 All `src.mlir` must start with test keyword or test option. They must include one and only test keyword, and may include one or more test options.   

--- a/tests/opts/README.md
+++ b/tests/opts/README.md
@@ -11,13 +11,18 @@ Also, each test case should form a pair of `.src.mlir` and `.tgt.mlir`.
 Use suffix `-bad` for `// VERIFY-INCORRECT` test cases
 
 ## Test keywords
-`// VERIFY` : check if the transformation is correct  
-`// VERIFY-INCORRECT` : check if the transformation is indeed wrong  
-`// UNSUPPORTED` : ignore test case that includes **yet** unimplemented dialects  
-`// EXPECT "<message>"` : check if the stdout/stderr includes the provided message  
+`// VERIFY` : Check if the transformation is correct  
+`// VERIFY-INCORRECT` : Check if the transformation is indeed wrong  
+`// UNSUPPORTED` : Ignore test case that includes **yet** unimplemented dialects  
+`// EXPECT: "<message>"[ ((&& "message")+|(|| "message")+)]` : Check if the stdout/stderr includes the provided message(s).
+* If messages are delimited by &&, the test passes iff every message is included
+* If messages are delimited by ||, the test passes if at least one of them is included.
+* **Using both && and || is not allowed.**
 
 ## Test options
-`// SKIP-IDCHECK` : skip identity checks for `src.mlir` and `tgt.mlir`
+`// ARGS: <arg>[( <arg>)+]` : Pass given arguments to `mlir-tv` for given test, except for identity checks.  
+`// SKIP-IDCHECK` : Skip identity checks for given test. **Cannot be used with `ARGS-IDCHECK`!**  
+`// ARGS-IDCHECK` : Pass given arguments to `mlir-tv` when running identity checks for given test. **Cannot be used with `SKIP-IDCHECK`!**
 
 ## Writing keywords and options
 All `src.mlir` must start with test keyword or test option. They must include one and only test keyword, and may include one or more test options.   

--- a/tests/opts/README.md
+++ b/tests/opts/README.md
@@ -17,7 +17,7 @@ Use suffix `-bad` for `// VERIFY-INCORRECT` test cases
 `// EXPECT "<message>"` : check if the stdout/stderr includes the provided message  
 
 ## Test options
-`// SKIP-IDENTITY-CHECKS` : skip identity checks for `src.mlir` and `tgt.mlir`
+`// SKIP-IDCHECK` : skip identity checks for `src.mlir` and `tgt.mlir`
 
 ## Writing keywords and options
 All `src.mlir` must start with test keyword or test option. They must include one and only test keyword, and may include one or more test options.   


### PR DESCRIPTION
This PR updates lit test script for `mlir-tv` to support more sophisticated testing.
- When `mlir-tv` crashes due to segmentation fault, lit test now raises FAIL and show stderr instead of throwing exception.
- Updated keywords and test features are described in README.