### PR TITLE
Encoding for extension and truncation of tensors

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -79,7 +79,7 @@ namespace {
     const auto amnt = op->getOperand(1);
     const auto amntTy = amnt.getType();
     smart_assert(argTy == amntTy,
-                    "Shift argument and amount types must be the same!");
+                 "Shift argument and amount types must be the same!");
 
     if (amntTy.isa<mlir::TensorType>()) {
       const auto amntTensor = st.regs.get<Tensor>(amnt);

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -822,7 +822,7 @@ Tensor Tensor::elementwiseBinOp(
 
 Tensor Tensor::elementwiseUnaryOp(
     mlir::Type resultElemType, const function<Expr(Expr &&)> &f) const {
-  auto idxvar = Index::var("idx_binop", VarType::BOUND);
+  auto idxvar = Index::var("idx_uop", VarType::BOUND);
   Expr elemout = f(getRaw(idxvar));
 
   // UB if uninitialized elem is used

--- a/tests/litmus/arith-ops/extsi.src.mlir
+++ b/tests/litmus/arith-ops/extsi.src.mlir
@@ -17,3 +17,15 @@ func.func @neg_i32_to_i64() -> i64 {
   %x = arith.extsi %c: i32 to i64
   return %x: i64
 }
+
+func.func @tensor_i32_to_i64() -> tensor<5xi64> {
+  %c = arith.constant dense<2147483647> : tensor<5xi32>
+  %x = arith.extsi %c: tensor<5xi32> to tensor<5xi64>
+  return %x: tensor<5xi64>
+}
+
+func.func @tensor_neg_i32_to_i64() -> tensor<5xi64> {
+  %c = arith.constant dense<2147483648> : tensor<5xi32>
+  %x = arith.extsi %c: tensor<5xi32> to tensor<5xi64>
+  return %x: tensor<5xi64>
+}

--- a/tests/litmus/arith-ops/extsi.tgt.mlir
+++ b/tests/litmus/arith-ops/extsi.tgt.mlir
@@ -12,3 +12,13 @@ func.func @neg_i32_to_i64() -> i64 {
   %c = arith.constant 0xffffffff80000000: i64
   return %c: i64
 }
+
+func.func @tensor_i32_to_i64() -> tensor<5xi64> {
+  %x = arith.constant dense<2147483647> : tensor<5xi64>
+  return %x: tensor<5xi64>
+}
+
+func.func @tensor_neg_i32_to_i64() -> tensor<5xi64> {
+  %x = arith.constant dense<0xffffffff80000000> : tensor<5xi64>
+  return %x: tensor<5xi64>
+}

--- a/tests/litmus/arith-ops/extui.src.mlir
+++ b/tests/litmus/arith-ops/extui.src.mlir
@@ -17,3 +17,15 @@ func.func @neg_i32_to_i64() -> i64 {
   %x = arith.extui %c: i32 to i64
   return %x: i64
 }
+
+func.func @tensor_i32_to_i64() -> tensor<5xi64> {
+  %c = arith.constant dense<2147483647> : tensor<5xi32>
+  %x = arith.extui %c: tensor<5xi32> to tensor<5xi64>
+  return %x: tensor<5xi64>
+}
+
+func.func @tensor_neg_i32_to_i64() -> tensor<5xi64> {
+  %c = arith.constant dense<2147483648> : tensor<5xi32>
+  %x = arith.extui %c: tensor<5xi32> to tensor<5xi64>
+  return %x: tensor<5xi64>
+}

--- a/tests/litmus/arith-ops/extui.tgt.mlir
+++ b/tests/litmus/arith-ops/extui.tgt.mlir
@@ -12,3 +12,13 @@ func.func @neg_i32_to_i64() -> i64 {
   %c = arith.constant 0x0000000080000000: i64
   return %c: i64
 }
+
+func.func @tensor_i32_to_i64() -> tensor<5xi64> {
+  %x = arith.constant dense<2147483647> : tensor<5xi64>
+  return %x: tensor<5xi64>
+}
+
+func.func @tensor_neg_i32_to_i64() -> tensor<5xi64> {
+  %x = arith.constant dense<0x0000000080000000> : tensor<5xi64>
+  return %x: tensor<5xi64>
+}

--- a/tests/litmus/fp-ops/ext_const.src.mlir
+++ b/tests/litmus/fp-ops/ext_const.src.mlir
@@ -8,3 +8,9 @@ func.func @f() -> f64 {
   %s = arith.addf %e, %ne : f64
   return %s: f64
 }
+
+func.func @tensor() -> tensor<5xf64> {
+  %c = arith.constant dense<5.0> : tensor<5xf32>
+  %x = arith.extf %c: tensor<5xf32> to tensor<5xf64>
+  return %x: tensor<5xf64>
+}

--- a/tests/litmus/fp-ops/ext_const.tgt.mlir
+++ b/tests/litmus/fp-ops/ext_const.tgt.mlir
@@ -2,3 +2,8 @@ func.func @f() -> f64 {
   %a = arith.constant 0.0 : f64
   return %a: f64
 }
+
+func.func @tensor() -> tensor<5xf64> {
+  %x = arith.constant dense<5.0> : tensor<5xf64>
+  return %x: tensor<5xf64>
+}

--- a/tests/litmus/fp-ops/trunc_const.src.mlir
+++ b/tests/litmus/fp-ops/trunc_const.src.mlir
@@ -8,3 +8,9 @@ func.func @f() -> f32 {
   %s = arith.addf %t, %nt : f32
   return %s: f32
 }
+
+func.func @tensor() -> tensor<5xf32> {
+  %c = arith.constant dense<5.0> : tensor<5xf64>
+  %x = arith.truncf %c: tensor<5xf64> to tensor<5xf32>
+  return %x: tensor<5xf32>
+}

--- a/tests/litmus/fp-ops/trunc_const.tgt.mlir
+++ b/tests/litmus/fp-ops/trunc_const.tgt.mlir
@@ -2,3 +2,8 @@ func.func @f() -> f32 {
   %a = arith.constant 0.0 : f32
   return %a: f32
 }
+
+func.func @tensor() -> tensor<5xf32> {
+  %x = arith.constant dense<5.0> : tensor<5xf32>
+  return %x: tensor<5xf32>
+}


### PR DESCRIPTION
This PR extends the encoding for extension(`arith.extf`, `arith.extsi`, `arith.extui`) and truncation(`arith.truncf`, `arith.trunci`) to support programs that use these operations with tensor operands.

When using these operations with tensor operands, they are expected to yield a tensor of the same dimensions, with extension/truncation applied elementwise.
More tests are added to test and verify the behavior.