### PR TITLE
Minor test script fixes

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,10 +1,12 @@
 # Before you add new test cases...
 
 ## Directory name convention
-### `<transformation-pass-name>`
-ex) `fold-tensor-extract-op`
+### Opts: `<transformation-pass-name>`
+ex) `opts/fold-tensor-extract-op`
+### Litmus: `<feature-category-name>`
+ex) `litmus/fp-ops`
 
-## Naming convention
+## File name convention
 ### `<case_name>[-bad].(src|tgt).mlir`
 ex) `nhwc_filter.src.mlir`, `const_tensor.tgt.mlir`, `i32-bad.src.mlir`.  
 Also, each test case should form a pair of `.src.mlir` and `.tgt.mlir`.  
@@ -13,7 +15,7 @@ Use suffix `-bad` for `// VERIFY-INCORRECT` test cases
 ## Test keywords
 `// VERIFY` : Check if the transformation is correct  
 `// VERIFY-INCORRECT` : Check if the transformation is indeed wrong  
-`// UNSUPPORTED` : Ignore test case that includes **yet** unimplemented dialects  
+`// UNSUPPORTED` : Use to ignore the test case that includes **yet** unimplemented dialects  
 `// EXPECT: "<message>"[ ((&& "message")+|(|| "message")+)]` : Check if the stdout/stderr includes the provided message(s).
 * If messages are delimited by &&, the test passes iff every message is included
 * If messages are delimited by ||, the test passes if at least one of them is included.

--- a/tests/lit/formats/mlirtest.py
+++ b/tests/lit/formats/mlirtest.py
@@ -3,15 +3,16 @@ from lit.formats.base import TestFormat
 import lit
 from lit.Test import ResultCode
 
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Tuple
 from abc import ABC, abstractmethod
 import subprocess
 import os
 import re
 import signal
 
+
 def _executeCommand(dir_tv: str, dir_src: str, dir_tgt: str,
-                    args = []) -> Tuple[str, str, int]:
+                    args=[]) -> Tuple[str, str, int]:
     command: list[str] = [dir_tv, dir_src, dir_tgt] + args
     with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8") as proc:
         exitCode = proc.wait()
