### PR TITLE
Re-enable build-release CI

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -59,27 +59,29 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo
           cmake --build build
   
-  # Disabled until MLIR bug is fixed
-  # build-release:
-  #   runs-on: ubuntu-20.04
-  #   container:
-  #     image: strikef/mlir-tv-ci-base:latest
-  #     credentials:
-  #       username: ${{ secrets.DOCKER_HUB_USERNAME }}
-  #       password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+  build-release:
+    runs-on: ubuntu-20.04
+    container:
+      image: strikef/mlir-tv-ci-base:latest
+      credentials:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  #   steps:
-  #     - name: Checkout this repo
-  #       uses: actions/checkout@v2
-  #       with:
-  #         path: mlir-tv
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v2
+        with:
+          path: mlir-tv
 
-  #     - name: Build mlir-tv
-  #       run: |
-  #         cd mlir-tv
-  #         cmake -B build -G Ninja \
-  #           -DCMAKE_BUILD_TYPE=Release
-  #         cmake --build build
+      - name: Build mlir-tv
+        run: |
+          cd mlir-tv
+          cmake -B build -G Ninja \
+            -DMLIR_ROOT=/opt/llvm \
+            -DUSE_Z3=ON \
+            -DUSE_cvc5=ON \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build
 
   build-Z3-only:
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ cmake -DMLIR_ROOT=<dir/to/mlir-install> \
 cmake --build . -- -j
 ```
 
-If you're seeing `error: pack expansion does not contain any unexpanded parameter packs` during compilation, please try the solution suggested at https://github.com/llvm/llvm-project/issues/55010.
-
 ## How to run MLIR-TV
 
 MLIR-TV takes two .mlir files that contain MLIR functions of identical signatures.


### PR DESCRIPTION
The LLVM bug that caused build-release CI to fail [is fixed](https://github.com/llvm/llvm-project/commit/49157fd468521ee482d3f5a0ae1586f9d7c8a550)