### PR TITLE
Temporarily disable build-release CI

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -56,28 +56,29 @@ jobs:
             -DMLIR_DIR=/opt/llvm -DZ3_DIR=/opt/z3 -DCVC5_DIR=/opt/cvc5 \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo
           cmake --build build
+  
+  # Disabled until MLIR bug is fixed
+  # build-release:
+  #   runs-on: ubuntu-20.04
+  #   container:
+  #     image: strikef/mlir-tv-ci-base:latest
+  #     credentials:
+  #       username: ${{ secrets.DOCKER_HUB_USERNAME }}
+  #       password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  build-release:
-    runs-on: ubuntu-20.04
-    container:
-      image: strikef/mlir-tv-ci-base:latest
-      credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+  #   steps:
+  #     - name: Checkout this repo
+  #       uses: actions/checkout@v2
+  #       with:
+  #         path: mlir-tv
 
-    steps:
-      - name: Checkout this repo
-        uses: actions/checkout@v2
-        with:
-          path: mlir-tv
-
-      - name: Build mlir-tv
-        run: |
-          cd mlir-tv
-          cmake -B build -G Ninja \
-            -DMLIR_DIR=/opt/llvm -DZ3_DIR=/opt/z3 -DCVC5_DIR=/opt/cvc5 \
-            -DCMAKE_BUILD_TYPE=Release
-          cmake --build build
+  #     - name: Build mlir-tv
+  #       run: |
+  #         cd mlir-tv
+  #         cmake -B build -G Ninja \
+  #           -DMLIR_DIR=/opt/llvm -DZ3_DIR=/opt/z3 -DCVC5_DIR=/opt/cvc5 \
+  #           -DCMAKE_BUILD_TYPE=Release
+  #         cmake --build build
 
   build-Z3-only:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Due to a bug in MLIR (see [here](https://github.com/llvm/llvm-project/issues/55010)), building mlir-tv in release mode fails.
Disable building in release mode until this bug is fixed.