### PR TITLE
Implement encoding for function calls with dynamic tensors

### DIFF
--- a/src/function.cpp
+++ b/src/function.cpp
@@ -4,25 +4,19 @@
 #include <algorithm>
 #include <iterator>
 #include <map>
-#include <vector>
 
 using namespace std;
 using namespace smt;
 
 namespace {
 map<string, DeclaredFunction, std::less<>> calleeMap;
-
-vector<uint64_t> getShapeDimVector(const mlir::ShapedType shapedTy) {
-  smart_assert(shapedTy.hasStaticShape(), "Not having static shape: "
-                                          << shapedTy);
-  const auto dims = shapedTy.getShape();
-  return vector<uint64_t>(dims.begin(), dims.end());
-}
 } // namespace
 
 DeclaredFunction::DeclaredFunction(vector<mlir::Type> &&domain,
-                                   mlir::Type &&range, FnDecl &&decl)
-    : domain(move(domain)), range(move(range)), decl(move(decl)) {}
+                                   mlir::Type &&range, FnDecl &&decl,
+                                   vector<FnDecl> &&dims)
+    : domain(move(domain)), range(move(range)), decl(move(decl)),
+      dims(move(dims)) {}
 
 DeclaredFunction DeclaredFunction::declare(std::vector<mlir::Type> &&domain,
                                            mlir::Type &&range,
@@ -32,10 +26,6 @@ DeclaredFunction DeclaredFunction::declare(std::vector<mlir::Type> &&domain,
       if (!tty.hasRank()) {
         throw UnsupportedException("A call with an unranked tensor as operand "
                                    "or return value is not supported");
-      } else if (!tty.hasStaticShape()) {
-        throw UnsupportedException("A call with a dynamically sized tensor "
-                                   "as operand or return value is not"
-                                   " supported");
       } else if (!Tensor::isTypeSupported(tty)) {
         throw UnsupportedException("Unsupported tensor type: " +
                                    to_string(tty));
@@ -59,7 +49,18 @@ DeclaredFunction DeclaredFunction::declare(std::vector<mlir::Type> &&domain,
   transform(domain.cbegin(), domain.cend(), back_inserter(smtDomain),
             typeToSort);
   FnDecl decl(smtDomain, typeToSort(range), string(name) + "_tvfn");
-  return DeclaredFunction(move(domain), move(range), move(decl));
+
+  vector<FnDecl> dims;
+  if (auto sty = range.dyn_cast<mlir::ShapedType>()) {
+    const auto rank = sty.getRank();
+    dims.reserve(rank);
+    const auto dimPrefix = string(name) + "_tvfn_dim_";
+    for (size_t i = 0; i < rank; i++) {
+      auto dim = FnDecl(smtDomain, Index::sort(), dimPrefix + to_string(i));
+      dims.push_back(move(dim));
+    }
+  }
+  return DeclaredFunction(move(domain), move(range), move(decl), move(dims));
 }
 
 ValueTy DeclaredFunction::apply(const std::vector<ValueTy> &operands) const {
@@ -75,16 +76,25 @@ ValueTy DeclaredFunction::apply(const std::vector<ValueTy> &operands) const {
                                 << range);
     return *fn_output;
   } else if (auto tensorRange = range.dyn_cast<mlir::TensorType>()) {
-    smart_assert(tensorRange.hasStaticShape(), "The range is a dynamically"
-                 " sized tensor type; UnsupportedException must have been "
-                 "thrown");
-    const auto dims = getShapeDimVector(tensorRange);
-    auto fn_output =
-        Tensor(tensorRange.getElementType(), decl.apply(operandExprs), dims);
+    vector<Expr> dims;
+    const auto rank = tensorRange.getRank();
+    dims.reserve(rank);
+    for (size_t i = 0; i < rank; i++) {
+      if (tensorRange.isDynamicDim(i)) {
+        dims.push_back(this->dims[i].apply(operandExprs));
+      } else {
+        // static dimension does not need to be obtained via UF
+        dims.push_back(Index(tensorRange.getDimSize(i)));
+      }
+    }
+
+    auto fn_output = Tensor::fromArray(tensorRange.getElementType(),
+                                       decl.apply(operandExprs), move(dims));
     return fn_output;
   } else {
     smart_assert(false, "Cannot create ValueTy from the call's result"
-                        " because its MLIR type is " << range);
+                        " because its MLIR type is "
+                            << range);
   }
 }
 

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -1,9 +1,15 @@
 #include "function.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "simplevalue.h"
 #include "utils.h"
+#include "value.h"
+#include "llvm/ADT/APFloat.h"
 
 #include <algorithm>
 #include <iterator>
 #include <map>
+#include <numeric>
+#include <variant>
 
 using namespace std;
 using namespace smt;
@@ -67,8 +73,38 @@ ValueTy DeclaredFunction::apply(const std::vector<ValueTy> &operands) const {
   vector<Expr> operandExprs;
   operandExprs.reserve(operands.size());
 
+  auto getZeroGuardedExpr = [](const ValueTy &val) {
+    if (holds_alternative<Tensor>(val)) {
+      const auto tensorVal = get<Tensor>(val);
+      Expr numElements = Index::one();
+      for (const auto &dim : tensorVal.getDims()) {
+        numElements = numElements * dim;
+      }
+
+      const Expr arr = tensorVal;
+      const auto i = static_cast<Expr>(Index::var("idx", VarType::BOUND));
+
+      Expr zero = Index::zero();
+      const auto elemType = tensorVal.getElemType();
+      if (elemType.isa<mlir::FloatType>()) {
+        zero = Float::constant(llvm::APFloat(0.0), elemType);
+      } else if (elemType.isa<mlir::IntegerType>()) {
+        zero = Integer(0, elemType.getIntOrFloatBitWidth());
+      } else if (elemType.isIndex()) {
+        // no-op
+      } else {
+        smart_assert(false, "Invalid tensor element type " << elemType);
+      }
+
+      return Expr::mkLambda(
+          i, Expr::mkIte(i.ult(numElements), arr.select(i), zero));
+    } else {
+      return getExpr(val);
+    }
+  };
+
   transform(operands.cbegin(), operands.cend(), back_inserter(operandExprs),
-            getExpr);
+            getZeroGuardedExpr);
   if (range.isIntOrIndexOrFloat()) {
     auto fn_output = fromExpr(decl.apply(operandExprs), range);
     smart_assert(fn_output, "Cannot create ValueTy from the call's result"

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -1,9 +1,5 @@
 #include "function.h"
-#include "mlir/IR/BuiltinTypes.h"
-#include "simplevalue.h"
 #include "utils.h"
-#include "value.h"
-#include "llvm/ADT/APFloat.h"
 
 #include <algorithm>
 #include <iterator>

--- a/src/function.h
+++ b/src/function.h
@@ -14,9 +14,10 @@ private:
   std::vector<mlir::Type> domain;
   mlir::Type range;
   smt::FnDecl decl;
+  std::vector<smt::FnDecl> dims;
 
   DeclaredFunction(std::vector<mlir::Type> &&domain, mlir::Type &&range,
-                   smt::FnDecl &&decl);
+                   smt::FnDecl &&decl, std::vector<smt::FnDecl> &&dims);
 
 public:
   static DeclaredFunction declare(std::vector<mlir::Type> &&domain,

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -451,13 +451,9 @@ Tensor::Tensor(mlir::Type elemType, vector<Expr> &&elems1d, const vector<uint64_
     dims.push_back(Index(dim[i]));
 }
 
-Tensor::Tensor(mlir::Type elemType, Expr &&arr, const vector<uint64_t> &dim):
-    ShapedValue(elemType),
-    dims({}),
-    arr(move(arr)),
-    initialized(splatArrayForTensor(Expr::mkBool(true))) {
-  for (unsigned i = 0; i < dim.size(); ++i)
-    dims.push_back(Index(dim[i]));
+Tensor Tensor::fromArray(mlir::Type elemType, smt::Expr &&arr, std::vector<smt::Expr> &&dims) {
+  return Tensor(elemType, move(dims), move(arr),
+    splatArrayForTensor(Expr::mkBool(true)));
 }
 
 // A fresh tensor

--- a/src/value.h
+++ b/src/value.h
@@ -141,9 +141,9 @@ public:
   // Multidimensional tensor
   Tensor(mlir::Type elemType, std::vector<smt::Expr> &&elems,
          const std::vector<uint64_t> &dims);
-  Tensor(mlir::Type elemType, smt::Expr &&arr,
-         const std::vector<uint64_t> &dims);
 
+  static Tensor fromArray(mlir::Type elemType, smt::Expr &&arr,
+         std::vector<smt::Expr> &&dims);
   smt::Expr asArray() const { return arr; }
   smt::Expr getWellDefined() const;
 

--- a/tests/litmus/func-ops/cast_to_dyn-bad.src.mlir
+++ b/tests/litmus/func-ops/cast_to_dyn-bad.src.mlir
@@ -1,0 +1,10 @@
+// VERIFY-INCORRECT
+
+func.func private @dyn_tensor(%t: tensor<?xi32>) -> f32
+
+func.func @dim_mismatch() -> f32 {
+  %zt = arith.constant sparse<[[0], [1], [2], [3], [4]], [0, 0, 0, 0, 0]> : tensor<5xi32>
+  %zdt = tensor.cast %zt: tensor<5xi32> to tensor<?xi32>
+  %r = func.call @dyn_tensor(%zdt): (tensor<?xi32>) -> f32
+  return %r: f32
+}

--- a/tests/litmus/func-ops/cast_to_dyn-bad.tgt.mlir
+++ b/tests/litmus/func-ops/cast_to_dyn-bad.tgt.mlir
@@ -1,0 +1,8 @@
+func.func private @dyn_tensor(%t: tensor<?xi32>) -> f32
+
+func.func @dim_mismatch() -> f32 {
+  %zt = arith.constant sparse<[[0], [1], [2]], [0, 0, 0]> : tensor<3xi32>
+  %zdt = tensor.cast %zt: tensor<3xi32> to tensor<?xi32>
+  %r = func.call @dyn_tensor(%zdt): (tensor<?xi32>) -> f32
+  return %r: f32
+}

--- a/tests/litmus/func-ops/tensor-bad.src.mlir
+++ b/tests/litmus/func-ops/tensor-bad.src.mlir
@@ -1,0 +1,11 @@
+// VERIFY-INCORRECT
+
+func.func private @linear_tensor(%t: tensor<5xf32>) -> f32
+
+func.func @different_tensor(%v: tensor<5xf32>) -> f32 {
+  %i = arith.constant 4: index
+  %c = arith.constant 5.0: f32
+  %mv = tensor.insert %c into %v[%i]: tensor<5xf32>
+  %r = func.call @linear_tensor(%mv): (tensor<5xf32>) -> f32
+  return %r: f32
+}

--- a/tests/litmus/func-ops/tensor-bad.tgt.mlir
+++ b/tests/litmus/func-ops/tensor-bad.tgt.mlir
@@ -1,0 +1,9 @@
+func.func private @linear_tensor(%t: tensor<5xf32>) -> f32
+
+func.func @different_tensor(%v: tensor<5xf32>) -> f32 {
+  %i = arith.constant 4: index
+  %c = arith.constant 3.0: f32
+  %mv = tensor.insert %c into %v[%i]: tensor<5xf32>
+  %r = func.call @linear_tensor(%mv): (tensor<5xf32>) -> f32
+  return %r: f32
+}

--- a/tests/litmus/func-ops/tensor.src.mlir
+++ b/tests/litmus/func-ops/tensor.src.mlir
@@ -3,6 +3,7 @@
 func.func private @simpl_tensor(%v: f32) -> tensor<3x5xf32>
 func.func private @simpl_large_tensor(%v: i32) -> tensor<4x2x33x55xf32>
 func.func private @argtensor(%v: tensor<3x5xi32>, %w: i32) -> tensor<3x5xi32>
+func.func private @dynamic_tensor(%v: f32) -> tensor<3x5x?xf32>
 
 func.func @commut_tensor(%v1: f32, %v2: f32) -> tensor<3x5xf32> {
   %r1 = func.call @simpl_tensor(%v1): (f32) -> tensor<3x5xf32>
@@ -16,6 +17,13 @@ func.func @commut_large_tensor(%v1: i32, %v2: i32) -> tensor<4x2x33x55xf32> {
   %r2 = func.call @simpl_large_tensor(%v2): (i32) -> tensor<4x2x33x55xf32>
   %r = "tosa.add"(%r1, %r2) : (tensor<4x2x33x55xf32>, tensor<4x2x33x55xf32>) -> tensor<4x2x33x55xf32>
   return %r: tensor<4x2x33x55xf32>
+}
+
+func.func @commut_dynamic_tensor(%v1: f32, %v2: f32) -> tensor<3x5x?xf32> {
+  %r1 = func.call @dynamic_tensor(%v1): (f32) -> tensor<3x5x?xf32>
+  %r2 = func.call @dynamic_tensor(%v2): (f32) -> tensor<3x5x?xf32>
+  %r = "tosa.add"(%r1, %r2) : (tensor<3x5x?xf32>, tensor<3x5x?xf32>) -> tensor<3x5x?xf32>
+  return %r: tensor<3x5x?xf32>
 }
 
 func.func @argtensor_identical(%v1: tensor<3x5xi32>, %w: i32) -> tensor<3x5xi32> {

--- a/tests/litmus/func-ops/tensor.src.mlir
+++ b/tests/litmus/func-ops/tensor.src.mlir
@@ -4,6 +4,7 @@ func.func private @simpl_tensor(%v: f32) -> tensor<3x5xf32>
 func.func private @simpl_large_tensor(%v: i32) -> tensor<4x2x33x55xf32>
 func.func private @argtensor(%v: tensor<3x5xi32>, %w: i32) -> tensor<3x5xi32>
 func.func private @dynamic_tensor(%v: f32) -> tensor<3x5x?xf32>
+func.func private @linear_tensor(%t: tensor<5xf32>) -> f32
 
 func.func @commut_tensor(%v1: f32, %v2: f32) -> tensor<3x5xf32> {
   %r1 = func.call @simpl_tensor(%v1): (f32) -> tensor<3x5xf32>
@@ -35,4 +36,13 @@ func.func @identical_operand_tensor(%v1: f32, %v2: f32) -> tensor<3x5xf32> {
   %v = arith.addf %v1, %v2: f32
   %r = func.call @simpl_tensor(%v): (f32) -> tensor<3x5xf32>
   return %r: tensor<3x5xf32>
+}
+
+func.func @slice_tensor(%v: tensor<6xf32>) -> f32 {
+  %i = arith.constant 5: index
+  %c = arith.constant 5.0: f32
+  %mv = tensor.insert %c into %v[%i]: tensor<6xf32>
+  %sv = tensor.extract_slice %mv[0][5][1]: tensor<6xf32> to tensor<5xf32>
+  %r = func.call @linear_tensor(%sv): (tensor<5xf32>) -> f32
+  return %r: f32
 }

--- a/tests/litmus/func-ops/tensor.tgt.mlir
+++ b/tests/litmus/func-ops/tensor.tgt.mlir
@@ -1,6 +1,7 @@
 func.func private @simpl_tensor(%v: f32) -> tensor<3x5xf32>
 func.func private @simpl_large_tensor(%v: i32) -> tensor<4x2x33x55xf32>
 func.func private @argtensor(%v: tensor<3x5xi32>, %w: i32) -> tensor<3x5xi32>
+func.func private @dynamic_tensor(%v: f32) -> tensor<3x5x?xf32>
 
 func.func @commut_tensor(%v1: f32, %v2: f32) -> tensor<3x5xf32> {
   %r1 = func.call @simpl_tensor(%v1): (f32) -> tensor<3x5xf32>
@@ -14,6 +15,13 @@ func.func @commut_large_tensor(%v1: i32, %v2: i32) -> tensor<4x2x33x55xf32> {
   %r2 = func.call @simpl_large_tensor(%v2): (i32) -> tensor<4x2x33x55xf32>
   %r = "tosa.add"(%r2, %r1) : (tensor<4x2x33x55xf32>, tensor<4x2x33x55xf32>) -> tensor<4x2x33x55xf32>
   return %r: tensor<4x2x33x55xf32>
+}
+
+func.func @commut_dynamic_tensor(%v1: f32, %v2: f32) -> tensor<3x5x?xf32> {
+  %r1 = func.call @dynamic_tensor(%v1): (f32) -> tensor<3x5x?xf32>
+  %r2 = func.call @dynamic_tensor(%v2): (f32) -> tensor<3x5x?xf32>
+  %r = "tosa.add"(%r2, %r1) : (tensor<3x5x?xf32>, tensor<3x5x?xf32>) -> tensor<3x5x?xf32>
+  return %r: tensor<3x5x?xf32>
 }
 
 func.func @argtensor_identical(%v1: tensor<3x5xi32>, %w: i32) -> tensor<3x5xi32> {

--- a/tests/litmus/func-ops/tensor.tgt.mlir
+++ b/tests/litmus/func-ops/tensor.tgt.mlir
@@ -2,6 +2,7 @@ func.func private @simpl_tensor(%v: f32) -> tensor<3x5xf32>
 func.func private @simpl_large_tensor(%v: i32) -> tensor<4x2x33x55xf32>
 func.func private @argtensor(%v: tensor<3x5xi32>, %w: i32) -> tensor<3x5xi32>
 func.func private @dynamic_tensor(%v: f32) -> tensor<3x5x?xf32>
+func.func private @linear_tensor(%t: tensor<5xf32>) -> f32
 
 func.func @commut_tensor(%v1: f32, %v2: f32) -> tensor<3x5xf32> {
   %r1 = func.call @simpl_tensor(%v1): (f32) -> tensor<3x5xf32>
@@ -33,4 +34,13 @@ func.func @identical_operand_tensor(%v1: f32, %v2: f32) -> tensor<3x5xf32> {
   %v = arith.addf %v2, %v1: f32
   %r = func.call @simpl_tensor(%v): (f32) -> tensor<3x5xf32>
   return %r: tensor<3x5xf32>
+}
+
+func.func @slice_tensor(%v: tensor<6xf32>) -> f32 {
+  %i = arith.constant 5: index
+  %c = arith.constant 3.0: f32
+  %mv = tensor.insert %c into %v[%i]: tensor<6xf32>
+  %sv = tensor.extract_slice %mv[0][5][1]: tensor<6xf32> to tensor<5xf32>
+  %r = func.call @linear_tensor(%sv): (tensor<5xf32>) -> f32
+  return %r: f32
 }


### PR DESCRIPTION
This PR lifts some restriction of encoding for scalar function call.

As of now, mlir-tv can encode very limited set of functions that succeeds to meet the following criterias.
* Function must have only one return value
* Function operand(s) must be zero or more scalar (int, float, index) value(s)
* Function must return a scalar value **or a ~~fixed-size~~ ranked tensor** // updated in this PR

More restrictions are to be lifted in the further PRs.