### PR TITLE
Encoding for integer shift operations

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -773,7 +773,8 @@ void encodeOp(State &st, mlir::arith::ExtUIOp op, bool) {
       [extamnt](Integer &&a) { return ((Expr)a).zext(extamnt); });
 }
 
-template <> void encodeOp(State &st, mlir::arith::ShLIOp op, bool) {
+template <>
+void encodeOp(State &st, mlir::arith::ShLIOp op, bool) {
   auto arg = op.getOperand(0);
   const auto src_bw = arg.getType().getIntOrFloatBitWidth();
   auto shlamnt = op.getOperand(1);
@@ -786,7 +787,8 @@ template <> void encodeOp(State &st, mlir::arith::ShLIOp op, bool) {
                  });
 }
 
-template <> void encodeOp(State &st, mlir::arith::ShRSIOp op, bool) {
+template <>
+void encodeOp(State &st, mlir::arith::ShRSIOp op, bool) {
   auto arg = op.getOperand(0);
   const auto src_bw = arg.getType().getIntOrFloatBitWidth();
   auto shlamnt = op.getOperand(1);
@@ -799,7 +801,8 @@ template <> void encodeOp(State &st, mlir::arith::ShRSIOp op, bool) {
                  });
 }
 
-template <> void encodeOp(State &st, mlir::arith::ShRUIOp op, bool) {
+template <>
+void encodeOp(State &st, mlir::arith::ShRUIOp op, bool) {
   auto arg = op.getOperand(0);
   const auto src_bw = arg.getType().getIntOrFloatBitWidth();
   auto shlamnt = op.getOperand(1);

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -773,41 +773,45 @@ void encodeOp(State &st, mlir::arith::ExtUIOp op, bool) {
       [extamnt](Integer &&a) { return ((Expr)a).zext(extamnt); });
 }
 
-template <>
-void encodeOp(State &st, mlir::arith::ShLIOp op, bool) {
+template <> void encodeOp(State &st, mlir::arith::ShLIOp op, bool) {
   auto arg = op.getOperand(0);
   const auto src_bw = arg.getType().getIntOrFloatBitWidth();
   auto shlamnt = op.getOperand(1);
 
   encodeBinaryOp(st, op, move(arg), move(shlamnt), {},
-                 [src_bw](Integer &&a, Integer &&amnt) {
+                 [&st, &op, src_bw](Integer &&a, Integer &&amnt) {
+                   st.wellDefined(op, static_cast<Expr>(amnt).ult(
+                                          Integer(src_bw, src_bw)));
                    return static_cast<Expr>(a).shl(amnt);
                  });
 }
 
-template<>
-void encodeOp(State &st, mlir::arith::ShRSIOp op, bool) {
+template <> void encodeOp(State &st, mlir::arith::ShRSIOp op, bool) {
   auto arg = op.getOperand(0);
   const auto src_bw = arg.getType().getIntOrFloatBitWidth();
   auto shlamnt = op.getOperand(1);
 
   encodeBinaryOp(st, op, move(arg), move(shlamnt), {},
-                 [src_bw](Integer &&a, Integer &&amnt) {
+                 [&st, &op, src_bw](Integer &&a, Integer &&amnt) {
+                   st.wellDefined(op, static_cast<Expr>(amnt).ult(
+                                          Integer(src_bw, src_bw)));
                    return static_cast<Expr>(a).ashr(amnt);
                  });
 }
 
-template<>
-void encodeOp(State &st, mlir::arith::ShRUIOp op, bool) {
+template <> void encodeOp(State &st, mlir::arith::ShRUIOp op, bool) {
   auto arg = op.getOperand(0);
   const auto src_bw = arg.getType().getIntOrFloatBitWidth();
   auto shlamnt = op.getOperand(1);
 
   encodeBinaryOp(st, op, move(arg), move(shlamnt), {},
-                 [src_bw](Integer &&a, Integer &&amnt) {
+                 [&st, &op, src_bw](Integer &&a, Integer &&amnt) {
+                   st.wellDefined(op, static_cast<Expr>(amnt).ult(
+                                          Integer(src_bw, src_bw)));
                    return static_cast<Expr>(a).lshr(amnt);
                  });
 }
+
 template<>
 void encodeOp(State &st, mlir::arith::TruncFOp op, bool) {
   auto op_type = op.getType();

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -773,6 +773,41 @@ void encodeOp(State &st, mlir::arith::ExtUIOp op, bool) {
       [extamnt](Integer &&a) { return ((Expr)a).zext(extamnt); });
 }
 
+template <>
+void encodeOp(State &st, mlir::arith::ShLIOp op, bool) {
+  auto arg = op.getOperand(0);
+  const auto src_bw = arg.getType().getIntOrFloatBitWidth();
+  auto shlamnt = op.getOperand(1);
+
+  encodeBinaryOp(st, op, move(arg), move(shlamnt), {},
+                 [src_bw](Integer &&a, Integer &&amnt) {
+                   return static_cast<Expr>(a).shl(amnt);
+                 });
+}
+
+template<>
+void encodeOp(State &st, mlir::arith::ShRSIOp op, bool) {
+  auto arg = op.getOperand(0);
+  const auto src_bw = arg.getType().getIntOrFloatBitWidth();
+  auto shlamnt = op.getOperand(1);
+
+  encodeBinaryOp(st, op, move(arg), move(shlamnt), {},
+                 [src_bw](Integer &&a, Integer &&amnt) {
+                   return static_cast<Expr>(a).ashr(amnt);
+                 });
+}
+
+template<>
+void encodeOp(State &st, mlir::arith::ShRUIOp op, bool) {
+  auto arg = op.getOperand(0);
+  const auto src_bw = arg.getType().getIntOrFloatBitWidth();
+  auto shlamnt = op.getOperand(1);
+
+  encodeBinaryOp(st, op, move(arg), move(shlamnt), {},
+                 [src_bw](Integer &&a, Integer &&amnt) {
+                   return static_cast<Expr>(a).lshr(amnt);
+                 });
+}
 template<>
 void encodeOp(State &st, mlir::arith::TruncFOp op, bool) {
   auto op_type = op.getType();
@@ -3536,6 +3571,9 @@ static void encodeBlock(
     ENCODE(st, op, mlir::arith::MulFOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::arith::MulIOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::arith::NegFOp, encodeMemWriteOps);
+    ENCODE(st, op, mlir::arith::ShLIOp, encodeMemWriteOps);
+    ENCODE(st, op, mlir::arith::ShRSIOp, encodeMemWriteOps);
+    ENCODE(st, op, mlir::arith::ShRUIOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::arith::SIToFPOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::arith::SubFOp, encodeMemWriteOps);
     ENCODE(st, op, mlir::arith::SubIOp, encodeMemWriteOps);

--- a/tests/litmus/arith-ops/shift.src.mlir
+++ b/tests/litmus/arith-ops/shift.src.mlir
@@ -1,0 +1,41 @@
+// VERIFY
+
+func.func @shift_left_i32(%v: i32) -> i32 {
+  %amnt = arith.constant 4: i32
+  %x = arith.shli %v, %amnt: i32
+  return %x: i32
+}
+
+func.func @shift_left_i64(%v: i64) -> i64 {
+  %amnt = arith.constant 33: i64
+  %x = arith.shli %v, %amnt: i64
+  return %x: i64
+}
+
+func.func @shift_right_signed_i32() -> i32 {
+  %v = arith.constant 0xabcd1234: i32
+  %amnt = arith.constant 4: i32
+  %x = arith.shrsi %v, %amnt: i32
+  return %x: i32
+}
+
+func.func @shift_right_signed_i64() -> i64 {
+  %v = arith.constant 0xabcd123456781111: i64
+  %amnt = arith.constant 36: i64
+  %x = arith.shrsi %v, %amnt: i64
+  return %x: i64
+}
+
+func.func @shift_right_unsigned_i32() -> i32 {
+  %v = arith.constant 0xabcd1234: i32
+  %amnt = arith.constant 4: i32
+  %x = arith.shrui %v, %amnt: i32
+  return %x: i32
+}
+
+func.func @shift_right_unsigned_i64() -> i64 {
+  %v = arith.constant 0xabcd123456781111: i64
+  %amnt = arith.constant 36: i64
+  %x = arith.shrui %v, %amnt: i64
+  return %x: i64
+}

--- a/tests/litmus/arith-ops/shift.src.mlir
+++ b/tests/litmus/arith-ops/shift.src.mlir
@@ -12,6 +12,18 @@ func.func @shift_left_i64(%v: i64) -> i64 {
   return %x: i64
 }
 
+func.func @shift_left_index(%v: index) -> index {
+  %amnt = arith.constant 4: index
+  %x = arith.shli %v, %amnt: index
+  return %x: index
+}
+
+func.func @shift_left_tensor(%t: tensor<5xi32>) -> tensor<5xi32> {
+  %amnt = arith.constant dense<4> : tensor<5xi32>
+  %x = arith.shli %t, %amnt: tensor<5xi32>
+  return %x: tensor<5xi32>
+}
+
 func.func @shift_right_signed_i32() -> i32 {
   %v = arith.constant 0xabcd1234: i32
   %amnt = arith.constant 4: i32

--- a/tests/litmus/arith-ops/shift.tgt.mlir
+++ b/tests/litmus/arith-ops/shift.tgt.mlir
@@ -10,6 +10,18 @@ func.func @shift_left_i64(%v: i64) -> i64 {
   return %x: i64
 }
 
+func.func @shift_left_index(%v: index) -> index {
+  %amnt = arith.constant 16: index
+  %x = arith.muli %v, %amnt: index
+  return %x: index
+}
+
+func.func @shift_left_tensor(%t: tensor<5xi32>) -> tensor<5xi32> {
+  %amnt = arith.constant dense<16> : tensor<5xi32>
+  %x = arith.muli %t, %amnt: tensor<5xi32>
+  return %x: tensor<5xi32>
+}
+
 func.func @shift_right_signed_i32() -> i32 {
   %x = arith.constant 0xfabcd123: i32
   return %x: i32

--- a/tests/litmus/arith-ops/shift.tgt.mlir
+++ b/tests/litmus/arith-ops/shift.tgt.mlir
@@ -1,5 +1,3 @@
-// VERIFY
-
 func.func @shift_left_i32(%v: i32) -> i32 {
   %amnt = arith.constant 16: i32
   %x = arith.muli %v, %amnt: i32

--- a/tests/litmus/arith-ops/shift.tgt.mlir
+++ b/tests/litmus/arith-ops/shift.tgt.mlir
@@ -1,0 +1,33 @@
+// VERIFY
+
+func.func @shift_left_i32(%v: i32) -> i32 {
+  %amnt = arith.constant 16: i32
+  %x = arith.muli %v, %amnt: i32
+  return %x: i32
+}
+
+func.func @shift_left_i64(%v: i64) -> i64 {
+  %amnt = arith.constant 8589934592: i64
+  %x = arith.muli %v, %amnt: i64
+  return %x: i64
+}
+
+func.func @shift_right_signed_i32() -> i32 {
+  %x = arith.constant 0xfabcd123: i32
+  return %x: i32
+}
+
+func.func @shift_right_signed_i64() -> i64 {
+  %x = arith.constant 0xfffffffffabcd123: i64
+  return %x: i64
+}
+
+func.func @shift_right_unsigned_i32() -> i32 {
+  %x = arith.constant 0x0abcd123: i32
+  return %x: i32
+}
+
+func.func @shift_right_unsigned_i64() -> i64 {
+  %x = arith.constant 0x000000000abcd123: i64
+  return %x: i64
+}

--- a/tests/litmus/arith-ops/shli_index_ub.src.mlir
+++ b/tests/litmus/arith-ops/shli_index_ub.src.mlir
@@ -1,0 +1,7 @@
+// EXPECT: "correct (source is always undefined)"
+
+func.func @shift_left_index_ub(%v: index) -> index {
+  %amnt = arith.constant 32: index
+  %x = arith.shli %v, %amnt: index
+  return %x: index
+}

--- a/tests/litmus/arith-ops/shli_index_ub.tgt.mlir
+++ b/tests/litmus/arith-ops/shli_index_ub.tgt.mlir
@@ -1,0 +1,4 @@
+func.func @shift_left_index_ub(%v: index) -> index {
+  %x = arith.constant 0xf0f0f0f0: index
+  return %x: index
+}

--- a/tests/litmus/arith-ops/shli_tensor_ub.src.mlir
+++ b/tests/litmus/arith-ops/shli_tensor_ub.src.mlir
@@ -1,0 +1,7 @@
+// EXPECT: "correct (source is always undefined)"
+
+func.func @shift_left_tensor_ub(%t: tensor<5xi32>) -> tensor<5xi32> {
+  %amnt = arith.constant dense<32> : tensor<5xi32>
+  %x = arith.shli %t, %amnt: tensor<5xi32>
+  return %x: tensor<5xi32>
+}

--- a/tests/litmus/arith-ops/shli_tensor_ub.tgt.mlir
+++ b/tests/litmus/arith-ops/shli_tensor_ub.tgt.mlir
@@ -1,0 +1,5 @@
+func.func @shift_left_tensor_ub(%t: tensor<5xi32>) -> tensor<5xi32> {
+  %amnt = arith.constant dense<0xf0f0f0f0> : tensor<5xi32>
+  %x = arith.shli %t, %amnt: tensor<5xi32>
+  return %x: tensor<5xi32>
+}

--- a/tests/litmus/arith-ops/shli_ub.src.mlir
+++ b/tests/litmus/arith-ops/shli_ub.src.mlir
@@ -1,0 +1,7 @@
+// EXPECT: "correct (source is always undefined)"
+
+func.func @shift_left_ub(%v: i32) -> i32 {
+  %amnt = arith.constant 32: i32
+  %x = arith.shli %v, %amnt: i32
+  return %x: i32
+}

--- a/tests/litmus/arith-ops/shli_ub.tgt.mlir
+++ b/tests/litmus/arith-ops/shli_ub.tgt.mlir
@@ -1,4 +1,4 @@
 func.func @shift_left_ub(%v: i32) -> i32 {
-  %x = arith.constant 0xffffffff: i32
+  %x = arith.constant 0xf0f0f0f0: i32
   return %x: i32
 }

--- a/tests/litmus/arith-ops/shli_ub.tgt.mlir
+++ b/tests/litmus/arith-ops/shli_ub.tgt.mlir
@@ -1,0 +1,4 @@
+func.func @shift_left_ub(%v: i32) -> i32 {
+  %x = arith.constant 0xffffffff: i32
+  return %x: i32
+}

--- a/tests/litmus/arith-ops/shrsi_ub.src.mlir
+++ b/tests/litmus/arith-ops/shrsi_ub.src.mlir
@@ -1,0 +1,7 @@
+// EXPECT: "correct (source is always undefined)"
+
+func.func @shift_right_signed_ub(%v: i32) -> i32 {
+  %amnt = arith.constant 32: i32
+  %x = arith.shrsi %v, %amnt: i32
+  return %x: i32
+}

--- a/tests/litmus/arith-ops/shrsi_ub.tgt.mlir
+++ b/tests/litmus/arith-ops/shrsi_ub.tgt.mlir
@@ -1,0 +1,4 @@
+func.func @shift_right_signed_ub(%v: i32) -> i32 {
+  %x = arith.constant 0xf0f0f0f0: i32
+  return %x: i32
+}

--- a/tests/litmus/arith-ops/shrui_ub.src.mlir
+++ b/tests/litmus/arith-ops/shrui_ub.src.mlir
@@ -1,0 +1,7 @@
+// EXPECT: "correct (source is always undefined)"
+
+func.func @shift_right_unsigned_ub(%v: i32) -> i32 {
+  %amnt = arith.constant 32: i32
+  %x = arith.shrui %v, %amnt: i32
+  return %x: i32
+}

--- a/tests/litmus/arith-ops/shrui_ub.tgt.mlir
+++ b/tests/litmus/arith-ops/shrui_ub.tgt.mlir
@@ -1,0 +1,4 @@
+func.func @shift_right_unsigned_ub(%v: i32) -> i32 {
+  %x = arith.constant 0xf0f0f0f0: i32
+  return %x: i32
+}


### PR DESCRIPTION
This PR implements encoding for integer shift operations(`arith.shli`, `arith.shrsi`, `arith.shrui`)
* `arith.shli` shifts an integer to the left by a given amount, and fills the 'low-order bits' with 0. `arith.shli %i, %amnt` is equivalent to `arith.mul %i, (math.ipowi 2, %amnt)`
* `arith.shrsi` shifts an integer to the right by a given amount, and fills the 'high-order bits' with the MSB. `arith.shrsi %i, %amnt` is equivalent to `arith.divsi %i, (math.ipowi 2, %amnt)`
* `arith.shrui` shifts an integer to the right by a given amount, and fills the 'high-order bits' with 0. `arith.shrui %i, %amnt` is equivalent to `arith.divui %i, (math.ipowi 2, %amnt)`

If the shift amount is greater than or equal to the integer's bitwidth, it *seems to be* UB. We don't have any official documentation to back up this claim though. I'll undraft this PR once I have a stronger evidence.