### PR TITLE
Fix `linalg.fill` operands to follow the updated syntax

### DIFF
--- a/tests/litmus/abstraction/dotint.tgt.mlir
+++ b/tests/litmus/abstraction/dotint.tgt.mlir
@@ -1,7 +1,7 @@
 func @f(%a: tensor<?xi32>, %b: tensor<?xi32>) -> tensor<i32> {
   %i = linalg.init_tensor [] : tensor<i32>
   %zero = arith.constant 0 : i32
-  %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<i32>) -> tensor<i32>
+  %outty = linalg.fill ins(%zero: i32) outs(%i: tensor<i32>) -> tensor<i32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,
                        affine_map<(d0) -> (d0)>,

--- a/tests/litmus/bufferization-ops/fill-memref-bad.tgt.mlir
+++ b/tests/litmus/bufferization-ops/fill-memref-bad.tgt.mlir
@@ -6,6 +6,6 @@ func @bufferize_fill(%arg0: memref<?xf32>) -> tensor<?xf32> {
 
     %cst2 = arith.constant 1.000000e+00 : f32
     %zerotensor = bufferization.to_tensor %arg0 : memref<?xf32>
-    %zerotensor2 = linalg.fill(%cst2, %zerotensor): f32, tensor<?xf32> -> tensor<?xf32>
+    %zerotensor2 = linalg.fill ins(%cst2: f32) outs(%zerotensor: tensor<?xf32>) -> tensor<?xf32>
     return %zerotensor2 : tensor<?xf32>
 }

--- a/tests/litmus/bufferization-ops/fill-memref.tgt.mlir
+++ b/tests/litmus/bufferization-ops/fill-memref.tgt.mlir
@@ -5,6 +5,6 @@ func @bufferize_fill(%arg0: memref<?xf32>) -> tensor<?xf32> {
     linalg.fill ins(%cst: f32) outs(%arg0: memref<?xf32>)
 
     %zerotensor = bufferization.to_tensor %arg0 : memref<?xf32>
-    %zerotensor2 = linalg.fill(%cst, %zerotensor): f32, tensor<?xf32> -> tensor<?xf32>
+    %zerotensor2 = linalg.fill ins(%cst: f32) outs(%zerotensor: tensor<?xf32>) -> tensor<?xf32>
     return %zerotensor2 : tensor<?xf32>
 }

