### PR TITLE
Fetch updates from master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ build
 venv
 **/__pycache__
 .DS_Store
+.cache
 tests/Testing

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -2020,7 +2020,6 @@ void encodeOp(State &st, mlir::tensor::GenerateOp op, bool) {
   auto retty = op.getType().dyn_cast<mlir::RankedTensorType>();
   if (!retty)
     throw UnsupportedException(op.getOperation(), "Unsupported type");
-  
   auto blk = op.getBody();
   if (!blk)
     throw UnsupportedException(op.getOperation(), "Unsupported form");


### PR DESCRIPTION
This PR fetches some new features in master into heaan-mlir branch.
* Add `.cache` (clangd cache directory) to `.gitignore`

It seems that 'merging' the master into another branch tries to apply every change made to master since the split, thus overriding the resolved merge conflicts from the previous merge PR.
Fetching updates from master should be done via 'cherry-picking' from the next PR.