### PR TITLE
Add command-line option `--use-fn-argument-dims`

### DIFF
--- a/src/function.cpp
+++ b/src/function.cpp
@@ -52,23 +52,24 @@ DeclaredFunction DeclaredFunction::declare(std::vector<mlir::Type> &&domain,
   if (rangeDimRefIdx) {
     const auto dimRefIdx = *rangeDimRefIdx;
     smart_assert(dimRefIdx < domain.size(),
-                "Tried to refer to the argument of an invalid index");
+                 "Tried to refer to the argument of an invalid index");
 
     const auto shapedDimRef = domain[dimRefIdx].dyn_cast<mlir::ShapedType>();
     const auto shapedRange = range.dyn_cast<mlir::ShapedType>();
-    smart_assert(shapedDimRef && shapedRange,
-                "Both the specified domain and the range must be shaped types");
+    smart_assert(
+        shapedDimRef && shapedRange,
+        "Both the specified domain and the range must be shaped types");
     smart_assert(shapedDimRef.getRank() == shapedRange.getRank(),
-                "The specified domain and the range must have the same ranks");
+                 "The specified domain and the range must have the same ranks");
 
     for (size_t r = 0; r < shapedDimRef.getRank(); r++) {
       if (shapedDimRef.isDynamicDim(r) != shapedRange.isDynamicDim(r)) {
         throw UnsupportedException("The dimensions of the specified domain and "
-                                  "the range are incompatible");
+                                   "the range are incompatible");
       } else if (!shapedDimRef.isDynamicDim(r) && shapedRange.isDynamicDim(r) &&
-                shapedDimRef.getDimSize(r) != shapedRange.getDimSize(r)) {
+                 shapedDimRef.getDimSize(r) != shapedRange.getDimSize(r)) {
         throw UnsupportedException("The dimensions of the specified domain and "
-                                  "the range are incompatible");
+                                   "the range are incompatible");
       }
     }
   }

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -51,16 +51,21 @@ DeclaredFunction DeclaredFunction::declare(std::vector<mlir::Type> &&domain,
 
   if (rangeDimRefIdx) {
     const auto dimRefIdx = *rangeDimRefIdx;
-    smart_assert(dimRefIdx < domain.size(),
-                 "Tried to refer to the argument of an invalid index");
+    if (dimRefIdx >= domain.size()) {
+      throw UnsupportedException(
+          "Tried to refer to the argument of an invalid index");
+    }
 
     const auto shapedDimRef = domain[dimRefIdx].dyn_cast<mlir::ShapedType>();
     const auto shapedRange = range.dyn_cast<mlir::ShapedType>();
-    smart_assert(
-        shapedDimRef && shapedRange,
-        "Both the specified domain and the range must be shaped types");
-    smart_assert(shapedDimRef.getRank() == shapedRange.getRank(),
-                 "The specified domain and the range must have the same ranks");
+    if (!(shapedDimRef && shapedRange)) {
+      throw UnsupportedException(
+          "Both the specified domain and the range must be shaped types");
+    }
+    if (shapedDimRef.getRank() != shapedRange.getRank()) {
+      throw UnsupportedException(
+          "The specified domain and the range must have the same ranks");
+    }
 
     for (size_t r = 0; r < shapedDimRef.getRank(); r++) {
       if (shapedDimRef.isDynamicDim(r) != shapedRange.isDynamicDim(r)) {

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -53,7 +53,7 @@ DeclaredFunction DeclaredFunction::declare(std::vector<mlir::Type> &&domain,
     const auto dimRefIdx = *rangeDimRefIdx;
     if (dimRefIdx >= domain.size()) {
       throw UnsupportedException(
-          "Tried to refer to the argument of an invalid index");
+          "Tried to refer to an argument of an invalid index");
     }
 
     const auto shapedDimRef = domain[dimRefIdx].dyn_cast<mlir::ShapedType>();

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -2,6 +2,7 @@
 #include "utils.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <iterator>
 #include <map>
 #include <numeric>
@@ -16,13 +17,15 @@ map<string, DeclaredFunction, std::less<>> calleeMap;
 
 DeclaredFunction::DeclaredFunction(vector<mlir::Type> &&domain,
                                    mlir::Type &&range, FnDecl &&decl,
-                                   vector<FnDecl> &&dims)
+                                   vector<FnDecl> &&dims,
+                                   optional<int64_t> &&rangeDimRefIdx)
     : domain(move(domain)), range(move(range)), decl(move(decl)),
-      dims(move(dims)) {}
+      dims(move(dims)), rangeDimRefIdx(move(rangeDimRefIdx)) {}
 
 DeclaredFunction DeclaredFunction::declare(std::vector<mlir::Type> &&domain,
                                            mlir::Type &&range,
-                                           const std::string_view name) {
+                                           const std::string_view name,
+                                           optional<int64_t> &&rangeDimRefIdx) {
   auto typeToSort = [](mlir::Type t) {
     if (auto tty = t.dyn_cast<mlir::TensorType>()) {
       if (!tty.hasRank()) {
@@ -46,6 +49,30 @@ DeclaredFunction DeclaredFunction::declare(std::vector<mlir::Type> &&domain,
     throw UnsupportedException("Unsupported type: " + to_string(t));
   };
 
+  if (rangeDimRefIdx) {
+    const auto dimRefIdx = *rangeDimRefIdx;
+    smart_assert(dimRefIdx < domain.size(),
+                "Tried to refer to the argument of an invalid index");
+
+    const auto shapedDimRef = domain[dimRefIdx].dyn_cast<mlir::ShapedType>();
+    const auto shapedRange = range.dyn_cast<mlir::ShapedType>();
+    smart_assert(shapedDimRef && shapedRange,
+                "Both the specified domain and the range must be shaped types");
+    smart_assert(shapedDimRef.getRank() == shapedRange.getRank(),
+                "The specified domain and the range must have the same ranks");
+
+    for (size_t r = 0; r < shapedDimRef.getRank(); r++) {
+      if (shapedDimRef.isDynamicDim(r) != shapedRange.isDynamicDim(r)) {
+        throw UnsupportedException("The dimensions of the specified domain and "
+                                  "the range are incompatible");
+      } else if (!shapedDimRef.isDynamicDim(r) && shapedRange.isDynamicDim(r) &&
+                shapedDimRef.getDimSize(r) != shapedRange.getDimSize(r)) {
+        throw UnsupportedException("The dimensions of the specified domain and "
+                                  "the range are incompatible");
+      }
+    }
+  }
+
   vector<Sort> smtDomain;
   for (const auto operandTy : domain) {
     smtDomain.push_back(typeToSort(operandTy));
@@ -68,7 +95,8 @@ DeclaredFunction DeclaredFunction::declare(std::vector<mlir::Type> &&domain,
       dims.push_back(move(dim));
     }
   }
-  return DeclaredFunction(move(domain), move(range), move(decl), move(dims));
+  return DeclaredFunction(move(domain), move(range), move(decl), move(dims),
+                          move(rangeDimRefIdx));
 }
 
 ValueTy DeclaredFunction::apply(const std::vector<ValueTy> &operands) const {
@@ -112,12 +140,22 @@ ValueTy DeclaredFunction::apply(const std::vector<ValueTy> &operands) const {
     vector<Expr> dims;
     const auto rank = tensorRange.getRank();
     dims.reserve(rank);
-    for (size_t i = 0; i < rank; i++) {
-      if (tensorRange.isDynamicDim(i)) {
-        dims.push_back(this->dims[i].apply(operandExprs));
-      } else {
-        // static dimension does not need to be obtained via UF
-        dims.push_back(Index(tensorRange.getDimSize(i)));
+
+    if (rangeDimRefIdx) {
+      // dim reference argument is given
+      const auto dimRefVal = operands[*rangeDimRefIdx];
+      if (holds_alternative<Tensor>(dimRefVal)) {
+        const auto refDims = get<Tensor>(dimRefVal).getDims();
+        dims.insert(end(dims), refDims.cbegin(), refDims.cend());
+      }
+    } else {
+      for (size_t i = 0; i < rank; i++) {
+        if (tensorRange.isDynamicDim(i)) {
+          dims.push_back(this->dims[i].apply(operandExprs));
+        } else {
+          // static dimension does not need to be obtained via UF
+          dims.push_back(Index(tensorRange.getDimSize(i)));
+        }
       }
     }
 
@@ -141,7 +179,8 @@ optional<DeclaredFunction> getDeclaredFunction(const std::string_view name) {
 }
 
 bool declareFunction(vector<mlir::Type> &&domain, mlir::Type &&range,
-                     const string_view name) {
+                     const string_view name,
+                     optional<int64_t> &&dimsReferenceIdx) {
   if (getDeclaredFunction(name)) {
     // no-op if there already exists a function of the same name
     return false;
@@ -149,8 +188,9 @@ bool declareFunction(vector<mlir::Type> &&domain, mlir::Type &&range,
     llvm::outs() << "WARNING: Function \"" << name << "\" is assumed to be "
                  << "stateless and does not read or write global memory\n";
 
-    calleeMap.insert({string(name), DeclaredFunction::declare(
-                                        move(domain), move(range), name)});
+    calleeMap.insert({string(name),
+                      DeclaredFunction::declare(move(domain), move(range), name,
+                                                move(dimsReferenceIdx))});
     return true;
   }
 }

--- a/src/function.h
+++ b/src/function.h
@@ -5,6 +5,7 @@
 
 #include "mlir/IR/Types.h"
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>
@@ -15,14 +16,17 @@ private:
   mlir::Type range;
   smt::FnDecl decl;
   std::vector<smt::FnDecl> dims;
+  std::optional<int64_t> rangeDimRefIdx;
 
   DeclaredFunction(std::vector<mlir::Type> &&domain, mlir::Type &&range,
-                   smt::FnDecl &&decl, std::vector<smt::FnDecl> &&dims);
+                   smt::FnDecl &&decl, std::vector<smt::FnDecl> &&dims,
+                   std::optional<int64_t> &&rangeDimRefIdx);
 
 public:
   static DeclaredFunction declare(std::vector<mlir::Type> &&domain,
                                   mlir::Type &&range,
-                                  const std::string_view name);
+                                  const std::string_view name,
+                                  std::optional<int64_t> &&rangeDimRefIdx);
 
   ValueTy apply(const std::vector<ValueTy> &operands) const;
 };
@@ -30,4 +34,5 @@ public:
 std::optional<DeclaredFunction>
 getDeclaredFunction(const std::string_view name);
 bool declareFunction(std::vector<mlir::Type> &&domain, mlir::Type &&range,
-                     const std::string_view name);
+                     const std::string_view name,
+                     std::optional<int64_t> &&dimsReferenceIdx);

--- a/tests/litmus/func-ops/fn_arg_dims.src.mlir
+++ b/tests/litmus/func-ops/fn_arg_dims.src.mlir
@@ -3,11 +3,9 @@
 
 func.func private @dyn_tensor_1(%v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
 
-func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> index {
   %t = func.call @dyn_tensor_1(%v): (tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
-  %c0 = arith.constant 0: index
-  %d1 = tensor.dim %v, %c0: tensor<3x?x?xf32>
-  %d2 = tensor.dim %t, %c0: tensor<3x?x?xf32>
-  %r = arith.cmpi eq, %d1, %d2 : index
-  return %r: i1
+  %c = arith.constant 1: index
+  %r = tensor.dim %v, %c: tensor<3x?x?xf32>
+  return %r: index
 }

--- a/tests/litmus/func-ops/fn_arg_dims.src.mlir
+++ b/tests/litmus/func-ops/fn_arg_dims.src.mlir
@@ -1,0 +1,13 @@
+// VERIFY
+// ARGS: --use-fn-argument-dims=dyn_tensor_1@0
+
+func.func private @dyn_tensor_1(%v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+  %t = func.call @dyn_tensor_1(%v): (tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+  %c0 = arith.constant 0: index
+  %d1 = tensor.dim %v, %c0: tensor<3x?x?xf32>
+  %d2 = tensor.dim %t, %c0: tensor<3x?x?xf32>
+  %r = arith.cmpi eq, %d1, %d2 : index
+  return %r: i1
+}

--- a/tests/litmus/func-ops/fn_arg_dims.tgt.mlir
+++ b/tests/litmus/func-ops/fn_arg_dims.tgt.mlir
@@ -1,10 +1,8 @@
 func.func private @dyn_tensor_1(%v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
 
-func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> index {
   %t = func.call @dyn_tensor_1(%v): (tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
-  %c0 = arith.constant 1: index
-  %d1 = tensor.dim %v, %c0: tensor<3x?x?xf32>
-  %d2 = tensor.dim %t, %c0: tensor<3x?x?xf32>
-  %r = arith.cmpi eq, %d1, %d2 : index
-  return %r: i1
+  %c = arith.constant 1: index
+  %r = tensor.dim %t, %c: tensor<3x?x?xf32>
+  return %r: index
 }

--- a/tests/litmus/func-ops/fn_arg_dims.tgt.mlir
+++ b/tests/litmus/func-ops/fn_arg_dims.tgt.mlir
@@ -1,0 +1,10 @@
+func.func private @dyn_tensor_1(%v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+  %t = func.call @dyn_tensor_1(%v): (tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+  %c0 = arith.constant 1: index
+  %d1 = tensor.dim %v, %c0: tensor<3x?x?xf32>
+  %d2 = tensor.dim %t, %c0: tensor<3x?x?xf32>
+  %r = arith.cmpi eq, %d1, %d2 : index
+  return %r: i1
+}

--- a/tests/litmus/func-ops/fn_arg_dims_multiple.src.mlir
+++ b/tests/litmus/func-ops/fn_arg_dims_multiple.src.mlir
@@ -4,13 +4,10 @@
 func.func private @dyn_tensor_1(%v1: f32, %v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
 func.func private @dyn_tensor_2(%v1: f32, %v2: f32, %v3: f32, %v4: f32, %v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
 
-func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> index {
   %f0 = arith.constant 1.0: f32
   %t1 = func.call @dyn_tensor_1(%f0, %v): (f32, tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
-  %t2 = func.call @dyn_tensor_2(%f0, %f0, %f0, %f0, %v): (f32, f32, f32, f32, tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
-  %c0 = arith.constant 0: index
-  %d1 = tensor.dim %t1, %c0: tensor<3x?x?xf32>
-  %d2 = tensor.dim %t2, %c0: tensor<3x?x?xf32>
-  %r = arith.cmpi eq, %d1, %d2 : index
-  return %r: i1
+  %c0 = arith.constant 1: index
+  %r = tensor.dim %t1, %c0: tensor<3x?x?xf32>
+  return %r: index
 }

--- a/tests/litmus/func-ops/fn_arg_dims_multiple.src.mlir
+++ b/tests/litmus/func-ops/fn_arg_dims_multiple.src.mlir
@@ -1,0 +1,16 @@
+// VERIFY
+// ARGS: --use-fn-argument-dims=dyn_tensor_1@1,dyn_tensor_2@4
+
+func.func private @dyn_tensor_1(%v1: f32, %v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+func.func private @dyn_tensor_2(%v1: f32, %v2: f32, %v3: f32, %v4: f32, %v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+  %f0 = arith.constant 1.0: f32
+  %t1 = func.call @dyn_tensor_1(%f0, %v): (f32, tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+  %t2 = func.call @dyn_tensor_2(%f0, %f0, %f0, %f0, %v): (f32, f32, f32, f32, tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+  %c0 = arith.constant 0: index
+  %d1 = tensor.dim %t1, %c0: tensor<3x?x?xf32>
+  %d2 = tensor.dim %t2, %c0: tensor<3x?x?xf32>
+  %r = arith.cmpi eq, %d1, %d2 : index
+  return %r: i1
+}

--- a/tests/litmus/func-ops/fn_arg_dims_multiple.tgt.mlir
+++ b/tests/litmus/func-ops/fn_arg_dims_multiple.tgt.mlir
@@ -1,0 +1,13 @@
+func.func private @dyn_tensor_1(%v1: f32, %v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+func.func private @dyn_tensor_2(%v1: f32, %v2: f32, %v3: f32, %v4: f32, %v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+  %f0 = arith.constant 1.0: f32
+  %t1 = func.call @dyn_tensor_1(%f0, %v): (f32, tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+  %t2 = func.call @dyn_tensor_2(%f0, %f0, %f0, %f0, %v): (f32, f32, f32, f32, tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+  %c0 = arith.constant 1: index
+  %d1 = tensor.dim %t1, %c0: tensor<3x?x?xf32>
+  %d2 = tensor.dim %t2, %c0: tensor<3x?x?xf32>
+  %r = arith.cmpi eq, %d1, %d2 : index
+  return %r: i1
+}

--- a/tests/litmus/func-ops/fn_arg_dims_multiple.tgt.mlir
+++ b/tests/litmus/func-ops/fn_arg_dims_multiple.tgt.mlir
@@ -1,13 +1,10 @@
 func.func private @dyn_tensor_1(%v1: f32, %v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
 func.func private @dyn_tensor_2(%v1: f32, %v2: f32, %v3: f32, %v4: f32, %v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
 
-func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> index {
   %f0 = arith.constant 1.0: f32
-  %t1 = func.call @dyn_tensor_1(%f0, %v): (f32, tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
   %t2 = func.call @dyn_tensor_2(%f0, %f0, %f0, %f0, %v): (f32, f32, f32, f32, tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
   %c0 = arith.constant 1: index
-  %d1 = tensor.dim %t1, %c0: tensor<3x?x?xf32>
-  %d2 = tensor.dim %t2, %c0: tensor<3x?x?xf32>
-  %r = arith.cmpi eq, %d1, %d2 : index
-  return %r: i1
+  %r = tensor.dim %t2, %c0: tensor<3x?x?xf32>
+  return %r: index
 }

--- a/tests/litmus/func-ops/no_fn_arg_dims-bad.src.mlir
+++ b/tests/litmus/func-ops/no_fn_arg_dims-bad.src.mlir
@@ -1,0 +1,12 @@
+// VERIFY-INCORRECT
+
+func.func private @dyn_tensor_1(%v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+  %t = func.call @dyn_tensor_1(%v): (tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+  %c0 = arith.constant 0: index
+  %d1 = tensor.dim %v, %c0: tensor<3x?x?xf32>
+  %d2 = tensor.dim %t, %c0: tensor<3x?x?xf32>
+  %r = arith.cmpi eq, %d1, %d2 : index
+  return %r: i1
+}

--- a/tests/litmus/func-ops/no_fn_arg_dims-bad.src.mlir
+++ b/tests/litmus/func-ops/no_fn_arg_dims-bad.src.mlir
@@ -2,11 +2,9 @@
 
 func.func private @dyn_tensor_1(%v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
 
-func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> index {
   %t = func.call @dyn_tensor_1(%v): (tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
-  %c0 = arith.constant 0: index
-  %d1 = tensor.dim %v, %c0: tensor<3x?x?xf32>
-  %d2 = tensor.dim %t, %c0: tensor<3x?x?xf32>
-  %r = arith.cmpi eq, %d1, %d2 : index
-  return %r: i1
+  %c = arith.constant 1: index
+  %r = tensor.dim %v, %c: tensor<3x?x?xf32>
+  return %r: index
 }

--- a/tests/litmus/func-ops/no_fn_arg_dims-bad.tgt.mlir
+++ b/tests/litmus/func-ops/no_fn_arg_dims-bad.tgt.mlir
@@ -1,10 +1,8 @@
 func.func private @dyn_tensor_1(%v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
 
-func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> index {
   %t = func.call @dyn_tensor_1(%v): (tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
-  %c0 = arith.constant 1: index
-  %d1 = tensor.dim %v, %c0: tensor<3x?x?xf32>
-  %d2 = tensor.dim %t, %c0: tensor<3x?x?xf32>
-  %r = arith.cmpi eq, %d1, %d2 : index
-  return %r: i1
+  %c = arith.constant 1: index
+  %r = tensor.dim %t, %c: tensor<3x?x?xf32>
+  return %r: index
 }

--- a/tests/litmus/func-ops/no_fn_arg_dims-bad.tgt.mlir
+++ b/tests/litmus/func-ops/no_fn_arg_dims-bad.tgt.mlir
@@ -1,0 +1,10 @@
+func.func private @dyn_tensor_1(%v: tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+
+func.func @tensor_dim(%v: tensor<3x?x?xf32>) -> i1 {
+  %t = func.call @dyn_tensor_1(%v): (tensor<3x?x?xf32>) -> tensor<3x?x?xf32>
+  %c0 = arith.constant 1: index
+  %d1 = tensor.dim %v, %c0: tensor<3x?x?xf32>
+  %d2 = tensor.dim %t, %c0: tensor<3x?x?xf32>
+  %r = arith.cmpi eq, %d1, %d2 : index
+  return %r: i1
+}


### PR DESCRIPTION
This PR adds a command-line option `--use-fn-argument-dims`. This option can be used to make an assumption on the shape of the dynamic tensor from a function call.

This option can be used as the following:
* `--use-fn-argument-dims=simpl_fn@0` (the output tensor from `simpl_fn` is assumed to have the same shape as the first argument)
* `--use-fn-argument-dims=fn1@2,fn2@4` (the output tensor from `fn1` is assumed to have the same shape as its third argument, and for `fn2` its fifth argument)

When using this option, UnsupportedException may be thrown under the following circumstances:
* The index used to specify the argument is invalid
* The specified argument or the output type is not shaped
* The output type is unranked or its rank does not match the specified argument
* The shape of the specified argument and the output type does not match
  * Only one of the dimensions on the same rank are dynamic
  * Both dimensions on the same rank are static, but they are not equal

The added tests verify and present its functionalities.