--- a/tests/litmus/linalg-ops/dot.src.mlir
+++ b/tests/litmus/linalg-ops/dot.src.mlir
@@ -3,7 +3,7 @@
 func @f(%a: tensor<100xf32>, %b: tensor<100xf32>) -> tensor<f32> {
   %i = linalg.init_tensor []: tensor<f32>
   %zero = arith.constant -0.0 : f32
-  %filled = linalg.fill(%zero, %i) : f32, tensor<f32> -> tensor<f32>
+  %filled = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %e = linalg.dot ins(%a, %b : tensor<100xf32>,tensor<100xf32>)
     outs(%filled: tensor<f32>) -> tensor<f32>
   return %e : tensor<f32>

--- a/tests/litmus/linalg-ops/dot.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot.tgt.mlir
@@ -1,7 +1,7 @@
 func @f(%a: tensor<100xf32>, %b: tensor<100xf32>) -> tensor<f32> {
   %outty = linalg.init_tensor [] : tensor<f32>
   %zero = arith.constant -0.0 : f32
-  %filled = linalg.fill(%zero, %outty) : f32, tensor<f32> -> tensor<f32>
+  %filled = linalg.fill ins(%zero: f32) outs(%outty: tensor<f32>) -> tensor<f32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,
                        affine_map<(d0) -> (d0)>,

--- a/tests/litmus/linalg-ops/dot2.src.mlir
+++ b/tests/litmus/linalg-ops/dot2.src.mlir
@@ -3,7 +3,7 @@
 func @f(%a: tensor<?xf32>, %b: tensor<?xf32>) -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
   %i = linalg.init_tensor [] : tensor<f32>
-  %outty = linalg.fill(%zero, %i) : f32, tensor<f32> -> tensor<f32>
+  %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %e = linalg.dot ins(%a, %b : tensor<?xf32>,tensor<?xf32>)
     outs(%outty: tensor<f32>) -> tensor<f32>
   return %e : tensor<f32>

--- a/tests/litmus/linalg-ops/dot2.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot2.tgt.mlir
@@ -1,7 +1,7 @@
 func @f(%a: tensor<?xf32>, %b: tensor<?xf32>) -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
   %i = linalg.init_tensor [] : tensor<f32>
-  %outty = linalg.fill(%zero, %i) : f32, tensor<f32> -> tensor<f32>
+  %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,
                        affine_map<(d0) -> (d0)>,

--- a/tests/litmus/linalg-ops/dot_commutative.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_commutative.tgt.mlir
@@ -1,7 +1,7 @@
 func @f(%a: tensor<100xf32>, %b: tensor<100xf32>) -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
   %i = linalg.init_tensor [] : tensor<f32>
-  %out = linalg.fill(%zero, %i) : f32, tensor<f32> -> tensor<f32>
+  %out = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,
                        affine_map<(d0) -> (d0)>,

--- a/tests/litmus/linalg-ops/dot_rewrite_manually.src.mlir
+++ b/tests/litmus/linalg-ops/dot_rewrite_manually.src.mlir
@@ -21,6 +21,6 @@ func @f() -> tensor<f32> {
   %r3 = arith.addf %r2, %c3 : f32
   %r4 = arith.addf %r3, %c4 : f32
   %res = linalg.init_tensor []: tensor<f32>
-  %res2 = linalg.fill (%r4, %res): f32, tensor<f32> -> tensor<f32>
+  %res2 = linalg.fill ins(%r4: f32) outs(%res: tensor<f32>) -> tensor<f32>
   return %res2 : tensor<f32>
 }

--- a/tests/litmus/linalg-ops/dot_rewrite_manually.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_rewrite_manually.tgt.mlir
@@ -1,7 +1,7 @@
 func @f() -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
   %i = linalg.init_tensor []: tensor<f32>
-  %outty = linalg.fill(%zero, %i) : f32, tensor<f32> -> tensor<f32>
+  %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %a = arith.constant sparse<[[0], [1], [2], [3], [4]], [-12.0, 3.0, 2.0, 5.0, 4.0]> : tensor<5xf32>
   %b = arith.constant sparse<[[0], [1], [2], [3], [4]], [1.0, 8.0, 5.0, 6.0, 0.0]> : tensor<5xf32>
   %res = linalg.dot ins(%a, %b : tensor<5xf32>,tensor<5xf32>)

--- a/tests/litmus/linalg-ops/dot_rewrite_manually_assoc.src.mlir
+++ b/tests/litmus/linalg-ops/dot_rewrite_manually_assoc.src.mlir
@@ -29,6 +29,6 @@ func @f() -> tensor<f32> {
   %r3 = arith.addf %r2, %c3 : f32
   %r4 = arith.addf %r3, %c4 : f32
   %res = linalg.init_tensor []: tensor<f32>
-  %res2 = linalg.fill (%r4, %res): f32, tensor<f32> -> tensor<f32>
+  %res2 = linalg.fill ins(%r4: f32) outs(%res: tensor<f32>) -> tensor<f32>
   return %res2 : tensor<f32>
 }

--- a/tests/litmus/linalg-ops/dot_rewrite_manually_assoc.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_rewrite_manually_assoc.tgt.mlir
@@ -1,7 +1,7 @@
 func @f() -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
   %i = linalg.init_tensor []: tensor<f32>
-  %outty = linalg.fill(%zero, %i) : f32, tensor<f32> -> tensor<f32>
+  %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %a = arith.constant sparse<[[4], [3], [2], [1], [0]], [-12.0, 3.0, 2.0, 5.0, 4.0]> : tensor<5xf32>
   %b = arith.constant sparse<[[4], [3], [2], [1], [0]], [1.0, 8.0, 5.0, 6.0, 0.0]> : tensor<5xf32>
   %res = linalg.dot ins(%a, %b : tensor<5xf32>,tensor<5xf32>)

--- a/tests/litmus/linalg-ops/fill.src.mlir
+++ b/tests/litmus/linalg-ops/fill.src.mlir
@@ -3,6 +3,6 @@
 func @f(%arg: tensor<3x3xf32>) -> tensor<3x3xf32> {
   %t = linalg.init_tensor [3, 3]: tensor<3x3xf32>
   %c0 = arith.constant 0.0: f32
-  %res = linalg.fill (%c0, %t): f32, tensor<3x3xf32> -> tensor<3x3xf32>
+  %res = linalg.fill ins(%c0: f32) outs(%t: tensor<3x3xf32>) -> tensor<3x3xf32>
   return %res: tensor<3x3xf32>
 }

--- a/tests/litmus/linalg-ops/fill.tgt.mlir
+++ b/tests/litmus/linalg-ops/fill.tgt.mlir
@@ -1,5 +1,5 @@
 func @f(%arg: tensor<3x3xf32>) -> tensor<3x3xf32> {
   %c0 = arith.constant 0.0: f32
-  %res = linalg.fill (%c0, %arg): f32, tensor<3x3xf32> -> tensor<3x3xf32>
+  %res = linalg.fill ins(%c0: f32) outs(%arg: tensor<3x3xf32>) -> tensor<3x3xf32>
   return %res: tensor<3x3xf32>
 }

--- a/tests/litmus/linalg-ops/memref_matmul.src.mlir
+++ b/tests/litmus/linalg-ops/memref_matmul.src.mlir
@@ -7,7 +7,7 @@ func @f() -> tensor<8x16xf32> {
   %b = memref.get_global @constant_b : memref<4x16xf32>
   %cst = arith.constant -0.0 : f32
   %c = memref.alloc(): memref<8x16xf32>
-  linalg.fill(%cst, %c) : f32, memref<8x16xf32>
+  linalg.fill ins(%cst: f32) outs(%c: memref<8x16xf32>)
   linalg.matmul ins(%a, %b: memref<8x4xf32>, memref<4x16xf32>) outs(%c: memref<8x16xf32>)
   %ret = bufferization.to_tensor %c : memref<8x16xf32>
   return %ret: tensor<8x16xf32>

--- a/tests/litmus/linalg-ops/memref_matmul.tgt.mlir
+++ b/tests/litmus/linalg-ops/memref_matmul.tgt.mlir
@@ -8,7 +8,7 @@ func @f() -> tensor<8x16xf32> {
   %tb = bufferization.to_tensor %b : memref<4x16xf32>
   %c = linalg.init_tensor [8, 16] : tensor<8x16xf32>
   %cst = arith.constant -0.0 : f32
-  %tc = linalg.fill(%cst, %c) : f32, tensor<8x16xf32> -> tensor<8x16xf32>
+  %tc = linalg.fill ins(%cst: f32) outs(%c: tensor<8x16xf32>) -> tensor<8x16xf32>
   %mat = linalg.matmul ins(%ta, %tb: tensor<8x4xf32>, tensor<4x16xf32>) outs(%tc: tensor<8x16xf32>) -> tensor<8x16xf32>
   return %mat : tensor<8x16xf32>
 }

--- a/tests/litmus/linalg-ops/pooling_unsupported2.src.mlir
+++ b/tests/litmus/linalg-ops/pooling_unsupported2.src.mlir
@@ -4,7 +4,7 @@ func @pooling_nhwc_i8_max_tensor(%input: tensor<1x4x4x1xi8>) -> tensor<1x2x2x1xi
   %fake = linalg.init_tensor [3, 3] : tensor<3x3xi8>
   %init = linalg.init_tensor [1, 2, 2, 1] : tensor<1x2x2x1xi8>
   %cst = arith.constant 0 : i8
-  %fill = linalg.fill(%cst, %init) : i8, tensor<1x2x2x1xi8> -> tensor<1x2x2x1xi8>
+  %fill = linalg.fill ins(%cst: i8) outs(%init: tensor<1x2x2x1xi8>) -> tensor<1x2x2x1xi8>
   %res = linalg.pooling_nhwc_max {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
     ins(%input, %fake: tensor<1x4x4x1xi8>, tensor<3x3xi8>)
     outs(%fill: tensor<1x2x2x1xi8>) -> tensor<1x2x2x1xi8>

--- a/tests/litmus/linalg-ops/pooling_unsupported2.tgt.mlir
+++ b/tests/litmus/linalg-ops/pooling_unsupported2.tgt.mlir
@@ -3,7 +3,7 @@ module  {
     %0 = linalg.init_tensor [3, 3] : tensor<3x3xi8>
     %1 = linalg.init_tensor [1, 2, 2, 1] : tensor<1x2x2x1xi8>
     %c0_i8 = arith.constant 0 : i8
-    %2 = linalg.fill(%c0_i8, %1) : i8, tensor<1x2x2x1xi8> -> tensor<1x2x2x1xi8> 
+    %2 = linalg.fill ins(%c0_i8: i8) outs(%1: tensor<1x2x2x1xi8>) -> tensor<1x2x2x1xi8> 
     %3 = linalg.pooling_nhwc_max {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %0 : tensor<1x4x4x1xi8>, tensor<3x3xi8>) outs(%2 : tensor<1x2x2x1xi8>) -> tensor<1x2x2x1xi8>
     return %3 : tensor<1x2x2x1xi8>
   }

--- a/tests/long-opts/tosa-to-linalg/conv2d2.tgt.mlir
+++ b/tests/long-opts/tosa-to-linalg/conv2d2.tgt.mlir
@@ -13,7 +13,7 @@ module  {
     } -> tensor<3x3x4x16xf32>
     %3 = linalg.init_tensor [1, 14, 14, 16] : tensor<1x14x14x16xf32>
     %cst_1 = arith.constant 0.000000e+00 : f32
-    %4 = linalg.fill(%cst_1, %3) : f32, tensor<1x14x14x16xf32> -> tensor<1x14x14x16xf32> 
+    %4 = linalg.fill ins(%cst_1: f32) outs(%3: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> 
     %5 = linalg.init_tensor [1, 14, 14, 16] : tensor<1x14x14x16xf32>
     %6 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %2 : tensor<1x29x29x4xf32>, tensor<3x3x4x16xf32>) outs(%4 : tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
     %7 = linalg.generic {indexing_maps = [#map2, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %6 : tensor<16xf32>, tensor<1x14x14x16xf32>) outs(%5 : tensor<1x14x14x16xf32>) {

--- a/tests/long-opts/tosa-to-linalg/conv_pad.tgt.mlir
+++ b/tests/long-opts/tosa-to-linalg/conv_pad.tgt.mlir
@@ -16,7 +16,7 @@ module  {
     } -> tensor<3x6x3x16xf32>
     %3 = linalg.init_tensor [2, 6, 9, 16] : tensor<2x6x9x16xf32>
     %cst_1 = arith.constant 0.000000e+00 : f32
-    %4 = linalg.fill(%cst_1, %3) : f32, tensor<2x6x9x16xf32> -> tensor<2x6x9x16xf32> 
+    %4 = linalg.fill ins(%cst_1: f32) outs(%3: tensor<2x6x9x16xf32>) -> tensor<2x6x9x16xf32> 
     %5 = linalg.init_tensor [2, 6, 9, 16] : tensor<2x6x9x16xf32>
     %6 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%0, %2 : tensor<2x8x14x3xf32>, tensor<3x6x3x16xf32>) outs(%4 : tensor<2x6x9x16xf32>) -> tensor<2x6x9x16xf32>
     %7 = linalg.generic {indexing_maps = [#map2, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg2, %6 : tensor<16xf32>, tensor<2x6x9x16xf32>) outs(%5 : tensor<2x6x9x16xf32>) {

--- a/tests/long-opts/tosa-to-linalg/depthwise2.tgt.mlir
+++ b/tests/long-opts/tosa-to-linalg/depthwise2.tgt.mlir
@@ -9,7 +9,7 @@ module  {
     } : tensor<2x5x5x2xf32> to tensor<2x7x7x2xf32>
     %1 = linalg.init_tensor [2, 6, 6, 2, 3] : tensor<2x6x6x2x3xf32>
     %cst_0 = arith.constant 0.000000e+00 : f32
-    %2 = linalg.fill(%cst_0, %1) : f32, tensor<2x6x6x2x3xf32> -> tensor<2x6x6x2x3xf32> 
+    %2 = linalg.fill ins(%cst_0: f32) outs(%1: tensor<2x6x6x2x3xf32>) -> tensor<2x6x6x2x3xf32> 
     %3 = linalg.init_tensor [2, 6, 6, 6] : tensor<2x6x6x6xf32>
     %4 = linalg.depthwise_conv_2d_nhwc_hwcm {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%0, %arg1 : tensor<2x7x7x2xf32>, tensor<2x2x2x3xf32>) outs(%2 : tensor<2x6x6x2x3xf32>) -> tensor<2x6x6x2x3xf32>
     %5 = tensor.collapse_shape %4 [[0], [1], [2], [3, 4]] : tensor<2x6x6x2x3xf32> into tensor<2x6x6x6xf32>


### PR DESCRIPTION
Before: `linalg.fill(%in, %out): inTy, outTy`
After: `linalg.fill ins(%in: inTy) outs(%out: outTy)`