@@ -24,11 +25,13 @@ def _executeCommand(dir_tv: str, dir_src: str, dir_tgt: str,
 
     return out, err, exitCode
 
+
 def _has_unknown_keyword(errs: str) -> bool:
     return "Unknown" in errs
 
-# Python 3.8 or earlier does not have removesuffix
+
 def remove_suffix(input_string, suffix):
+    # Python 3.8 or earlier does not have removesuffix
     if suffix and input_string.endswith(suffix):
         return input_string[:-len(suffix)]
     return input_string
@@ -41,17 +44,19 @@ class TestKeyword(Enum):
     UNSUPPORTED = auto()
     EXPECT = auto()
 
+
 class TestBase(ABC):
     @abstractmethod
     def __init__(self, keyword: TestKeyword) -> None:
-        self.__keyword: TestKeyword = keyword
+        self._keyword: TestKeyword = keyword
 
     @abstractmethod
     def check_exit_code(self, outs: str, errs: str, exit_code: int) -> Tuple[ResultCode, str]:
         pass
 
     def __eq__(self, other: TestKeyword) -> bool:
-        return self.__keyword == other
+        return self._keyword == other
+
 
 class ExitCodeDependentTestBase(TestBase):
     def __init__(self, keyword: TestKeyword) -> None:
@@ -71,7 +76,7 @@ class ExitCodeDependentTestBase(TestBase):
             # timeout
             return lit.Test.TIMEOUT, ""
         elif exit_code == 0 or int(exit_code / 10) == 9 or \
-             int(exit_code / 10) == 10:
+                int(exit_code / 10) == 10:
             # 90~99:   unsupported
             # 100~109: timeout/value mismatch/etc
             return self._check(outs, errs, exit_code)
@@ -83,9 +88,11 @@ class ExitCodeDependentTestBase(TestBase):
     def _check(self, outs: str, errs: str, exit_code: int) -> Tuple[ResultCode, str]:
         pass
 
+
 class FixedResultTestBase(TestBase):
     def __init__(self, keyword: TestKeyword) -> None:
         super().__init__(keyword)
+
 
 class InvalidTest(FixedResultTestBase):
     def __init__(self):
@@ -94,12 +101,14 @@ class InvalidTest(FixedResultTestBase):
     def check_exit_code(self, outs, errs, exit_code) -> Tuple[ResultCode, str]:
         return lit.Test.UNRESOLVED, "Ill-formed test setup!"
 
+
 class UnsupportedTest(FixedResultTestBase):
     def __init__(self):
         super().__init__(TestKeyword.UNSUPPORTED)
 
     def check_exit_code(self, outs, errs, exit_code) -> Tuple[ResultCode, str]:
         return lit.Test.UNSUPPORTED, ""
+
 
 class VerifyTest(ExitCodeDependentTestBase):
     def __init__(self):
@@ -111,6 +120,7 @@ class VerifyTest(ExitCodeDependentTestBase):
         else:
             return lit.Test.FAIL, f"stdout >>\n{outs}\n\nstderr >>\n{errs}"
 
+
 class VerifyIncorrectTest(ExitCodeDependentTestBase):
     def __init__(self):
         super().__init__(TestKeyword.VERIFY_INCORRECT)
@@ -121,38 +131,43 @@ class VerifyIncorrectTest(ExitCodeDependentTestBase):
         else:
             return lit.Test.XFAIL, ""
 
+
 class ExpectTest(ExitCodeDependentTestBase):
     def __init__(self, keywords: List[str], cond_or: bool = False):
         super().__init__(TestKeyword.EXPECT)
-        self.__keywords: list[str] = keywords
-        self.__use_cond_or: bool = cond_or
+        self._keywords: list[str] = keywords
+        self._use_cond_or: bool = cond_or
 
     def _check(self, outs: str, errs: str, exit_code: int) -> Tuple[ResultCode, str]:
-        for keyword in self.__keywords:
+        for keyword in self._keywords:
             if keyword in outs or keyword in errs:
-                if self.__use_cond_or:
+                if self._use_cond_or:
                     return lit.Test.PASS, ""
             else:
-                if not self.__use_cond_or:
+                if not self._use_cond_or:
                     return lit.Test.FAIL, f"Expected message >>\n{keyword}\n\nstdout >>\n{outs}\n\nstderr >>\n{errs}"
 
-        if self.__use_cond_or:
-            return lit.Test.FAIL, f"Expected messages >>\n{self.__keywords}\n\nstdout >>\n{outs}\n\nstderr >>\n{errs}"
+        if self._use_cond_or:
+            return lit.Test.FAIL, f"Expected messages >>\n{self._keywords}\n\nstdout >>\n{outs}\n\nstderr >>\n{errs}"
         else:
             return lit.Test.PASS, ""
 
+
 class SrcTgtPairTest(TestFormat):
-    __suffix_src: str = ".src.mlir"
-    __suffix_tgt: str = ".tgt.mlir"
-    __args_regex = re.compile(r"^// ?ARGS ?: ?(.+)$")
-    __verify_regex = re.compile(r"^// ?VERIFY$")
-    __verify_incorrect_regex = re.compile(r"^// ?VERIFY-INCORRECT$")
-    __unsupported_regex = re.compile(r"^// ?UNSUPPORTED$")
-    __expect_regex = re.compile(r"^// ?EXPECT ?: ?\"(.+?)\"(?: ?(?:(?:\&\&)|(?:\|\|)) ?\"(.+?)\")*$")
-    __expect_and_regex = re.compile(r"^// ?EXPECT ?: ?\"(.+?)\"(?: ?\&\& ?\"(.+?)\")*$")
-    __expect_or_regex =  re.compile(r"^// ?EXPECT ?: ?\"(.+?)\"(?: ?\|\| ?\"(.+?)\")*$")
-    __args_identity_regex = re.compile(r"^// ?ARGS-IDCHECK ?: ?(.+)$")
-    __skip_identity_regex = re.compile(r"^// ?SKIP-IDCHECK$")
+    _suffix_src: str = ".src.mlir"
+    _suffix_tgt: str = ".tgt.mlir"
+    _args_regex = re.compile(r"^// ?ARGS ?: ?(.+)$")
+    _verify_regex = re.compile(r"^// ?VERIFY$")
+    _verify_incorrect_regex = re.compile(r"^// ?VERIFY-INCORRECT$")
+    _unsupported_regex = re.compile(r"^// ?UNSUPPORTED$")
+    _expect_regex = re.compile(
+        r"^// ?EXPECT ?: ?\"(.+?)\"(?: ?(?:(?:\&\&)|(?:\|\|)) ?\"(.+?)\")*$")
+    _expect_and_regex = re.compile(
+        r"^// ?EXPECT ?: ?\"(.+?)\"(?: ?\&\& ?\"(.+?)\")*$")
+    _expect_or_regex = re.compile(
+        r"^// ?EXPECT ?: ?\"(.+?)\"(?: ?\|\| ?\"(.+?)\")*$")
+    _args_identity_regex = re.compile(r"^// ?ARGS-IDCHECK ?: ?(.+)$")
+    _skip_identity_regex = re.compile(r"^// ?SKIP-IDCHECK$")
 
     def __init__(self, dir_tv: str, pass_name: str) -> None:
         self._dir_tv: str = dir_tv
@@ -160,59 +175,60 @@ class SrcTgtPairTest(TestFormat):
 
     def getTestsInDirectory(self, testSuite, path_in_suite, litConfig, localConfig):
         source_path = testSuite.getSourcePath(path_in_suite)
-        for pass_name in filter(lambda name: (os.path.isdir(os.path.join(source_path, name)) \
-                    and not name.startswith('.') \
-                    and name == self._pass_name)
-                , os.listdir(source_path)):
+        for pass_name in filter(lambda name: (os.path.isdir(os.path.join(source_path, name))
+                                              and not name.startswith('.')
+                                              and name == self._pass_name), os.listdir(source_path)):
             pass_path: str = os.path.join(source_path, pass_name)
-            for case_name in filter(lambda name: (os.path.isfile(os.path.join(pass_path, name)) \
-                        and not name.startswith('.') \
-                        and name.endswith(self.__suffix_src))
-                    , os.listdir(pass_path)):
-                yield lit.Test.Test(testSuite, path_in_suite 
-                    + (os.path.join(pass_name, remove_suffix(case_name, self.__suffix_src)),), localConfig)
+            for case_name in filter(lambda name: (os.path.isfile(os.path.join(pass_path, name))
+                                                  and not name.startswith('.')
+                                                  and name.endswith(self._suffix_src)), os.listdir(pass_path)):
+                yield lit.Test.Test(testSuite, path_in_suite
+                                    + (os.path.join(pass_name, remove_suffix(case_name, self._suffix_src)),), localConfig)
 
     def execute(self, test_filename, litConfig) -> Tuple[ResultCode, str]:
         testname = test_filename.getSourcePath()
-        tc_src = testname + self.__suffix_src
-        tc_tgt = testname + self.__suffix_tgt
+        tc_src = testname + self._suffix_src
+        tc_tgt = testname + self._suffix_tgt
         if not (os.path.isfile(tc_src) and os.path.isfile(tc_tgt)):
             # src or tgt mlir file is missing
             return lit.Test.SKIPPED, ""
 
         class MutOnce:
             def __init__(self, data: Any) -> None:
-                self.__data: Any = data
-                self.__mutable: bool = True
+                self._data: Any = data
+                self._mutable: bool = True
 
             def update(self, data: Any) -> None:
-                if self.__mutable:
-                    self.__data = data
-                    self.__mutable = False
+                if self._mutable:
+                    self._data = data
+                    self._mutable = False
                 else:
                     raise RuntimeError
 
             def get(self) -> Any:
-                return self.__data
+                return self._data
 
-        idcheck_args = MutOnce([]) # Optional[list[str]]
-        custom_args = MutOnce([]) # list[str]
-        test = MutOnce(InvalidTest()) # TestBase
+        idcheck_args = MutOnce([])  # Optional[list[str]]
+        custom_args = MutOnce([])  # list[str]
+        test = MutOnce(InvalidTest())  # TestBase
         with open(tc_src, 'r') as src_file:
             try:
                 for line in src_file.readlines():
-                    if self.__verify_regex.match(line):
+                    if self._verify_regex.match(line):
                         test.update(VerifyTest())
-                    elif self.__verify_incorrect_regex.match(line):
+                    elif self._verify_incorrect_regex.match(line):
                         test.update(VerifyIncorrectTest())
-                    elif self.__unsupported_regex.match(line):
+                    elif self._unsupported_regex.match(line):
                         test.update(UnsupportedTest())
-                    elif self.__expect_regex.match(line):
+                    elif self._expect_regex.match(line):
                         # remove empty matches
-                        discard_empty = lambda x: bool(x) # str -> bool
-                        match = list(filter(discard_empty, self.__expect_regex.findall(line)[0]))
-                        and_match = list(filter(discard_empty, self.__expect_and_regex.findall(line)[0]))
-                        or_match = list(filter(discard_empty, self.__expect_or_regex.findall(line)[0]))
+                        def discard_empty(x): return bool(x)  # str -> bool
+                        match = list(
+                            filter(discard_empty, self._expect_regex.findall(line)[0]))
+                        and_match = list(
+                            filter(discard_empty, self._expect_and_regex.findall(line)[0]))
+                        or_match = list(
+                            filter(discard_empty, self._expect_or_regex.findall(line)[0]))
 
                         if len(match) > len(and_match) and len(match) > len(or_match):
                             # both && and || are used: this is not yet supported...
@@ -223,14 +239,16 @@ class SrcTgtPairTest(TestFormat):
                         else:
                             # matching against and regex yielded more keywords: test writer intended &&.
                             test.update(ExpectTest(and_match))
-                    elif self.__skip_identity_regex.match(line):
+                    elif self._skip_identity_regex.match(line):
                         idcheck_args.update(None)
-                    elif self.__args_identity_regex.match(line):
-                        keywords: list[str] = list(self.__args_identity_regex.findall(line)[0])
+                    elif self._args_identity_regex.match(line):
+                        keywords: list[str] = list(
+                            self._args_identity_regex.findall(line)[0])
                         idcheck_args.update(keywords)
-                    elif self.__args_regex.match(line):
-                        custom_args.update(self.__args_regex.match(line).group(1).split())
-                    elif not line.strip(): # empty line: no more test keyword
+                    elif self._args_regex.match(line):
+                        custom_args.update(
+                            self._args_regex.match(line).group(1).split())
+                    elif not line.strip():  # empty line: no more test keyword
                         break
             except RuntimeError:
                 # invalid test keyword combination
@@ -238,11 +256,13 @@ class SrcTgtPairTest(TestFormat):
                 test = MutOnce(InvalidTest())
 
         if not (test.get() == TestKeyword.UNSUPPORTED or test.get() == TestKeyword.INVALID) and idcheck_args.get() is not None:
-            src_identity: Tuple[ResultCode, str] = VerifyTest().check_exit_code(*_executeCommand(self._dir_tv, tc_src, tc_src, idcheck_args.get()))
+            src_identity: Tuple[ResultCode, str] = VerifyTest().check_exit_code(
+                *_executeCommand(self._dir_tv, tc_src, tc_src, idcheck_args.get()))
             if src_identity[0] != lit.Test.PASS:
                 return src_identity
 
-            tgt_identity: Tuple[ResultCode, str] = VerifyTest().check_exit_code(*_executeCommand(self._dir_tv, tc_tgt, tc_tgt, idcheck_args.get()))
+            tgt_identity: Tuple[ResultCode, str] = VerifyTest().check_exit_code(
+                *_executeCommand(self._dir_tv, tc_tgt, tc_tgt, idcheck_args.get()))
             if tgt_identity[0] != lit.Test.PASS:
                 return tgt_identity
 

--- a/tests/lit/formats/mlirtest.py
+++ b/tests/lit/formats/mlirtest.py
@@ -156,18 +156,18 @@ class ExpectTest(ExitCodeDependentTestBase):
 class SrcTgtPairTest(TestFormat):
     _suffix_src: str = ".src.mlir"
     _suffix_tgt: str = ".tgt.mlir"
-    _args_regex = re.compile(r"^// ?ARGS ?: ?(.+)$")
-    _verify_regex = re.compile(r"^// ?VERIFY$")
-    _verify_incorrect_regex = re.compile(r"^// ?VERIFY-INCORRECT$")
-    _unsupported_regex = re.compile(r"^// ?UNSUPPORTED$")
+    _args_regex = re.compile(r"^// *ARGS ?: ?(.+)$")
+    _verify_regex = re.compile(r"^// *VERIFY$")
+    _verify_incorrect_regex = re.compile(r"^// *VERIFY-INCORRECT$")
+    _unsupported_regex = re.compile(r"^// *UNSUPPORTED$")
     _expect_regex = re.compile(
-        r"^// ?EXPECT ?: ?\"(.+?)\"(?: ?(?:(?:\&\&)|(?:\|\|)) ?\"(.+?)\")*$")
+        r"^// *EXPECT ?: ?\"(.+?)\"(?: ?(?:(?:\&\&)|(?:\|\|)) ?\"(.+?)\")*$")
     _expect_and_regex = re.compile(
-        r"^// ?EXPECT ?: ?\"(.+?)\"(?: ?\&\& ?\"(.+?)\")*$")
+        r"^// *EXPECT ?: ?\"(.+?)\"(?: ?\&\& ?\"(.+?)\")*$")
     _expect_or_regex = re.compile(
-        r"^// ?EXPECT ?: ?\"(.+?)\"(?: ?\|\| ?\"(.+?)\")*$")
-    _args_identity_regex = re.compile(r"^// ?ARGS-IDCHECK ?: ?(.+)$")
-    _skip_identity_regex = re.compile(r"^// ?SKIP-IDCHECK$")
+        r"^// *EXPECT ?: ?\"(.+?)\"(?: ?\|\| ?\"(.+?)\")*$")
+    _args_identity_regex = re.compile(r"^// *ARGS-IDCHECK ?: ?(.+)$")
+    _skip_identity_regex = re.compile(r"^// *SKIP-IDCHECK$")
 
     def __init__(self, dir_tv: str, pass_name: str) -> None:
         self._dir_tv: str = dir_tv


### PR DESCRIPTION
- Test code are formatted according to [PEP8](https://www.python.org/dev/peps/pep-0008/) guideline.
- Whitespace of an arbitrary length is allowed between `//` and the test keyword.
- README is moved from tests/opts to tests directory.