### PR TITLE
Update tests to use the new MLIR strided layout syntax

### DIFF
--- a/tests/litmus/memref-ops/memref-arg-stride.src.mlir
+++ b/tests/litmus/memref-ops/memref-arg-stride.src.mlir
@@ -1,6 +1,0 @@
-// VERIFY
-
-func.func @fill_view(%arg0: memref<?xf32, offset: ?, strides: [1]>, %arg1: f32) {
-  linalg.fill ins(%arg1: f32) outs(%arg0: memref<?xf32, offset: ?, strides: [1]>)
-  return
-}

--- a/tests/litmus/memref-ops/memref-arg-stride.tgt.mlir
+++ b/tests/litmus/memref-ops/memref-arg-stride.tgt.mlir
@@ -1,7 +1,0 @@
-#map = affine_map<(d0)[s0] -> (d0 + s0)>
-module  {
-  func.func @fill_view(%arg0: memref<?xf32, #map>, %arg1: f32) {
-    linalg.fill ins(%arg1: f32) outs(%arg0: memref<?xf32, #map>)
-    return
-  }
-}

--- a/tests/litmus/memref-ops/subview_out_of_bounds.src.mlir
+++ b/tests/litmus/memref-ops/subview_out_of_bounds.src.mlir
@@ -3,7 +3,7 @@
 func.func @fold_rank_reducing_subview_with_load(%arg0 : memref<?x?xf32>) -> f32 {
   %c0 = arith.constant 0: index
   %c1 = arith.constant 1: index
-  %ptr = memref.subview %arg0[%c0, %c0][1, 1][%c1, %c1] : memref<?x?xf32> to memref<1xf32, offset:?, strides: [?]>
-  %1 = memref.load %ptr[%c1] : memref<1xf32, offset:?, strides: [?]>
+  %ptr = memref.subview %arg0[%c0, %c0][1, 1][%c1, %c1] : memref<?x?xf32> to memref<1xf32, strided<[?], offset: ?>>
+  %1 = memref.load %ptr[%c1] : memref<1xf32, strided<[?], offset: ?>>
   return %1 : f32
 }

--- a/tests/opts/fold-memref-subview-op/rank_reduction.src.mlir
+++ b/tests/opts/fold-memref-subview-op/rank_reduction.src.mlir
@@ -6,8 +6,8 @@ func.func @fold_rank_reducing_subview_with_load
      %arg7 : index, %arg8 : index, %arg9 : index, %arg10: index,
      %arg11 : index, %arg12 : index, %arg13 : index, %arg14: index,
      %arg15 : index, %arg16 : index) -> f32 {
-  %0 = memref.subview %arg0[%arg1, %arg2, %arg3, %arg4, %arg5, %arg6][4, 1, 1, 4, 1, 1][%arg7, %arg8, %arg9, %arg10, %arg11, %arg12] : memref<?x?x?x?x?x?xf32> to memref<4x1x4x1xf32, offset:?, strides: [?, ?, ?, ?]>
-  %1 = memref.load %0[%arg13, %arg14, %arg15, %arg16] : memref<4x1x4x1xf32, offset:?, strides: [?, ?, ?, ?]>
+  %0 = memref.subview %arg0[%arg1, %arg2, %arg3, %arg4, %arg5, %arg6][4, 1, 1, 4, 1, 1][%arg7, %arg8, %arg9, %arg10, %arg11, %arg12] : memref<?x?x?x?x?x?xf32> to memref<4x1x4x1xf32, strided<[?, ?, ?, ?], offset: ?>>
+  %1 = memref.load %0[%arg13, %arg14, %arg15, %arg16] : memref<4x1x4x1xf32, strided<[?, ?, ?, ?], offset: ?>>
   return %1 : f32
 }
 


### PR DESCRIPTION
The syntax for the strided layout has been changed.
Also, according to [this documentation](https://mlir.llvm.org/docs/Dialects/Builtin/#strided-layout) strided layout cannot be implicitly converted to affine layout anymore. The deleted tests became invalid due to this change.