### PR TITLE
Implement bit shift for `smt::Expr`

### DIFF
--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -1171,7 +1171,7 @@ Expr Expr::shl(const Expr &rhs) const {
   CHECK_LOCK2(rhs);
 
   uint64_t a, b;
-  if (isUInt(a) && rhs.isUInt(b))
+  if (isUInt(a) && rhs.isUInt(b) && b < 64)
     return mkBV(a << b, rhs.bitwidth());
   else if (rhs.isUInt(b)) {
     if (b == 0)
@@ -1217,7 +1217,7 @@ Expr Expr::lshr(const Expr &rhs) const {
   CHECK_LOCK2(rhs);
 
   uint64_t a, b;
-  if (isUInt(a) && rhs.isUInt(b))
+  if (isUInt(a) && rhs.isUInt(b) && b < 64)
     return mkBV(a >> b, rhs.bitwidth());
   else if (rhs.isUInt(b)) {
     if (b == 0)

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -864,36 +864,6 @@ Expr Expr::sext(unsigned bits) const {
   return e;
 }
 
-Expr Expr::shl(const unsigned bits) const {
-  CHECK_LOCK();
-
-  Expr e;
-  const auto shifting_bits = Expr::mkBV(bits, *this);
-  SET_Z3_USEOP(e, shifting_bits, shl);
-  SET_CVC5_USEOP(e, shifting_bits, BITVECTOR_SHL);
-  return e;
-}
-
-Expr Expr::ashr(const unsigned bits) const {
-  CHECK_LOCK();
-
-  Expr e;
-  const auto shifting_bits = Expr::mkBV(bits, *this);
-  SET_Z3_USEOP(e, shifting_bits, ashr);
-  SET_CVC5_USEOP(e, shifting_bits, BITVECTOR_ASHR);
-  return e;
-}
-
-Expr Expr::lshr(const unsigned bits) const {
-  CHECK_LOCK();
-
-  Expr e;
-  const auto shifting_bits = Expr::mkBV(bits, *this);
-  SET_Z3_USEOP(e, shifting_bits, lshr);
-  SET_CVC5_USEOP(e, shifting_bits, BITVECTOR_LSHR);
-  return e;
-}
-
 Expr Expr::implies(const Expr &rhs) const {
   CHECK_LOCK2(rhs);
 
@@ -1188,6 +1158,36 @@ Expr &Expr::operator|=(const Expr &rhs) {
   SET_Z3(*this, move(e.z3));
   SET_CVC5(*this, move(e.cvc5));
   return *this;
+}
+
+EXPR_BVOP_UINT64(shl)
+Expr Expr::shl(const Expr &rhs) const {
+  CHECK_LOCK2(rhs);
+
+  Expr e;
+  SET_Z3_USEOP(e, rhs, shl);
+  SET_CVC5_USEOP(e, rhs, BITVECTOR_SHL);
+  return e;
+}
+
+EXPR_BVOP_UINT64(ashr)
+Expr Expr::ashr(const Expr &rhs) const {
+  CHECK_LOCK2(rhs);
+
+  Expr e;
+  SET_Z3_USEOP(e, rhs, ashr);
+  SET_CVC5_USEOP(e, rhs, BITVECTOR_ASHR);
+  return e;
+}
+
+EXPR_BVOP_UINT64(lshr)
+Expr Expr::lshr(const Expr &rhs) const {
+  CHECK_LOCK2(rhs);
+
+  Expr e;
+  SET_Z3_USEOP(e, rhs, lshr);
+  SET_CVC5_USEOP(e, rhs, BITVECTOR_LSHR);
+  return e;
 }
 
 Expr Expr::substitute(

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -864,7 +864,7 @@ Expr Expr::sext(unsigned bits) const {
   return e;
 }
 
-Expr Expr::shl(unsigned bits) const {
+Expr Expr::shl(const unsigned bits) const {
   CHECK_LOCK();
 
   Expr e;
@@ -874,7 +874,7 @@ Expr Expr::shl(unsigned bits) const {
   return e;
 }
 
-Expr Expr::ashr(unsigned bits) const {
+Expr Expr::ashr(const unsigned bits) const {
   CHECK_LOCK();
 
   Expr e;
@@ -884,7 +884,7 @@ Expr Expr::ashr(unsigned bits) const {
   return e;
 }
 
-Expr Expr::lshr(unsigned bits) const {
+Expr Expr::lshr(const unsigned bits) const {
   CHECK_LOCK();
 
   Expr e;

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -1164,6 +1164,17 @@ EXPR_BVOP_UINT64(shl)
 Expr Expr::shl(const Expr &rhs) const {
   CHECK_LOCK2(rhs);
 
+  uint64_t a, b;
+  if (isUInt(a) && rhs.isUInt(b))
+    return mkBV(a << b, rhs.bitwidth());
+  else if (rhs.isUInt(b)) {
+    if (b == 0)
+      return *this;
+  } else if (isUInt(a)) {
+    if (a == 0)
+      return *this;
+  }
+
   Expr e;
   SET_Z3_USEOP(e, rhs, shl);
   SET_CVC5_USEOP(e, rhs, BITVECTOR_SHL);
@@ -1174,6 +1185,21 @@ EXPR_BVOP_UINT64(ashr)
 Expr Expr::ashr(const Expr &rhs) const {
   CHECK_LOCK2(rhs);
 
+  uint64_t a, b;
+  // The value of a >> b for unsigned a is the integer part of a/(2^b)
+  // which is equivalent to lshr.
+  // Therefore we cannot apply uint optimization for ashr.
+  // Even if we use signed int, the value of >> on a signed int
+  // is implementation-defined until c++17 (it is ashr since c++20),
+  // so it is hard to implement a robust optimization.
+  if (rhs.isUInt(b)) {
+    if (b == 0)
+      return *this;
+  } else if (isUInt(a)) {
+    if (a == 0)
+      return *this;
+  }
+
   Expr e;
   SET_Z3_USEOP(e, rhs, ashr);
   SET_CVC5_USEOP(e, rhs, BITVECTOR_ASHR);
@@ -1183,6 +1209,17 @@ Expr Expr::ashr(const Expr &rhs) const {
 EXPR_BVOP_UINT64(lshr)
 Expr Expr::lshr(const Expr &rhs) const {
   CHECK_LOCK2(rhs);
+
+  uint64_t a, b;
+  if (isUInt(a) && rhs.isUInt(b))
+    return mkBV(a >> b, rhs.bitwidth());
+  else if (rhs.isUInt(b)) {
+    if (b == 0)
+      return *this;
+  } else if (isUInt(a)) {
+    if (a == 0)
+      return *this;
+  }
 
   Expr e;
   SET_Z3_USEOP(e, rhs, lshr);

--- a/src/smt.cpp
+++ b/src/smt.cpp
@@ -864,6 +864,36 @@ Expr Expr::sext(unsigned bits) const {
   return e;
 }
 
+Expr Expr::shl(unsigned bits) const {
+  CHECK_LOCK();
+
+  Expr e;
+  const auto shifting_bits = Expr::mkBV(bits, *this);
+  SET_Z3_USEOP(e, shifting_bits, shl);
+  SET_CVC5_USEOP(e, shifting_bits, BITVECTOR_SHL);
+  return e;
+}
+
+Expr Expr::ashr(unsigned bits) const {
+  CHECK_LOCK();
+
+  Expr e;
+  const auto shifting_bits = Expr::mkBV(bits, *this);
+  SET_Z3_USEOP(e, shifting_bits, ashr);
+  SET_CVC5_USEOP(e, shifting_bits, BITVECTOR_ASHR);
+  return e;
+}
+
+Expr Expr::lshr(unsigned bits) const {
+  CHECK_LOCK();
+
+  Expr e;
+  const auto shifting_bits = Expr::mkBV(bits, *this);
+  SET_Z3_USEOP(e, shifting_bits, lshr);
+  SET_CVC5_USEOP(e, shifting_bits, BITVECTOR_LSHR);
+  return e;
+}
+
 Expr Expr::implies(const Expr &rhs) const {
   CHECK_LOCK2(rhs);
 

--- a/src/smt.h
+++ b/src/smt.h
@@ -158,9 +158,6 @@ public:
   Expr concat(const Expr &lowbits) const;
   Expr zext(unsigned bits) const;
   Expr sext(unsigned bits) const;
-  Expr shl(const unsigned bits) const;
-  Expr ashr(const unsigned bits) const;
-  Expr lshr(const unsigned bits) const;
 
   Expr operator+(const Expr &rhs) const;
   Expr operator+(uint64_t rhs) const;
@@ -184,6 +181,12 @@ public:
   Expr operator-() const;
   Expr &operator&=(const Expr &rhs);
   Expr &operator|=(const Expr &rhs);
+  Expr shl(const Expr &rhs) const;
+  Expr shl(uint64_t rhs) const;
+  Expr ashr(const Expr &rhs) const;
+  Expr ashr(uint64_t rhs) const;
+  Expr lshr(const Expr &rhs) const;
+  Expr lshr(uint64_t rhs) const;
 
   Expr implies(const Expr &rhs) const;
   Expr isZero() const;

--- a/src/smt.h
+++ b/src/smt.h
@@ -158,6 +158,9 @@ public:
   Expr concat(const Expr &lowbits) const;
   Expr zext(unsigned bits) const;
   Expr sext(unsigned bits) const;
+  Expr shl(unsigned bits) const;
+  Expr ashr(unsigned bits) const;
+  Expr lshr(unsigned bits) const;
 
   Expr operator+(const Expr &rhs) const;
   Expr operator+(uint64_t rhs) const;

--- a/src/smt.h
+++ b/src/smt.h
@@ -158,9 +158,9 @@ public:
   Expr concat(const Expr &lowbits) const;
   Expr zext(unsigned bits) const;
   Expr sext(unsigned bits) const;
-  Expr shl(unsigned bits) const;
-  Expr ashr(unsigned bits) const;
-  Expr lshr(unsigned bits) const;
+  Expr shl(const unsigned bits) const;
+  Expr ashr(const unsigned bits) const;
+  Expr lshr(const unsigned bits) const;
 
   Expr operator+(const Expr &rhs) const;
   Expr operator+(uint64_t rhs) const;


### PR DESCRIPTION
This PR implements `shl`, `ashr`, and `lshr` methods for `smt::Expr`.
* `Expr::shl(const unsigned bits) const` yields a new BV of the same sort with `bits` bits shifted to the left.
* `Expr::ashr(const unsigned bits) const` yields a new BV of the same sort with `bits` bits shifted to the right. Higher bits are filled with 1 if the MSB of the original BV was 1, and 0 otherwise.
* `Expr::lshr(const unsigned bits) const` yields a new BV of the same sort with `bits` bits shifted to the right. Higher bits are always filled with 0.
