### PR TITLE
Fix Heaan-Image script

### DIFF
--- a/.github/workflows/env-heaan.yml
+++ b/.github/workflows/env-heaan.yml
@@ -4,8 +4,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  pull_request:
-
 jobs:
   configure-dependencies:
     if: github.repository == 'aqjune/mlir-tv'

--- a/.github/workflows/env-heaan.yml
+++ b/.github/workflows/env-heaan.yml
@@ -4,9 +4,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # Check update every 3 days
-  schedule:
-    - cron: '0 0 1/3 * *'
+  pull_request:
 
 jobs:
   configure-dependencies:


### PR DESCRIPTION
Apparently `schedule` event trigger does not work on non-default branch, so this PR removes it.

Also, this PR 'registers' the Heaan-Image Action by temporarilly creating a commit that contains `pull_request` event trigger. This will be removed in the next commit and won't be merged into the heaan-mlir branch.