### PR TITLE
Print stdout and stderr upon parsing failure

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           cd /src/mlir-tv/build
           . /venv/bin/activate
-          ctest -R Opts
+          ctest --output-on-failure -R Opts
 
       - name: Upload test log
         if: ${{ failure() }}
@@ -182,7 +182,7 @@ jobs:
         run: |
           cd /src/mlir-tv/build
           . /venv/bin/activate
-          ctest -R Litmus
+          ctest --output-on-failure -R Litmus
 
       - name: Upload test log
         if: ${{ failure() }}

--- a/tests/lit/formats/mlirtest.py
+++ b/tests/lit/formats/mlirtest.py
@@ -71,7 +71,7 @@ class ExitCodeDependentTestBase(TestBase):
             return lit.Test.SKIPPED, ""
         elif int(exit_code / 10) == 8:
             # exit code 80~89: parsing related errors
-            return lit.Test.UNRESOLVED, ""
+            return lit.Test.UNRESOLVED, f"stdout >>\n{outs}\n\nstderr >>\n{errs}"
         elif exit_code == 101:
             # timeout
             return lit.Test.TIMEOUT, ""


### PR DESCRIPTION
Parsing error messages are shown on stderr, which is not captured by ctest and therefore does not appear on the test log.
This patch updates the lit test script to redirect both stdout and stderr to stdout when a parsing error is thrown.

`--output-on-failure` is added to show the error on Actions log as well. Hopefully we won't have to download the log file anymore for most of the time.