### PR TITLE
Upgrade mlir

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -19,9 +19,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: strikef/mlir-tv-ci-base:latest
-      credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     
     steps:
       - name: Fetch mlir-tv cache
@@ -31,7 +28,7 @@ jobs:
           path: |
             /src/mlir-tv
             !/src/mlir-tv/build/Testing
-          key: cache-${{ secrets.CACHE_VERSION }}-${{ github.sha }}
+          key: cache-${{ github.sha }}
 
       # if cache miss
       - name: Create /src if not exists
@@ -63,9 +60,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: strikef/mlir-tv-ci-base:latest
-      credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
     steps:
       - name: Checkout this repo
@@ -87,9 +81,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: strikef/mlir-tv-ci-base:latest
-      credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     
     steps:
       - name: Checkout this repo
@@ -110,9 +101,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: strikef/mlir-tv-ci-base:latest
-      credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     
     steps:
       - name: Checkout this repo
@@ -134,9 +122,6 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: strikef/mlir-tv-ci-base:latest
-      credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
     steps:
       - name: Fetch mlir-tv cache
@@ -145,7 +130,7 @@ jobs:
           path: |
             /src/mlir-tv
             !/src/mlir-tv/build/Testing
-          key: cache-${{ secrets.CACHE_VERSION }}-${{ github.sha }}
+          key: cache-${{ github.sha }}
       
       - name: Run ctest
         run: |
@@ -165,9 +150,6 @@ jobs:
     needs: build
     container:
       image: strikef/mlir-tv-ci-base:latest
-      credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     
     steps:
       - name: Fetch mlir-tv cache
@@ -176,7 +158,7 @@ jobs:
           path: |
             /src/mlir-tv
             !/src/mlir-tv/build/Testing
-          key: cache-${{ secrets.CACHE_VERSION }}-${{ github.sha }}
+          key: cache-${{ github.sha }}
       
       - name: Run ctest
         run: |

--- a/src/abstractops.h
+++ b/src/abstractops.h
@@ -2,7 +2,7 @@
 
 #include "smt.h"
 #include "llvm/ADT/APFloat.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinOps.h"
 #include <vector>
 #include <set>

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -226,7 +226,7 @@ bool analyzeOp(mlir::memref::GetGlobalOp op, AnalysisResult &res) {
   res.memref.usedGlobals[glbName.str()] = glb;
 
   if (glb.getConstant() && glb.getInitialValue()) {
-    analyzeElemAttr(*glb.getInitialValue(), res);
+    analyzeElemAttr(glb.getInitialValue()->cast<mlir::ElementsAttr>(), res);
   }
   return true;
 }

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -220,13 +220,13 @@ void analyzeRegion(mlir::Region &region, AnalysisResult &res) {
 
 template<>
 bool analyzeOp(mlir::memref::GetGlobalOp op, AnalysisResult &res) {
-  llvm::StringRef glbName = op.name();
+  llvm::StringRef glbName = op.getName();
   auto mop = op.getOperation()->getParentOfType<mlir::ModuleOp>();
   auto glb = mlir::cast<mlir::memref::GlobalOp>(mop.lookupSymbol(glbName));
   res.memref.usedGlobals[glbName.str()] = glb;
 
-  if (glb.constant() && glb.initial_value()) {
-    analyzeElemAttr(*glb.initial_value(), res);
+  if (glb.getConstant() && glb.getInitialValue()) {
+    analyzeElemAttr(*glb.getInitialValue(), res);
   }
   return true;
 }
@@ -282,13 +282,13 @@ bool analyzeOp(mlir::tosa::ClampOp op, AnalysisResult &res) {
 template<>
 bool analyzeOp(mlir::linalg::GenericOp op, AnalysisResult &res) {
   // If generic loop has reduction loops, then result is not elementwise
-  auto indexingMaps = op.indexing_maps().getValue();
+  auto indexingMaps = op.getIndexingMaps().getValue();
   auto outputMap = indexingMaps.back().cast<mlir::AffineMapAttr>().getValue();
   bool isReudctionLoop = !outputMap.isPermutation();
   if (isReudctionLoop)
     res.isElementwiseFPOps = false;
 
-  analyzeRegion(op.region(), res);
+  analyzeRegion(op.getRegion(), res);
   return true;
 }
 
@@ -338,7 +338,7 @@ void analyzeBlock(
     // and newly created FPs can be stored to output memref.
     if (auto op2 = mlir::dyn_cast<mlir::linalg::GenericOp>(op)) {
       if (op2.hasBufferSemantics()) {
-        for (const auto &operand: op2.outputs()) {
+        for (const auto &operand: op2.getOutputs()) {
           analyzeVariable(operand, res, VarAnalysisConfig::operand());
         }
       }

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1589,6 +1589,8 @@ void encodeOp(State &st, mlir::tosa::AvgPool2dOp op, bool) {
           "Zero-padded pooling is supported only.");
   }
 
+  // TODO: The current modeling ignores the acc_type attribute.
+
   auto result = input.avgPool(kernelDims, strides);
   st.regs.add(op.getResult(), move(result));
   st.wellDefined(op, input.isFullyInitialized(), "source tensor initialized");

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -8,7 +8,7 @@
 
 #include "llvm/Support/ErrorHandling.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]) {
   // NOTE: we cannot use mlir::registerAllDialects because IREE does not have
   // dependency on some of those dialects
   registry.insert<AffineDialect>();
-  registry.insert<arith::ArithmeticDialect>();
+  registry.insert<arith::ArithDialect>();
   registry.insert<bufferization::BufferizationDialect>();
   registry.insert<func::FuncDialect>();
   registry.insert<linalg::LinalgDialect>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,7 @@ int main(int argc, char* argv[]) {
   DialectRegistry registry;
   // NOTE: we cannot use mlir::registerAllDialects because IREE does not have
   // dependency on some of those dialects
-  registry.insert<AffineDialect>();
+  registry.insert<affine::AffineDialect>();
   registry.insert<arith::ArithDialect>();
   registry.insert<bufferization::BufferizationDialect>();
   registry.insert<func::FuncDialect>();

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -148,7 +148,8 @@ Memory::Memory(const TypeMap<size_t> &numGlobalBlocksPerType,
       if (glb.getConstant()) {
         auto tensorTy = mlir::RankedTensorType::get(glb.getType().getShape(),
             glb.getType().getElementType());
-        Tensor t = Tensor::fromElemsAttr(tensorTy, *glb.getInitialValue());
+        Tensor t = Tensor::fromElemsAttr(
+            tensorTy, glb.getInitialValue()->cast<mlir::ElementsAttr>());
         newArrs.push_back(t.asArray());
       } else {
         string name = "#" + glb.getName().str() + "_array";

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -125,7 +125,7 @@ Memory::Memory(const TypeMap<size_t> &numGlobalBlocksPerType,
     vector<mlir::memref::GlobalOp> globalsForTy;
 
     for (auto glb: globals) {
-      if (glb.type().getElementType() == elemTy)
+      if (glb.getType().getElementType() == elemTy)
         globalsForTy.push_back(glb);
     }
 
@@ -145,18 +145,18 @@ Memory::Memory(const TypeMap<size_t> &numGlobalBlocksPerType,
       verbose("memory init") << "Assigning bid = " << i << " to global var "
           << glb.getName() << "...\n";
 
-      if (glb.constant()) {
-        auto tensorTy = mlir::RankedTensorType::get(glb.type().getShape(),
-            glb.type().getElementType());
-        Tensor t = Tensor::fromElemsAttr(tensorTy, *glb.initial_value());
+      if (glb.getConstant()) {
+        auto tensorTy = mlir::RankedTensorType::get(glb.getType().getShape(),
+            glb.getType().getElementType());
+        Tensor t = Tensor::fromElemsAttr(tensorTy, *glb.getInitialValue());
         newArrs.push_back(t.asArray());
       } else {
         string name = "#" + glb.getName().str() + "_array";
         newArrs.push_back(Expr::mkFreshVar(arrSort, name));
       }
       newInits.push_back(Expr::mkSplatArray(Index::sort(), Expr::mkBool(true)));
-      newWrit.push_back(Expr::mkBool(!glb.constant()));
-      newNumElems.push_back(Index(glb.type().getNumElements()));
+      newWrit.push_back(Expr::mkBool(!glb.getConstant()));
+      newNumElems.push_back(Index(glb.getType().getNumElements()));
       newLiveness.push_back(Expr::mkBool(true));
       newCreatedByAllocs.push_back(Expr::mkBool(false));
     }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -77,8 +77,8 @@ vector<Expr> ShapedValue::getDims(
   dims.reserve(rank);
   unsigned unknownVarIdx = 0;
   for (unsigned i = 0; i < rank; ++i) {
-    uint64_t sz = shapedTy.getDimSize(i);
-    if (sz == (uint64_t)-1ull) {
+    int64_t sz = shapedTy.getDimSize(i);
+    if (sz == mlir::ShapedType::kDynamic) {
       if (freshVarForUnknownSize) {
         dims.emplace_back(Index::var("dim", VarType::FRESH));
       } else if (valsForUnknownSz) {
@@ -87,8 +87,10 @@ vector<Expr> ShapedValue::getDims(
         llvm_unreachable("Don't know what to do with a dimension of "
                          "an unknown size");
       }
-    } else
-      dims.push_back(Index(sz));
+    } else {
+      assert(sz >= 0);
+      dims.push_back(Index((uint64_t)sz));
+    }
   }
 
   return dims;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -1336,7 +1336,7 @@ Tensor Tensor::fromElemsAttr(mlir::RankedTensorType tensorty,
       int64_t totalSize = 1;
       for (int i = 0; i < rank; ++i) {
         auto dsize = tensorty.getDimSize(i);
-        assert(dsize != mlir::ShapedType::kDynamicSize);
+        assert(dsize != mlir::ShapedType::kDynamic);
         dims.push_back(dsize);
         dimExprs.push_back(Index(dsize));
         totalSize *= dsize;
@@ -1588,7 +1588,7 @@ MemRef::Layout MemRef::getLayout(
     return MemRef::Layout(dims);
 
   auto getConstOrFreshVar = [](int64_t val, string &&name) -> Expr {
-    return (val == mlir::ShapedType::kDynamicStrideOrOffset) ?
+    return (val == mlir::ShapedType::kDynamic) ?
         Index::var(move(name), VarType::FRESH) : Index(val);
   };
 

--- a/src/vcgen.cpp
+++ b/src/vcgen.cpp
@@ -713,15 +713,15 @@ static vector<mlir::memref::GlobalOp> mergeGlobals(
     }
 
     auto glbTgt = tgtItr->second;
-    if (glbSrc.type() != glbTgt.type() ||
+    if (glbSrc.getType() != glbTgt.getType() ||
         glbSrc.isPrivate() != glbTgt.isPrivate() ||
-        glbSrc.constant() != glbTgt.constant() ||
-        glbSrc.initial_value() != glbTgt.initial_value()) {
+        glbSrc.getConstant() != glbTgt.getConstant() ||
+        glbSrc.getInitialValue() != glbTgt.getInitialValue()) {
       throw UnsupportedException(
           name + " has different signatures in src and tgt");
     }
 
-    assert(glbSrc.type().hasStaticShape() &&
+    assert(glbSrc.getType().hasStaticShape() &&
            "Global var must be statically shaped");
 
     mergedGlbs.push_back(glbSrc);
@@ -731,7 +731,7 @@ static vector<mlir::memref::GlobalOp> mergeGlobals(
     auto glbTgt = glbTgt0;
     auto tgtItr = srcGlobals.find(name);
     if (tgtItr == srcGlobals.end()) {
-      if (glbTgt.constant()) {
+      if (glbTgt.getConstant()) {
         mergedGlbs.push_back(glbTgt);
       } else
         throw UnsupportedException("Introducing new non-const globals "

--- a/tests/litmus/abstraction/dot.src.mlir
+++ b/tests/litmus/abstraction/dot.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @f(%a: tensor<?xf32>, %b: tensor<?xf32>) -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %e = linalg.dot ins(%a, %b : tensor<?xf32>,tensor<?xf32>)
     outs(%outty: tensor<f32>) -> tensor<f32>

--- a/tests/litmus/abstraction/dot.tgt.mlir
+++ b/tests/litmus/abstraction/dot.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @f(%a: tensor<?xf32>, %b: tensor<?xf32>) -> tensor<f32> {
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %zero = arith.constant -0.0 : f32
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %result = linalg.generic {

--- a/tests/litmus/abstraction/dot_concat.src.mlir
+++ b/tests/litmus/abstraction/dot_concat.src.mlir
@@ -4,7 +4,7 @@
 // dot (A, B) + dot(C, D) → dot(A::C, B::D)
 func.func @f(%a: tensor<5xf32>, %b: tensor<5xf32>, %c: tensor<5xf32>, %d: tensor<5xf32>) -> f32 {
   %identity = arith.constant -0.0 : f32
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %outty = linalg.fill ins(%identity: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %rt1 = linalg.dot ins(%a, %b : tensor<5xf32>, tensor<5xf32>)
       outs(%outty: tensor<f32>) -> tensor<f32>

--- a/tests/litmus/abstraction/dot_concat.tgt.mlir
+++ b/tests/litmus/abstraction/dot_concat.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f(%a: tensor<5xf32>, %b: tensor<5xf32>, %c: tensor<5xf32>, %d: tensor<5xf32>) -> f32 {
   %identity = arith.constant -0.0 : f32
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %outty = linalg.fill ins(%identity: f32) outs(%i: tensor<f32>) -> tensor<f32>
 
   %ca = "tosa.concat"(%a, %c) {axis = 0: i64}: (tensor<5xf32>, tensor<5xf32>) -> tensor<10xf32>

--- a/tests/litmus/abstraction/dot_concat_multiset.src.mlir
+++ b/tests/litmus/abstraction/dot_concat_multiset.src.mlir
@@ -4,7 +4,7 @@
 // dot (A, B) + dot(C, D) → dot(A::C, B::D)
 func.func @f(%a: tensor<5xf32>, %b: tensor<5xf32>, %c: tensor<5xf32>, %d: tensor<5xf32>) -> f32 {
   %identity = arith.constant -0.0 : f32
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %outty = linalg.fill ins(%identity: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %rt1 = linalg.dot ins(%a, %b : tensor<5xf32>, tensor<5xf32>)
       outs(%outty: tensor<f32>) -> tensor<f32>

--- a/tests/litmus/abstraction/dot_concat_multiset.tgt.mlir
+++ b/tests/litmus/abstraction/dot_concat_multiset.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f(%a: tensor<5xf32>, %b: tensor<5xf32>, %c: tensor<5xf32>, %d: tensor<5xf32>) -> f32 {
   %identity = arith.constant -0.0 : f32
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %outty = linalg.fill ins(%identity: f32) outs(%i: tensor<f32>) -> tensor<f32>
 
   %ca = "tosa.concat"(%a, %c) {axis = 0: i64}: (tensor<5xf32>, tensor<5xf32>) -> tensor<10xf32>

--- a/tests/litmus/abstraction/dotint.src.mlir
+++ b/tests/litmus/abstraction/dotint.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @f(%a: tensor<?xi32>, %b: tensor<?xi32>) -> tensor<i32> {
   %zero = arith.constant 0 : i32
-  %i = linalg.init_tensor []: tensor<i32>
+  %i = tensor.empty (): tensor<i32>
   %outty = linalg.fill ins(%zero: i32) outs(%i: tensor<i32>) -> tensor<i32>
   %e = linalg.dot ins(%a, %b : tensor<?xi32>,tensor<?xi32>)
     outs(%outty: tensor<i32>) -> tensor<i32>

--- a/tests/litmus/abstraction/dotint.tgt.mlir
+++ b/tests/litmus/abstraction/dotint.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @f(%a: tensor<?xi32>, %b: tensor<?xi32>) -> tensor<i32> {
-  %i = linalg.init_tensor [] : tensor<i32>
+  %i = tensor.empty () : tensor<i32>
   %zero = arith.constant 0 : i32
   %outty = linalg.fill ins(%zero: i32) outs(%i: tensor<i32>) -> tensor<i32>
   %result = linalg.generic {

--- a/tests/litmus/linalg-loops/convert-elementwise-cmpf.tgt.mlir
+++ b/tests/litmus/linalg-loops/convert-elementwise-cmpf.tgt.mlir
@@ -1,7 +1,7 @@
 #map = affine_map<() -> ()>
 module  {
   func.func @cmpf(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<i1> {
-    %0 = linalg.init_tensor [] : tensor<i1>
+    %0 = tensor.empty () : tensor<i1>
     %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = []} ins(%arg0, %arg1 : tensor<f32>, tensor<f32>) outs(%0 : tensor<i1>) {
     ^bb0(%arg2: f32, %arg3: f32, %arg4: i1):  // no predecessors
       %2 = arith.cmpf olt, %arg2, %arg3 : f32

--- a/tests/litmus/linalg-loops/nested.src.mlir
+++ b/tests/litmus/linalg-loops/nested.src.mlir
@@ -4,7 +4,7 @@
 func.func @dumb_loop(%arg0: tensor<?xi32>) -> tensor<?xi32> {
   %c0 = arith.constant 0: index
   %sz = tensor.dim %arg0, %c0: tensor<?xi32>
-  %outty = linalg.init_tensor [%sz] : tensor<?xi32>
+  %outty = tensor.empty (%sz) : tensor<?xi32>
 
   %res = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]}
       ins(%arg0: tensor<?xi32>)

--- a/tests/litmus/linalg-loops/output-value-bad.src.mlir
+++ b/tests/litmus/linalg-loops/output-value-bad.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @f(%arg0: tensor<10x10xi32>) -> tensor<10x10xi32> {
   %cst = arith.constant 1 : i32
-  %init_tensor = linalg.init_tensor [10, 10] : tensor<10x10xi32>
+  %init_tensor = tensor.empty () : tensor<10x10xi32>
   %filled = linalg.fill ins(%cst: i32) outs(%init_tensor: tensor<10x10xi32>) -> tensor<10x10xi32>
   %res = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],

--- a/tests/litmus/linalg-loops/output-value-bad.tgt.mlir
+++ b/tests/litmus/linalg-loops/output-value-bad.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f(%arg0: tensor<10x10xi32>) -> tensor<10x10xi32> {
   %not_three= arith.constant 4 : i32
-  %init_tensor = linalg.init_tensor [10, 10] : tensor<10x10xi32>
+  %init_tensor = tensor.empty () : tensor<10x10xi32>
   %filled = linalg.fill ins(%not_three: i32) outs(%init_tensor: tensor<10x10xi32>) -> tensor<10x10xi32>
   return %filled : tensor<10x10xi32>
 }

--- a/tests/litmus/linalg-loops/output-value.src.mlir
+++ b/tests/litmus/linalg-loops/output-value.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @f(%arg0: tensor<10x10xi32>) -> tensor<10x10xi32> {
   %cst = arith.constant 1 : i32
-  %init_tensor = linalg.init_tensor [10, 10] : tensor<10x10xi32>
+  %init_tensor = tensor.empty () : tensor<10x10xi32>
   %filled = linalg.fill ins(%cst: i32) outs(%init_tensor: tensor<10x10xi32>) -> tensor<10x10xi32>
   %res = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],

--- a/tests/litmus/linalg-loops/output-value.tgt.mlir
+++ b/tests/litmus/linalg-loops/output-value.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f(%arg0: tensor<10x10xi32>) -> tensor<10x10xi32> {
   %three= arith.constant 3 : i32
-  %init_tensor = linalg.init_tensor [10, 10] : tensor<10x10xi32>
+  %init_tensor = tensor.empty () : tensor<10x10xi32>
   %filled = linalg.fill ins(%three: i32) outs(%init_tensor: tensor<10x10xi32>) -> tensor<10x10xi32>
   return %filled : tensor<10x10xi32>
 }

--- a/tests/litmus/linalg-loops/sum-assoc-bad.src.mlir
+++ b/tests/litmus/linalg-loops/sum-assoc-bad.src.mlir
@@ -4,7 +4,7 @@
 func.func @sum(%mat: tensor<100x100xf32>) -> tensor<f32>
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
 
   %mat_transposed = linalg.generic {

--- a/tests/litmus/linalg-loops/sum-assoc-bad.tgt.mlir
+++ b/tests/litmus/linalg-loops/sum-assoc-bad.tgt.mlir
@@ -5,7 +5,7 @@ func.func @sum(%mat0: tensor<100x100xf32>) -> tensor<f32>
   %i2 = arith.constant 2: index
   %mat = tensor.insert %c0 into %mat0[%i0,%i2]: tensor<100x100xf32>
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %mat_col = tensor.collapse_shape %mat [[0, 1]] : tensor<100x100xf32> into tensor<10000xf32>
   %result = linalg.generic {

--- a/tests/litmus/linalg-loops/sum-assoc-f64.src.mlir
+++ b/tests/litmus/linalg-loops/sum-assoc-f64.src.mlir
@@ -4,7 +4,7 @@
 func.func @sum(%mat: tensor<100x100xf64>) -> tensor<f64>
 {
   %zero = arith.constant -0.0 : f64
-  %i = linalg.init_tensor [] : tensor<f64>
+  %i = tensor.empty () : tensor<f64>
   %outty = linalg.fill ins(%zero: f64) outs(%i: tensor<f64>) -> tensor<f64>
 
   %mat_transposed = linalg.generic {

--- a/tests/litmus/linalg-loops/sum-assoc-f64.tgt.mlir
+++ b/tests/litmus/linalg-loops/sum-assoc-f64.tgt.mlir
@@ -4,7 +4,7 @@ func.func @sum(%mat: tensor<100x100xf64>) -> tensor<f64>
   %i0 = arith.constant 0: index
   %i2 = arith.constant 2: index
   %zero = arith.constant -0.0 : f64
-  %i = linalg.init_tensor [] : tensor<f64>
+  %i = tensor.empty () : tensor<f64>
   %outty = linalg.fill ins(%zero: f64) outs(%i: tensor<f64>) -> tensor<f64>
   %mat_col = tensor.collapse_shape %mat [[0, 1]] : tensor<100x100xf64> into tensor<10000xf64>
   %result = linalg.generic {

--- a/tests/litmus/linalg-loops/sum-assoc.src.mlir
+++ b/tests/litmus/linalg-loops/sum-assoc.src.mlir
@@ -4,7 +4,7 @@
 func.func @sum(%mat: tensor<100x100xf32>) -> tensor<f32>
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
 
   %mat_transposed = linalg.generic {

--- a/tests/litmus/linalg-loops/sum-assoc.tgt.mlir
+++ b/tests/litmus/linalg-loops/sum-assoc.tgt.mlir
@@ -4,7 +4,7 @@ func.func @sum(%mat: tensor<100x100xf32>) -> tensor<f32>
   %i0 = arith.constant 0: index
   %i2 = arith.constant 2: index
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %mat_col = tensor.collapse_shape %mat [[0, 1]] : tensor<100x100xf32> into tensor<10000xf32>
   %result = linalg.generic {

--- a/tests/litmus/linalg-loops/sum-bad.src.mlir
+++ b/tests/litmus/linalg-loops/sum-bad.src.mlir
@@ -4,7 +4,7 @@
 func.func @sum(%mat: tensor<5x5xf32>) -> tensor<5xf32>
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [5] : tensor<5xf32>
+  %i = tensor.empty () : tensor<5xf32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<5xf32>) -> tensor<5xf32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,

--- a/tests/litmus/linalg-loops/sum-bad.tgt.mlir
+++ b/tests/litmus/linalg-loops/sum-bad.tgt.mlir
@@ -1,7 +1,7 @@
 func.func @sum(%mat: tensor<5x5xf32>) -> tensor<5xf32>
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [5] : tensor<5xf32>
+  %i = tensor.empty () : tensor<5xf32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<5xf32>) -> tensor<5xf32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,

--- a/tests/litmus/linalg-loops/sum-int-unroll.src.mlir
+++ b/tests/litmus/linalg-loops/sum-int-unroll.src.mlir
@@ -5,7 +5,7 @@ func.func @sum() -> tensor<i8>
 {
   %cst = arith.constant dense<10> : tensor<5xi8>
   %zero = arith.constant 0 : i8
-  %i = linalg.init_tensor []: tensor<i8>
+  %i = tensor.empty (): tensor<i8>
   %outty = linalg.fill ins(%zero: i8) outs(%i: tensor<i8>) -> tensor<i8>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,

--- a/tests/litmus/linalg-loops/sum-int-unroll.tgt.mlir
+++ b/tests/litmus/linalg-loops/sum-int-unroll.tgt.mlir
@@ -2,7 +2,7 @@ func.func @sum() -> tensor<i8>
 {
   %fifty = arith.constant 50: i8
   %zero = arith.constant 0 : i8
-  %i = linalg.init_tensor []: tensor<i8>
+  %i = tensor.empty (): tensor<i8>
   %t = linalg.fill ins(%zero: i8) outs(%i: tensor<i8>) -> tensor<i8>
   %t2 = tensor.insert %fifty into %t[]: tensor<i8>
   return %t2: tensor<i8>

--- a/tests/litmus/linalg-loops/sum-mul.src.mlir
+++ b/tests/litmus/linalg-loops/sum-mul.src.mlir
@@ -3,7 +3,7 @@
 func.func @sum(%mat: tensor<5x5xf32>) -> tensor<5xf32>
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [5] : tensor<5xf32>
+  %i = tensor.empty () : tensor<5xf32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<5xf32>) -> tensor<5xf32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,

--- a/tests/litmus/linalg-loops/sum-mul.tgt.mlir
+++ b/tests/litmus/linalg-loops/sum-mul.tgt.mlir
@@ -1,7 +1,7 @@
 func.func @sum(%mat: tensor<5x5xf32>) -> tensor<5xf32>
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [5] : tensor<5xf32>
+  %i = tensor.empty () : tensor<5xf32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<5xf32>) -> tensor<5xf32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,

--- a/tests/litmus/linalg-loops/sum-unit-tensor-ub.src.mlir
+++ b/tests/litmus/linalg-loops/sum-unit-tensor-ub.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @sum(%x: tensor<1xf32>) -> f32
  {
-   %outty = linalg.init_tensor [] : tensor<f32>
+   %outty = tensor.empty () : tensor<f32>
    %result = linalg.generic {
        indexing_maps = [affine_map<(d0) -> (d0)>,
                         affine_map<(d0) -> ()>],

--- a/tests/litmus/linalg-loops/sum-unit-tensor.src.mlir
+++ b/tests/litmus/linalg-loops/sum-unit-tensor.src.mlir
@@ -3,7 +3,7 @@
 func.func @sum(%x: tensor<1xf32>) -> f32
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,

--- a/tests/litmus/linalg-loops/sum-with-identity-assoc.src.mlir
+++ b/tests/litmus/linalg-loops/sum-with-identity-assoc.src.mlir
@@ -4,7 +4,7 @@
 func.func @sum() -> tensor<f32>
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %cst = arith.constant sparse<[[0], [1], [2], [3], [4]], [2.000000e+00, -0.000000e+00, 3.000000e+00, -0.000000e+00, -1.200000e+01]> : tensor<5xf32>
   %result = linalg.generic {

--- a/tests/litmus/linalg-loops/sum-with-identity-assoc.tgt.mlir
+++ b/tests/litmus/linalg-loops/sum-with-identity-assoc.tgt.mlir
@@ -1,7 +1,7 @@
 func.func @sum() -> tensor<f32>
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %cst = arith.constant sparse<[[0], [1], [2]], [-1.200000e+01, 3.000000e+00, 2.000000e+00]> : tensor<3xf32>
   %result = linalg.generic {

--- a/tests/litmus/linalg-loops/sum-with-identity.src.mlir
+++ b/tests/litmus/linalg-loops/sum-with-identity.src.mlir
@@ -4,7 +4,7 @@
 func.func @sum() -> tensor<f32>
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %cst = arith.constant sparse<[[0], [1], [2], [3], [4]], [-1.200000e+01, -0.000000e+00, 3.000000e+00, 2.000000e+00, -0.000000e+00]> : tensor<5xf32>
   %result = linalg.generic {

--- a/tests/litmus/linalg-loops/sum-with-identity.tgt.mlir
+++ b/tests/litmus/linalg-loops/sum-with-identity.tgt.mlir
@@ -1,7 +1,7 @@
 func.func @sum() -> tensor<f32>
 {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %cst = arith.constant sparse<[[0], [1], [2]], [-1.200000e+01, 3.000000e+00, 2.000000e+00]> : tensor<3xf32>
   %result = linalg.generic {

--- a/tests/litmus/linalg-ops/convolution_constfold.src.mlir
+++ b/tests/litmus/linalg-ops/convolution_constfold.src.mlir
@@ -4,7 +4,7 @@
 func.func @conv() -> tensor<1x1x1x1xf32> {
     %img = arith.constant dense<[[[[1.0,-0.0],[-0.0,-0.0],[-0.0,-0.0]],[[-0.0,-0.0],[-0.0,-0.0],[-0.0,-0.0]],[[-0.0,-0.0],[-0.0,-0.0],[-0.0,-0.0]]]]> : tensor<1x3x3x2xf32>
     %fil = arith.constant dense<[[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]],[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]],[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]]]> : tensor<3x3x2x1xf32>
-    %out = linalg.init_tensor [1,1,1,1] : tensor<1x1x1x1xf32>
+    %out = tensor.empty () : tensor<1x1x1x1xf32>
     %0 = linalg.conv_2d_nhwc_hwcf
       {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
        ins(%img, %fil: tensor<1x3x3x2xf32>, tensor<3x3x2x1xf32>)

--- a/tests/litmus/linalg-ops/convolution_int.src.mlir
+++ b/tests/litmus/linalg-ops/convolution_int.src.mlir
@@ -3,7 +3,7 @@
 func.func @conv() -> tensor<1x1x1x1xf32> {
     %img = arith.constant dense<[[[[1.0,-0.0],[-0.0,-0.0],[-0.0,-0.0]],[[-0.0,-0.0],[-0.0,-0.0],[-0.0,-0.0]],[[-0.0,-0.0],[-0.0,-0.0],[-0.0,-0.0]]]]> : tensor<1x3x3x2xf32>
     %fil = arith.constant dense<[[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]],[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]],[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]]]> : tensor<3x3x2x1xf32>
-    %out = linalg.init_tensor [1,1,1,1] : tensor<1x1x1x1xf32>
+    %out = tensor.empty () : tensor<1x1x1x1xf32>
     %0 = linalg.conv_2d_nhwc_hwcf
       {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
        ins(%img, %fil: tensor<1x3x3x2xf32>, tensor<3x3x2x1xf32>)

--- a/tests/litmus/linalg-ops/convolution_int.tgt.mlir
+++ b/tests/litmus/linalg-ops/convolution_int.tgt.mlir
@@ -1,7 +1,7 @@
 func.func @conv() -> tensor<1x1x1x1xf32> {
     %img = arith.constant dense<[[[[1.0,-0.0],[-0.0,-0.0],[-0.0,-0.0]],[[-0.0,-0.0],[-0.0,-0.0],[-0.0,-0.0]],[[-0.0,-0.0],[-0.0,-0.0],[-0.0,-0.0]]]]> : tensor<1x3x3x2xf32>
     %fil = arith.constant dense<[[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]],[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]],[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]]]> : tensor<3x3x2x1xf32>
-    %out = linalg.init_tensor [1,1,1,1] : tensor<1x1x1x1xf32>
+    %out = tensor.empty () : tensor<1x1x1x1xf32>
     %0 = linalg.conv_2d_nhwc_hwcf
       {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
        ins(%img, %fil: tensor<1x3x3x2xf32>, tensor<3x3x2x1xf32>)

--- a/tests/litmus/linalg-ops/dot.src.mlir
+++ b/tests/litmus/linalg-ops/dot.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func.func @f(%a: tensor<100xf32>, %b: tensor<100xf32>) -> tensor<f32> {
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %zero = arith.constant -0.0 : f32
   %filled = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %e = linalg.dot ins(%a, %b : tensor<100xf32>,tensor<100xf32>)

--- a/tests/litmus/linalg-ops/dot.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @f(%a: tensor<100xf32>, %b: tensor<100xf32>) -> tensor<f32> {
-  %outty = linalg.init_tensor [] : tensor<f32>
+  %outty = tensor.empty () : tensor<f32>
   %zero = arith.constant -0.0 : f32
   %filled = linalg.fill ins(%zero: f32) outs(%outty: tensor<f32>) -> tensor<f32>
   %result = linalg.generic {

--- a/tests/litmus/linalg-ops/dot2.src.mlir
+++ b/tests/litmus/linalg-ops/dot2.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @f(%a: tensor<?xf32>, %b: tensor<?xf32>) -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %e = linalg.dot ins(%a, %b : tensor<?xf32>,tensor<?xf32>)
     outs(%outty: tensor<f32>) -> tensor<f32>

--- a/tests/litmus/linalg-ops/dot2.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot2.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f(%a: tensor<?xf32>, %b: tensor<?xf32>) -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,

--- a/tests/litmus/linalg-ops/dot_assoc_varlen.src.mlir
+++ b/tests/litmus/linalg-ops/dot_assoc_varlen.src.mlir
@@ -2,7 +2,7 @@
 // ARGS: --associative
 
 func.func @f(%a: tensor<?xf32>, %b: tensor<?xf32>) -> tensor<f32> {
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %res = linalg.dot ins(%a, %b : tensor<?xf32>,tensor<?xf32>)
     outs(%i: tensor<f32>) -> tensor<f32>
   return %res : tensor<f32>

--- a/tests/litmus/linalg-ops/dot_assoc_varlen.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_assoc_varlen.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @f(%a: tensor<?xf32>, %b: tensor<?xf32>) -> tensor<f32> {
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %res = linalg.dot ins(%a, %a : tensor<?xf32>,tensor<?xf32>)
     outs(%i: tensor<f32>) -> tensor<f32>
   return %res : tensor<f32>

--- a/tests/litmus/linalg-ops/dot_associativity.src.mlir
+++ b/tests/litmus/linalg-ops/dot_associativity.src.mlir
@@ -9,7 +9,7 @@
 // dot based on multiset theroy (to be precise, the argument of 'sum').
 
 func.func @f() -> tensor<f32> {
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %a = arith.constant sparse<[[0], [1], [2], [3], [4]], [-12.0, 3.0, 2.0, 5.0, 4.0]> : tensor<5xf32>
   %b = arith.constant sparse<[[0], [1], [2], [3], [4]], [1.0, 8.0, 5.0, 6.0, 0.0]> : tensor<5xf32>
   %res = linalg.dot ins(%a, %b : tensor<5xf32>,tensor<5xf32>)

--- a/tests/litmus/linalg-ops/dot_associativity.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_associativity.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @f() -> tensor<f32> {
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %a = arith.constant sparse<[[4], [3], [2], [1], [0]], [-12.0, 3.0, 2.0, 5.0, 4.0]> : tensor<5xf32>
   %b = arith.constant sparse<[[4], [3], [2], [1], [0]], [1.0, 8.0, 5.0, 6.0, 0.0]> : tensor<5xf32>
   %res = linalg.dot ins(%a, %b : tensor<5xf32>,tensor<5xf32>)

--- a/tests/litmus/linalg-ops/dot_associativity2.src.mlir
+++ b/tests/litmus/linalg-ops/dot_associativity2.src.mlir
@@ -10,7 +10,7 @@
 
 func.func @f() -> f32 {
   %c0 = arith.constant 0 : index
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %a1 = arith.constant sparse<[[0], [1]], [-12.0, 3.0]> : tensor<2xf32>
   %a2 = arith.constant sparse<[[0], [1], [2]], [2.0, 5.0, 4.0]> : tensor<3xf32>
   %b1 = arith.constant sparse<[[0], [1]], [1.0, 8.0]> : tensor<2xf32>

--- a/tests/litmus/linalg-ops/dot_associativity2.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_associativity2.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f() -> f32 {
   %c0 = arith.constant 0 : index
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %a1 = arith.constant sparse<[[1], [0]], [-12.0, 3.0]> : tensor<2xf32>
   %a2 = arith.constant sparse<[[2], [1], [0]], [2.0, 5.0, 4.0]> : tensor<3xf32>
   %b1 = arith.constant sparse<[[1], [0]], [1.0, 8.0]> : tensor<2xf32>

--- a/tests/litmus/linalg-ops/dot_associativity2_multiset.src.mlir
+++ b/tests/litmus/linalg-ops/dot_associativity2_multiset.src.mlir
@@ -10,7 +10,7 @@
 
 func.func @f() -> f32 {
   %c0 = arith.constant 0 : index
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %a1 = arith.constant sparse<[[0], [1]], [-12.0, 3.0]> : tensor<2xf32>
   %a2 = arith.constant sparse<[[0], [1], [2]], [2.0, 5.0, 4.0]> : tensor<3xf32>
   %b1 = arith.constant sparse<[[0], [1]], [1.0, 8.0]> : tensor<2xf32>

--- a/tests/litmus/linalg-ops/dot_associativity2_multiset.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_associativity2_multiset.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f() -> f32 {
   %c0 = arith.constant 0 : index
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %a1 = arith.constant sparse<[[1], [0]], [-12.0, 3.0]> : tensor<2xf32>
   %a2 = arith.constant sparse<[[2], [1], [0]], [2.0, 5.0, 4.0]> : tensor<3xf32>
   %b1 = arith.constant sparse<[[1], [0]], [1.0, 8.0]> : tensor<2xf32>

--- a/tests/litmus/linalg-ops/dot_associativity3_multiset.src.mlir
+++ b/tests/litmus/linalg-ops/dot_associativity3_multiset.src.mlir
@@ -10,7 +10,7 @@
 
 func.func @f() -> (f32, f32) {
   %c0 = arith.constant 0 : index
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %a1 = arith.constant sparse<[[0], [1]], [-12.0, 3.0]> : tensor<2xf32>
   %a2 = arith.constant sparse<[[0], [1], [2]], [2.0, 5.0, 4.0]> : tensor<3xf32>
   %b1 = arith.constant sparse<[[0], [1]], [1.0, 8.0]> : tensor<2xf32>

--- a/tests/litmus/linalg-ops/dot_associativity3_multiset.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_associativity3_multiset.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f() -> (f32, f32) {
   %c0 = arith.constant 0 : index
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %a1 = arith.constant sparse<[[1], [0]], [-12.0, 3.0]> : tensor<2xf32>
   %a2 = arith.constant sparse<[[2], [1], [0]], [2.0, 5.0, 4.0]> : tensor<3xf32>
   %b1 = arith.constant sparse<[[1], [0]], [1.0, 8.0]> : tensor<2xf32>

--- a/tests/litmus/linalg-ops/dot_commutative.src.mlir
+++ b/tests/litmus/linalg-ops/dot_commutative.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func.func @f(%a: tensor<100xf32>, %b: tensor<100xf32>) -> tensor<f32> {
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %e = linalg.dot ins(%a, %b : tensor<100xf32>,tensor<100xf32>)
     outs(%i: tensor<f32>) -> tensor<f32>
   return %e : tensor<f32>

--- a/tests/litmus/linalg-ops/dot_commutative.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_commutative.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f(%a: tensor<100xf32>, %b: tensor<100xf32>) -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor [] : tensor<f32>
+  %i = tensor.empty () : tensor<f32>
   %out = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %result = linalg.generic {
       indexing_maps = [affine_map<(d0) -> (d0)>,

--- a/tests/litmus/linalg-ops/dot_constfold.src.mlir
+++ b/tests/litmus/linalg-ops/dot_constfold.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func.func @f() -> f32 {
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %a1 = arith.constant sparse<[[0], [1], [2]], [1.0, -0.0, -0.0]> : tensor<3xf32>
   %a2 = arith.constant sparse<[[0], [1], [2]], [1.0, 2.0, 3.0]> : tensor<3xf32>
   %o1 = linalg.dot ins(%a1, %a2 : tensor<3xf32>,tensor<3xf32>)

--- a/tests/litmus/linalg-ops/dot_rewrite_manually.src.mlir
+++ b/tests/litmus/linalg-ops/dot_rewrite_manually.src.mlir
@@ -20,7 +20,7 @@ func.func @f() -> tensor<f32> {
   %r2 = arith.addf %r1, %c2 : f32
   %r3 = arith.addf %r2, %c3 : f32
   %r4 = arith.addf %r3, %c4 : f32
-  %res = linalg.init_tensor []: tensor<f32>
+  %res = tensor.empty (): tensor<f32>
   %res2 = linalg.fill ins(%r4: f32) outs(%res: tensor<f32>) -> tensor<f32>
   return %res2 : tensor<f32>
 }

--- a/tests/litmus/linalg-ops/dot_rewrite_manually.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_rewrite_manually.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f() -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %a = arith.constant sparse<[[0], [1], [2], [3], [4]], [-12.0, 3.0, 2.0, 5.0, 4.0]> : tensor<5xf32>
   %b = arith.constant sparse<[[0], [1], [2], [3], [4]], [1.0, 8.0, 5.0, 6.0, 0.0]> : tensor<5xf32>

--- a/tests/litmus/linalg-ops/dot_rewrite_manually_assoc.src.mlir
+++ b/tests/litmus/linalg-ops/dot_rewrite_manually_assoc.src.mlir
@@ -28,7 +28,7 @@ func.func @f() -> tensor<f32> {
   %r2 = arith.addf %r1, %c2 : f32
   %r3 = arith.addf %r2, %c3 : f32
   %r4 = arith.addf %r3, %c4 : f32
-  %res = linalg.init_tensor []: tensor<f32>
+  %res = tensor.empty (): tensor<f32>
   %res2 = linalg.fill ins(%r4: f32) outs(%res: tensor<f32>) -> tensor<f32>
   return %res2 : tensor<f32>
 }

--- a/tests/litmus/linalg-ops/dot_rewrite_manually_assoc.tgt.mlir
+++ b/tests/litmus/linalg-ops/dot_rewrite_manually_assoc.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @f() -> tensor<f32> {
   %zero = arith.constant -0.0 : f32
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %outty = linalg.fill ins(%zero: f32) outs(%i: tensor<f32>) -> tensor<f32>
   %a = arith.constant sparse<[[4], [3], [2], [1], [0]], [-12.0, 3.0, 2.0, 5.0, 4.0]> : tensor<5xf32>
   %b = arith.constant sparse<[[4], [3], [2], [1], [0]], [1.0, 8.0, 5.0, 6.0, 0.0]> : tensor<5xf32>

--- a/tests/litmus/linalg-ops/fill.src.mlir
+++ b/tests/litmus/linalg-ops/fill.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func.func @f(%arg: tensor<3x3xf32>) -> tensor<3x3xf32> {
-  %t = linalg.init_tensor [3, 3]: tensor<3x3xf32>
+  %t = tensor.empty (): tensor<3x3xf32>
   %c0 = arith.constant 0.0: f32
   %res = linalg.fill ins(%c0: f32) outs(%t: tensor<3x3xf32>) -> tensor<3x3xf32>
   return %res: tensor<3x3xf32>

--- a/tests/litmus/linalg-ops/init_tensor.src.mlir
+++ b/tests/litmus/linalg-ops/init_tensor.src.mlir
@@ -3,7 +3,7 @@
 func.func @f() -> index {
 	%c0 = arith.constant 0: index
 	%c10 = arith.constant 10: index
-  %v = linalg.init_tensor [%c10]: tensor<?xf32>
+  %v = tensor.empty (%c10): tensor<?xf32>
 	%d = tensor.dim %v, %c0: tensor<?xf32>
 	return %d: index
 }

--- a/tests/litmus/linalg-ops/init_tensor.tgt.mlir
+++ b/tests/litmus/linalg-ops/init_tensor.tgt.mlir
@@ -1,7 +1,7 @@
 func.func @f() -> index {
 	%c0 = arith.constant 0: index
 	%c10 = arith.constant 20: index
-  %v = linalg.init_tensor [%c10]: tensor<?xf32>
+  %v = tensor.empty (%c10): tensor<?xf32>
 	%d = tensor.dim %v, %c0: tensor<?xf32>
 	return %d: index
 }

--- a/tests/litmus/linalg-ops/init_tensor_cast.src.mlir
+++ b/tests/litmus/linalg-ops/init_tensor_cast.src.mlir
@@ -2,6 +2,6 @@
 
 func.func @f() -> (tensor<4x5x?xf32>) {
   %c6 = arith.constant 6 : index
-  %0 = linalg.init_tensor [4, 5, %c6] : tensor<4x5x?xf32>
+  %0 = tensor.empty (%c6) : tensor<4x5x?xf32>
   return %0 : tensor<4x5x?xf32>
 }

--- a/tests/litmus/linalg-ops/init_tensor_cast.tgt.mlir
+++ b/tests/litmus/linalg-ops/init_tensor_cast.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @f() -> tensor<4x5x?xf32> {
-  %0 = linalg.init_tensor [4, 5, 6] : tensor<4x5x6xf32>
+  %0 = tensor.empty () : tensor<4x5x6xf32>
   %1 = tensor.cast %0 : tensor<4x5x6xf32> to tensor<4x5x?xf32>
   return %1 : tensor<4x5x?xf32>
 }

--- a/tests/litmus/linalg-ops/memref_matmul.tgt.mlir
+++ b/tests/litmus/linalg-ops/memref_matmul.tgt.mlir
@@ -6,7 +6,7 @@ func.func @f() -> tensor<8x16xf32> {
   %b = memref.get_global @constant_b : memref<4x16xf32>
   %ta = bufferization.to_tensor %a : memref<8x4xf32>
   %tb = bufferization.to_tensor %b : memref<4x16xf32>
-  %c = linalg.init_tensor [8, 16] : tensor<8x16xf32>
+  %c = tensor.empty () : tensor<8x16xf32>
   %cst = arith.constant -0.0 : f32
   %tc = linalg.fill ins(%cst: f32) outs(%c: tensor<8x16xf32>) -> tensor<8x16xf32>
   %mat = linalg.matmul ins(%ta, %tb: tensor<8x4xf32>, tensor<4x16xf32>) outs(%tc: tensor<8x16xf32>) -> tensor<8x16xf32>

--- a/tests/litmus/linalg-ops/pooling_unsupported2.src.mlir
+++ b/tests/litmus/linalg-ops/pooling_unsupported2.src.mlir
@@ -1,8 +1,8 @@
 // UNSUPPORTED
 
 func.func @pooling_nhwc_i8_max_tensor(%input: tensor<1x4x4x1xi8>) -> tensor<1x2x2x1xi8> {
-  %fake = linalg.init_tensor [3, 3] : tensor<3x3xi8>
-  %init = linalg.init_tensor [1, 2, 2, 1] : tensor<1x2x2x1xi8>
+  %fake = tensor.empty () : tensor<3x3xi8>
+  %init = tensor.empty () : tensor<1x2x2x1xi8>
   %cst = arith.constant 0 : i8
   %fill = linalg.fill ins(%cst: i8) outs(%init: tensor<1x2x2x1xi8>) -> tensor<1x2x2x1xi8>
   %res = linalg.pooling_nhwc_max {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}

--- a/tests/litmus/linalg-ops/pooling_unsupported2.tgt.mlir
+++ b/tests/litmus/linalg-ops/pooling_unsupported2.tgt.mlir
@@ -1,7 +1,7 @@
 module  {
   func.func @pooling_nhwc_i8_max_tensor(%arg0: tensor<1x4x4x1xi8>) -> tensor<1x2x2x1xi8> {
-    %0 = linalg.init_tensor [3, 3] : tensor<3x3xi8>
-    %1 = linalg.init_tensor [1, 2, 2, 1] : tensor<1x2x2x1xi8>
+    %0 = tensor.empty () : tensor<3x3xi8>
+    %1 = tensor.empty () : tensor<1x2x2x1xi8>
     %c0_i8 = arith.constant 0 : i8
     %2 = linalg.fill ins(%c0_i8: i8) outs(%1: tensor<1x2x2x1xi8>) -> tensor<1x2x2x1xi8> 
     %3 = linalg.pooling_nhwc_max {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %0 : tensor<1x4x4x1xi8>, tensor<3x3xi8>) outs(%2 : tensor<1x2x2x1xi8>) -> tensor<1x2x2x1xi8>

--- a/tests/litmus/memref-ops/copy-fill-bad.src.mlir
+++ b/tests/litmus/memref-ops/copy-fill-bad.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @copy(%m1: memref<10x10xf32>, %m2: memref<10x10xf32>)
 {
-  %t = linalg.init_tensor [9, 9]: tensor<9x9xf32>
+  %t = tensor.empty (): tensor<9x9xf32>
   %c0 = arith.constant 0.0: f32
   %zerotensor = linalg.fill ins(%c0: f32) outs(%t: tensor<9x9xf32>) -> tensor<9x9xf32>
 

--- a/tests/litmus/memref-ops/copy-fill-bad.tgt.mlir
+++ b/tests/litmus/memref-ops/copy-fill-bad.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @copy(%m1: memref<10x10xf32>, %m2: memref<10x10xf32>)
 {
-  %t = linalg.init_tensor [9, 9]: tensor<9x9xf32>
+  %t = tensor.empty (): tensor<9x9xf32>
   %c0 = arith.constant 0.0: f32
   %zerotensor = linalg.fill ins(%c0: f32) outs(%t: tensor<9x9xf32>) -> tensor<9x9xf32>
 

--- a/tests/litmus/memref-ops/copy-fill.src.mlir
+++ b/tests/litmus/memref-ops/copy-fill.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @copy(%m1: memref<10x10xf32>, %m2: memref<10x10xf32>)
 {
-  %t = linalg.init_tensor [10, 10]: tensor<10x10xf32>
+  %t = tensor.empty (): tensor<10x10xf32>
   %c0 = arith.constant 0.0: f32
   %zerotensor = linalg.fill ins(%c0: f32) outs(%t: tensor<10x10xf32>) -> tensor<10x10xf32>
 

--- a/tests/litmus/memref-ops/copy-fill.tgt.mlir
+++ b/tests/litmus/memref-ops/copy-fill.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @copy(%m1: memref<10x10xf32>, %m2: memref<10x10xf32>)
 {
-  %t = linalg.init_tensor [10, 10]: tensor<10x10xf32>
+  %t = tensor.empty (): tensor<10x10xf32>
   %c0 = arith.constant 0.0: f32
   %zerotensor = linalg.fill ins(%c0: f32) outs(%t: tensor<10x10xf32>) -> tensor<10x10xf32>
 

--- a/tests/litmus/refinement/size-mismatch.src.mlir
+++ b/tests/litmus/refinement/size-mismatch.src.mlir
@@ -3,6 +3,6 @@
 
 func.func @f() -> tensor<?xf32> {
 	%c10 = arith.constant 10: index
-  %v = linalg.init_tensor [%c10]: tensor<?xf32>
+  %v = tensor.empty (%c10): tensor<?xf32>
 	return %v: tensor<?xf32>
 }

--- a/tests/litmus/refinement/size-mismatch.tgt.mlir
+++ b/tests/litmus/refinement/size-mismatch.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @f() -> tensor<?xf32> {
 	%c20 = arith.constant 20: index
-  %v = linalg.init_tensor [%c20]: tensor<?xf32>
+  %v = tensor.empty (%c20): tensor<?xf32>
 	return %v: tensor<?xf32>
 }

--- a/tests/litmus/tensor-constant/transpose.src.mlir
+++ b/tests/litmus/tensor-constant/transpose.src.mlir
@@ -5,7 +5,7 @@
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 func.func @transpose() -> tensor<1x1x2x2xf32> {
   %cst = arith.constant dense<[[[[1.0, 3.0]]], [[[2.0, 4.0]]]]> : tensor<2x1x1x2xf32>
-  %1 = linalg.init_tensor [1, 1, 2, 2] : tensor<1x1x2x2xf32>
+  %1 = tensor.empty () : tensor<1x1x2x2xf32>
   %2 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst : tensor<2x1x1x2xf32>) outs(%1 : tensor<1x1x2x2xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
       linalg.yield %arg1 : f32

--- a/tests/litmus/tensor-ops/extract_tensor_sum.src.mlir
+++ b/tests/litmus/tensor-ops/extract_tensor_sum.src.mlir
@@ -2,7 +2,7 @@
 // ARGS: --associative
 
 func.func @f(%a: tensor<1000xf32>, %b: tensor<1000xf32>) -> tensor<f32> {
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %a1 = tensor.extract_slice %a[0][500][1]: tensor<1000xf32> to tensor<500xf32>
   %a2 = tensor.extract_slice %a[500][500][1]: tensor<1000xf32> to tensor<500xf32>
   %b1 = tensor.extract_slice %b[0][500][1]: tensor<1000xf32> to tensor<500xf32>

--- a/tests/litmus/tensor-ops/extract_tensor_sum.tgt.mlir
+++ b/tests/litmus/tensor-ops/extract_tensor_sum.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @f(%a: tensor<1000xf32>, %b: tensor<1000xf32>) -> tensor<f32> {
-  %i = linalg.init_tensor []: tensor<f32>
+  %i = tensor.empty (): tensor<f32>
   %e = linalg.dot ins(%a, %b : tensor<1000xf32>,tensor<1000xf32>)
     outs(%i: tensor<f32>) -> tensor<f32>
   return %e : tensor<f32>

--- a/tests/litmus/tensor-ops/extract_ub.src.mlir
+++ b/tests/litmus/tensor-ops/extract_ub.src.mlir
@@ -3,7 +3,7 @@
 func.func @f() -> ()
 {
   %c10 = arith.constant 10 : index
-  %v = linalg.init_tensor [%c10]: tensor<?xf32>
+  %v = tensor.empty (%c10): tensor<?xf32>
   tensor.extract %v[%c10]: tensor<?xf32>
   return
 }

--- a/tests/litmus/tensor-ops/extract_ub.tgt.mlir
+++ b/tests/litmus/tensor-ops/extract_ub.tgt.mlir
@@ -1,7 +1,7 @@
 func.func @f() -> ()
 {
   %c10 = arith.constant 10 : index
-  %v = linalg.init_tensor [%c10]: tensor<?xf32>
+  %v = tensor.empty (%c10): tensor<?xf32>
   tensor.extract %v[%c10]: tensor<?xf32>
   return
 }

--- a/tests/litmus/tensor-ops/from_elements.tgt.mlir
+++ b/tests/litmus/tensor-ops/from_elements.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @from_elem() -> tensor<3xf32>
 {
-  %v = linalg.init_tensor[3]: tensor<3xf32>
+  %v = tensor.empty (): tensor<3xf32>
   %c0 = arith.constant 3.0: f32
   %res = linalg.fill ins(%c0: f32) outs(%v: tensor<3xf32>) -> tensor<3xf32>
   return %res : tensor<3xf32>

--- a/tests/litmus/tensor-ops/from_elements_arg.tgt.mlir
+++ b/tests/litmus/tensor-ops/from_elements_arg.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @from_elem(%x:f32) -> tensor<3xf32>
 {
-  %v = linalg.init_tensor[3]: tensor<3xf32>
+  %v = tensor.empty (): tensor<3xf32>
   %res = linalg.fill ins(%x: f32) outs(%v: tensor<3xf32>) -> tensor<3xf32>
   return %res : tensor<3xf32>
 }

--- a/tests/litmus/tosa-ops/add_broadcast1.src.mlir
+++ b/tests/litmus/tosa-ops/add_broadcast1.src.mlir
@@ -3,7 +3,7 @@
 func.func @add(%arg0: tensor<1xf32>, %arg1: tensor<10x9x8x7xf32>) -> tensor<10x9x8x7xf32> {
   %c0 = arith.constant 0 : index
   %c = tensor.extract %arg0[%c0] : tensor<1xf32>
-  %t1 = linalg.init_tensor [10, 9, 8, 7] : tensor<10x9x8x7xf32>
+  %t1 = tensor.empty () : tensor<10x9x8x7xf32>
   %t2 = linalg.fill ins(%c: f32) outs(%t1: tensor<10x9x8x7xf32>) -> tensor<10x9x8x7xf32>
   %0 = "tosa.add"(%t2, %arg1) : (tensor<10x9x8x7xf32>, tensor<10x9x8x7xf32>) -> tensor<10x9x8x7xf32>
   

--- a/tests/litmus/tosa-ops/add_broadcast3.src.mlir
+++ b/tests/litmus/tosa-ops/add_broadcast3.src.mlir
@@ -9,8 +9,8 @@ func.func @add(%arg0: tensor<2x1xf32>, %arg1: tensor<1x3xf32>) -> tensor<2x3xf32
   %y11 = tensor.extract %arg1[%c0, %c0] : tensor<1x3xf32>
   %y12 = tensor.extract %arg1[%c0, %c1] : tensor<1x3xf32>
   %y13 = tensor.extract %arg1[%c0, %c2] : tensor<1x3xf32>
-  %tx0 = linalg.init_tensor [2, 3] : tensor<2x3xf32>
-  %ty0 = linalg.init_tensor [2, 3] : tensor<2x3xf32>
+  %tx0 = tensor.empty () : tensor<2x3xf32>
+  %ty0 = tensor.empty () : tensor<2x3xf32>
   %tx1 = tensor.insert %x11 into %tx0[%c0, %c0] : tensor<2x3xf32>
   %tx2 = tensor.insert %x11 into %tx1[%c0, %c1] : tensor<2x3xf32>
   %tx3 = tensor.insert %x11 into %tx2[%c0, %c2] : tensor<2x3xf32>

--- a/tests/litmus/tosa-ops/avgpool2d.src.mlir
+++ b/tests/litmus/tosa-ops/avgpool2d.src.mlir
@@ -2,6 +2,6 @@
 // ARGS: --use-neg-zero
 
 func.func @avgpool(%arg0: tensor<1x13x13x1001xf32>) -> tensor<1x1x1x1001xf32> {
-  %0 = "tosa.avg_pool2d"(%arg0) {kernel = [13, 13], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x13x13x1001xf32>) -> tensor<1x1x1x1001xf32>
+  %0 = "tosa.avg_pool2d"(%arg0) {kernel = [13, 13], pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x13x13x1001xf32>) -> tensor<1x1x1x1001xf32>
   return %0 : tensor<1x1x1x1001xf32>
 }

--- a/tests/litmus/tosa-ops/avgpool2d.src.mlir
+++ b/tests/litmus/tosa-ops/avgpool2d.src.mlir
@@ -2,6 +2,6 @@
 // ARGS: --use-neg-zero
 
 func.func @avgpool(%arg0: tensor<1x13x13x1001xf32>) -> tensor<1x1x1x1001xf32> {
-  %0 = "tosa.avg_pool2d"(%arg0) {kernel = [13, 13], pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x13x13x1001xf32>) -> tensor<1x1x1x1001xf32>
+  %0 = "tosa.avg_pool2d"(%arg0) {kernel = array<i64: 13, 13>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x13x13x1001xf32>) -> tensor<1x1x1x1001xf32>
   return %0 : tensor<1x1x1x1001xf32>
 }

--- a/tests/litmus/tosa-ops/avgpool2d.src.mlir
+++ b/tests/litmus/tosa-ops/avgpool2d.src.mlir
@@ -2,6 +2,6 @@
 // ARGS: --use-neg-zero
 
 func.func @avgpool(%arg0: tensor<1x13x13x1001xf32>) -> tensor<1x1x1x1001xf32> {
-  %0 = "tosa.avg_pool2d"(%arg0) {kernel = array<i64: 13, 13>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x13x13x1001xf32>) -> tensor<1x1x1x1001xf32>
+  %0 = "tosa.avg_pool2d"(%arg0) {kernel = array<i64: 13, 13>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, acc_type = f32} : (tensor<1x13x13x1001xf32>) -> tensor<1x1x1x1001xf32>
   return %0 : tensor<1x1x1x1001xf32>
 }

--- a/tests/litmus/tosa-ops/avgpool2d.tgt.mlir
+++ b/tests/litmus/tosa-ops/avgpool2d.tgt.mlir
@@ -1,11 +1,11 @@
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 func.func @avgpool(%arg0: tensor<1x13x13x1001xf32>) -> tensor<1x1x1x1001xf32> {
   %cst_194 = arith.constant 0.000000e+00 : f32
-  %373 = linalg.init_tensor [1, 1, 1, 1001] : tensor<1x1x1x1001xf32>
+  %373 = tensor.empty () : tensor<1x1x1x1001xf32>
   %374 = linalg.fill ins(%cst_194: f32) outs(%373: tensor<1x1x1x1001xf32>) -> tensor<1x1x1x1001xf32>
-  %375 = linalg.init_tensor [13, 13] : tensor<13x13xf32>
+  %375 = tensor.empty () : tensor<13x13xf32>
   %376 = linalg.pooling_nhwc_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%arg0, %375 : tensor<1x13x13x1001xf32>, tensor<13x13xf32>) outs(%374 : tensor<1x1x1x1001xf32>) -> tensor<1x1x1x1001xf32>
-  %377 = linalg.init_tensor [1, 1, 1, 1001] : tensor<1x1x1x1001xf32>
+  %377 = tensor.empty () : tensor<1x1x1x1001xf32>
   %378 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%376 : tensor<1x1x1x1001xf32>) outs(%377 : tensor<1x1x1x1001xf32>) {
   ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
     %c0_196 = arith.constant 0 : index

--- a/tests/litmus/tosa-ops/avgpool2d_memref.src.mlir
+++ b/tests/litmus/tosa-ops/avgpool2d_memref.src.mlir
@@ -5,11 +5,11 @@
 func.func @avgpool(%arg0: tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32> {
   %cst_0 = arith.constant 0.000000e+00 : f32
   %c49_i32 = arith.constant 49 : i32
-  %507 = linalg.init_tensor [1, 1, 1, 1280] : tensor<1x1x1x1280xf32>
+  %507 = tensor.empty () : tensor<1x1x1x1280xf32>
   %508 = linalg.fill ins(%cst_0: f32) outs(%507: tensor<1x1x1x1280xf32>) -> tensor<1x1x1x1280xf32>
-  %509 = linalg.init_tensor [7, 7] : tensor<7x7xf32>
+  %509 = tensor.empty () : tensor<7x7xf32>
   %510 = linalg.pooling_nhwc_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%arg0, %509 : tensor<1x7x7x1280xf32>, tensor<7x7xf32>) outs(%508 : tensor<1x1x1x1280xf32>) -> tensor<1x1x1x1280xf32>
-  %511 = linalg.init_tensor [1, 1, 1, 1280] : tensor<1x1x1x1280xf32>
+  %511 = tensor.empty () : tensor<1x1x1x1280xf32>
   %512 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%510 : tensor<1x1x1x1280xf32>) outs(%511 : tensor<1x1x1x1280xf32>) {
   ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
     %526 = arith.sitofp %c49_i32 : i32 to f32

--- a/tests/litmus/tosa-ops/conv2d1.src.mlir
+++ b/tests/litmus/tosa-ops/conv2d1.src.mlir
@@ -5,6 +5,6 @@ func.func @conv(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>) -> te
     %bias = tensor.from_elements %c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0: tensor<16xf32>
     %filperms = "tosa.const"() {value = dense<[3, 0, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
     %arg3 = "tosa.transpose"(%arg1, %filperms) : (tensor<3x3x4x16xf32>, tensor<4xi64>) -> tensor<16x3x3x4xf32>
-    %0 = "tosa.conv2d"(%arg0, %arg3, %bias) {dilation = array<i64:1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
+    %0 = "tosa.conv2d"(%arg0, %arg3, %bias) {dilation = array<i64:1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
     return %0 : tensor<1x14x14x16xf32>
 }

--- a/tests/litmus/tosa-ops/conv2d1.src.mlir
+++ b/tests/litmus/tosa-ops/conv2d1.src.mlir
@@ -5,6 +5,6 @@ func.func @conv(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>) -> te
     %bias = tensor.from_elements %c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0: tensor<16xf32>
     %filperms = "tosa.const"() {value = dense<[3, 0, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
     %arg3 = "tosa.transpose"(%arg1, %filperms) : (tensor<3x3x4x16xf32>, tensor<4xi64>) -> tensor<16x3x3x4xf32>
-    %0 = "tosa.conv2d"(%arg0, %arg3, %bias) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
+    %0 = "tosa.conv2d"(%arg0, %arg3, %bias) {dilation = array<i64:1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
     return %0 : tensor<1x14x14x16xf32>
 }

--- a/tests/litmus/tosa-ops/conv2d1.tgt.mlir
+++ b/tests/litmus/tosa-ops/conv2d1.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @conv(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>) -> tensor<1x14x14x16xf32> {
-    %i = linalg.init_tensor [1,14,14,16] : tensor<1x14x14x16xf32>
+    %i = tensor.empty () : tensor<1x14x14x16xf32>
     %zero = arith.constant -0.0 : f32
     %out = linalg.fill ins(%zero: f32) outs(%i: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
     %0 = linalg.conv_2d_nhwc_hwcf

--- a/tests/litmus/tosa-ops/conv2d2.src.mlir
+++ b/tests/litmus/tosa-ops/conv2d2.src.mlir
@@ -5,6 +5,6 @@ func.func @conv() -> tensor<1x1x1x1xf32> {
     %filter = arith.constant dense<[[[[1.0,1.0],[1.0,1.0],[1.0,1.0]],[[1.0,1.0],[1.0,1.0],[1.0,1.0]],[[1.0,1.0],[1.0,1.0],[1.0,1.0]]]]> : tensor<1x3x3x2xf32>
     %c0 = arith.constant -0.0 : f32
     %bias = tensor.from_elements %c0: tensor<1xf32>
-    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x3x3x2xf32>, tensor<1x3x3x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
+    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x3x3x2xf32>, tensor<1x3x3x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
     return %0 : tensor<1x1x1x1xf32>
 }

--- a/tests/litmus/tosa-ops/conv2d2.src.mlir
+++ b/tests/litmus/tosa-ops/conv2d2.src.mlir
@@ -5,6 +5,6 @@ func.func @conv() -> tensor<1x1x1x1xf32> {
     %filter = arith.constant dense<[[[[1.0,1.0],[1.0,1.0],[1.0,1.0]],[[1.0,1.0],[1.0,1.0],[1.0,1.0]],[[1.0,1.0],[1.0,1.0],[1.0,1.0]]]]> : tensor<1x3x3x2xf32>
     %c0 = arith.constant -0.0 : f32
     %bias = tensor.from_elements %c0: tensor<1xf32>
-    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x3x3x2xf32>, tensor<1x3x3x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
+    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x3x3x2xf32>, tensor<1x3x3x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
     return %0 : tensor<1x1x1x1xf32>
 }

--- a/tests/litmus/tosa-ops/conv2d3.src.mlir
+++ b/tests/litmus/tosa-ops/conv2d3.src.mlir
@@ -5,6 +5,6 @@ func.func @conv() -> tensor<1x1x1x1xf32> {
     %fil = arith.constant dense<[[[[1.0,1.0],[1.0,1.0]],[[1.0,1.0],[1.0,1.0]]]]> : tensor<1x2x2x2xf32>
     %c0 = arith.constant -0.0 : f32
     %bias = tensor.from_elements %c0: tensor<1xf32>
-    %0 = "tosa.conv2d"(%img, %fil, %bias) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x2x2x2xf32>, tensor<1x2x2x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
+    %0 = "tosa.conv2d"(%img, %fil, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x2x2x2xf32>, tensor<1x2x2x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
     return %0 : tensor<1x1x1x1xf32>
 }

--- a/tests/litmus/tosa-ops/conv2d3.src.mlir
+++ b/tests/litmus/tosa-ops/conv2d3.src.mlir
@@ -5,6 +5,6 @@ func.func @conv() -> tensor<1x1x1x1xf32> {
     %fil = arith.constant dense<[[[[1.0,1.0],[1.0,1.0]],[[1.0,1.0],[1.0,1.0]]]]> : tensor<1x2x2x2xf32>
     %c0 = arith.constant -0.0 : f32
     %bias = tensor.from_elements %c0: tensor<1xf32>
-    %0 = "tosa.conv2d"(%img, %fil, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x2x2x2xf32>, tensor<1x2x2x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
+    %0 = "tosa.conv2d"(%img, %fil, %bias) {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x2x2x2xf32>, tensor<1x2x2x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
     return %0 : tensor<1x1x1x1xf32>
 }

--- a/tests/litmus/tosa-ops/depthwise1.src.mlir
+++ b/tests/litmus/tosa-ops/depthwise1.src.mlir
@@ -5,6 +5,6 @@ func.func @conv() -> tensor<1x1x1x1xf32> {
     %filter = arith.constant dense<[[[[1.0]],[[1.0]],[[1.0]]],[[[1.0]],[[1.0]],[[1.0]]],[[[1.0]],[[1.0]],[[1.0]]]]> : tensor<3x3x1x1xf32>
     %c0 = arith.constant -0.0 : f32
     %bias = tensor.from_elements %c0: tensor<1xf32>
-    %0 = "tosa.depthwise_conv2d"(%img, %filter, %bias) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x3x3x1xf32>, tensor<3x3x1x1xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
+    %0 = "tosa.depthwise_conv2d"(%img, %filter, %bias) {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x3x3x1xf32>, tensor<3x3x1x1xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
     return %0 : tensor<1x1x1x1xf32>
 }

--- a/tests/litmus/tosa-ops/depthwise2.src.mlir
+++ b/tests/litmus/tosa-ops/depthwise2.src.mlir
@@ -5,6 +5,6 @@ func.func @conv() -> tensor<1x1x1x2xf32> {
     %filter = arith.constant dense<[[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]],[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]],[[[1.0],[1.0]],[[1.0],[1.0]],[[1.0],[1.0]]]]> : tensor<3x3x2x1xf32>
     %c0 = arith.constant -0.0 : f32
     %bias = tensor.from_elements %c0, %c0: tensor<2xf32>
-    %0 = "tosa.depthwise_conv2d"(%img, %filter, %bias) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x3x3x2xf32>, tensor<3x3x2x1xf32>, tensor<2xf32>) -> tensor<1x1x1x2xf32>
+    %0 = "tosa.depthwise_conv2d"(%img, %filter, %bias) {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x3x3x2xf32>, tensor<3x3x2x1xf32>, tensor<2xf32>) -> tensor<1x1x1x2xf32>
     return %0 : tensor<1x1x1x2xf32>
 }

--- a/tests/litmus/tosa-ops/depthwise3.src.mlir
+++ b/tests/litmus/tosa-ops/depthwise3.src.mlir
@@ -4,7 +4,7 @@ func.func @depthwise_conv() -> tensor<1x1x1x2xf32> {
   %arg0 =  arith.constant dense<[[[[1.0,1.0,1.0]]]]>: tensor<1x1x1x3xf32>
   %arg1 =  arith.constant dense<[[[[1.0,2.0],[3.0,4.0],[5.0,6.0]]]]>: tensor<1x1x3x2xf32>
   %arg2 =  arith.constant dense<[7.0,8.0,9.0,10.0,11.0,12.0]>: tensor<6xf32>
-  %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = [1, 1] } : (tensor<1x1x1x3xf32>, tensor<1x1x3x2xf32>, tensor<6xf32>)  -> (tensor<1x1x1x6xf32>)
+  %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) { pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1> } : (tensor<1x1x1x3xf32>, tensor<1x1x3x2xf32>, tensor<6xf32>)  -> (tensor<1x1x1x6xf32>)
   %1 = tensor.extract_slice %0[0,0,0,4][1,1,1,2][1,1,1,1]: tensor<1x1x1x6xf32> to tensor<2xf32>
   %2 = tensor.expand_shape %1 [[0,1,2,3]] : tensor<2xf32> into tensor<1x1x1x2xf32>
   return %2 : tensor<1x1x1x2xf32>

--- a/tests/litmus/tosa-ops/depthwise3.tgt.mlir
+++ b/tests/litmus/tosa-ops/depthwise3.tgt.mlir
@@ -9,6 +9,6 @@ func.func @depthwise_conv() -> tensor<1x1x1x2xf32> {
   %bias = tensor.extract_slice %arg2[4][2][1]: tensor<6xf32> to tensor<2xf32>
   %filperms = "tosa.const"() {value = dense<[3, 0, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
   %fil3 = "tosa.transpose"(%fil2, %filperms) : (tensor<1x1x1x2xf32>, tensor<4xi64>) -> tensor<2x1x1x1xf32>
-  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = [1, 1] } : (tensor<1x1x1x1xf32>, tensor<2x1x1x1xf32>, tensor<2xf32>)  -> (tensor<1x1x1x2xf32>)
+  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = array<i64: 1, 1> } : (tensor<1x1x1x1xf32>, tensor<2x1x1x1xf32>, tensor<2xf32>)  -> (tensor<1x1x1x2xf32>)
   return %0 : tensor<1x1x1x2xf32>
 }

--- a/tests/litmus/tosa-ops/depthwise3.tgt.mlir
+++ b/tests/litmus/tosa-ops/depthwise3.tgt.mlir
@@ -9,6 +9,6 @@ func.func @depthwise_conv() -> tensor<1x1x1x2xf32> {
   %bias = tensor.extract_slice %arg2[4][2][1]: tensor<6xf32> to tensor<2xf32>
   %filperms = "tosa.const"() {value = dense<[3, 0, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
   %fil3 = "tosa.transpose"(%fil2, %filperms) : (tensor<1x1x1x2xf32>, tensor<4xi64>) -> tensor<2x1x1x1xf32>
-  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = array<i64: 1, 1> } : (tensor<1x1x1x1xf32>, tensor<2x1x1x1xf32>, tensor<2xf32>)  -> (tensor<1x1x1x2xf32>)
+  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1> } : (tensor<1x1x1x1xf32>, tensor<2x1x1x1xf32>, tensor<2xf32>)  -> (tensor<1x1x1x2xf32>)
   return %0 : tensor<1x1x1x2xf32>
 }

--- a/tests/litmus/tosa-ops/depthwise4.src.mlir
+++ b/tests/litmus/tosa-ops/depthwise4.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func.func @depthwise_conv(%arg0 : tensor<1x1x1x3xf32>, %arg1 : tensor<1x1x3x2xf32>, %arg2 : tensor<6xf32>) -> tensor<1x1x1x2xf32> {
-  %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = [1, 1] } : (tensor<1x1x1x3xf32>, tensor<1x1x3x2xf32>, tensor<6xf32>)  -> (tensor<1x1x1x6xf32>)
+  %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) { pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1> } : (tensor<1x1x1x3xf32>, tensor<1x1x3x2xf32>, tensor<6xf32>)  -> (tensor<1x1x1x6xf32>)
   %1 = tensor.extract_slice %0[0,0,0,4][1,1,1,2][1,1,1,1]: tensor<1x1x1x6xf32> to tensor<2xf32>
   %2 = tensor.expand_shape %1 [[0,1,2,3]] : tensor<2xf32> into tensor<1x1x1x2xf32>
   return %2 : tensor<1x1x1x2xf32>

--- a/tests/litmus/tosa-ops/depthwise4.tgt.mlir
+++ b/tests/litmus/tosa-ops/depthwise4.tgt.mlir
@@ -6,6 +6,6 @@ func.func @depthwise_conv(%arg0 : tensor<1x1x1x3xf32>, %arg1 : tensor<1x1x3x2xf3
   %bias = tensor.extract_slice %arg2[4][2][1]: tensor<6xf32> to tensor<2xf32>
   %filperms = "tosa.const"() {value = dense<[3, 0, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
   %fil3 = "tosa.transpose"(%fil2, %filperms) : (tensor<1x1x1x2xf32>, tensor<4xi64>) -> tensor<2x1x1x1xf32>
-  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = [1, 1] } : (tensor<1x1x1x1xf32>, tensor<2x1x1x1xf32>, tensor<2xf32>)  -> (tensor<1x1x1x2xf32>)
+  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = array<i64: 1, 1> } : (tensor<1x1x1x1xf32>, tensor<2x1x1x1xf32>, tensor<2xf32>)  -> (tensor<1x1x1x2xf32>)
   return %0 : tensor<1x1x1x2xf32>
 }

--- a/tests/litmus/tosa-ops/depthwise4.tgt.mlir
+++ b/tests/litmus/tosa-ops/depthwise4.tgt.mlir
@@ -6,6 +6,6 @@ func.func @depthwise_conv(%arg0 : tensor<1x1x1x3xf32>, %arg1 : tensor<1x1x3x2xf3
   %bias = tensor.extract_slice %arg2[4][2][1]: tensor<6xf32> to tensor<2xf32>
   %filperms = "tosa.const"() {value = dense<[3, 0, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
   %fil3 = "tosa.transpose"(%fil2, %filperms) : (tensor<1x1x1x2xf32>, tensor<4xi64>) -> tensor<2x1x1x1xf32>
-  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = array<i64: 1, 1> } : (tensor<1x1x1x1xf32>, tensor<2x1x1x1xf32>, tensor<2xf32>)  -> (tensor<1x1x1x2xf32>)
+  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1> } : (tensor<1x1x1x1xf32>, tensor<2x1x1x1xf32>, tensor<2xf32>)  -> (tensor<1x1x1x2xf32>)
   return %0 : tensor<1x1x1x2xf32>
 }

--- a/tests/litmus/tosa-ops/depthwise5.src.mlir
+++ b/tests/litmus/tosa-ops/depthwise5.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func.func @depthwise_conv(%arg0 : tensor<2x7x5x3xf32>, %arg1 : tensor<3x1x3x2xf32>, %arg2 : tensor<6xf32>) -> tensor<2x5x5x2xf32> {
-  %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = [1, 1] } : (tensor<2x7x5x3xf32>, tensor<3x1x3x2xf32>, tensor<6xf32>)  -> (tensor<2x5x5x6xf32>)
+  %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) { pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1> } : (tensor<2x7x5x3xf32>, tensor<3x1x3x2xf32>, tensor<6xf32>)  -> (tensor<2x5x5x6xf32>)
   %1 = tensor.extract_slice %0[0,0,0,4][2,5,5,2][1,1,1,1]: tensor<2x5x5x6xf32> to tensor<2x5x5x2xf32>
   return %1 : tensor<2x5x5x2xf32>
 }

--- a/tests/litmus/tosa-ops/depthwise5.tgt.mlir
+++ b/tests/litmus/tosa-ops/depthwise5.tgt.mlir
@@ -8,6 +8,6 @@ func.func @depthwise_conv(%arg0 : tensor<2x7x5x3xf32>, %arg1 : tensor<3x1x3x2xf3
   %bias = tensor.extract_slice %arg2[4][2][1]: tensor<6xf32> to tensor<2xf32>
   %filperms = "tosa.const"() {value = dense<[3, 0, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
   %fil3 = "tosa.transpose"(%fil2, %filperms) : (tensor<3x1x1x2xf32>, tensor<4xi64>) -> tensor<2x3x1x1xf32>
-  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = array<i64: 1, 1> } : (tensor<2x7x5x1xf32>, tensor<2x3x1x1xf32>, tensor<2xf32>)  -> (tensor<2x5x5x2xf32>)
+  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1> } : (tensor<2x7x5x1xf32>, tensor<2x3x1x1xf32>, tensor<2xf32>)  -> (tensor<2x5x5x2xf32>)
   return %0 : tensor<2x5x5x2xf32>
 }

--- a/tests/litmus/tosa-ops/depthwise5.tgt.mlir
+++ b/tests/litmus/tosa-ops/depthwise5.tgt.mlir
@@ -8,6 +8,6 @@ func.func @depthwise_conv(%arg0 : tensor<2x7x5x3xf32>, %arg1 : tensor<3x1x3x2xf3
   %bias = tensor.extract_slice %arg2[4][2][1]: tensor<6xf32> to tensor<2xf32>
   %filperms = "tosa.const"() {value = dense<[3, 0, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
   %fil3 = "tosa.transpose"(%fil2, %filperms) : (tensor<3x1x1x2xf32>, tensor<4xi64>) -> tensor<2x3x1x1xf32>
-  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = [1, 1] } : (tensor<2x7x5x1xf32>, tensor<2x3x1x1xf32>, tensor<2xf32>)  -> (tensor<2x5x5x2xf32>)
+  %0 = "tosa.conv2d"(%in2, %fil3, %bias) { pad = [0, 0, 0, 0], stride = [1, 1], dilation = array<i64: 1, 1> } : (tensor<2x7x5x1xf32>, tensor<2x3x1x1xf32>, tensor<2xf32>)  -> (tensor<2x5x5x2xf32>)
   return %0 : tensor<2x5x5x2xf32>
 }

--- a/tests/litmus/tosa-ops/depthwise5.tgt.mlir
+++ b/tests/litmus/tosa-ops/depthwise5.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @depthwise_conv(%arg0 : tensor<2x7x5x3xf32>, %arg1 : tensor<3x1x3x2xf32>, %arg2 : tensor<6xf32>) -> tensor<2x5x5x2xf32> {
-  %i = linalg.init_tensor [2, 7, 5, 1] : tensor<2x7x5x1xf32>
-  %i2 = linalg.init_tensor [3, 1, 1, 2] : tensor<3x1x1x2xf32>
+  %i = tensor.empty () : tensor<2x7x5x1xf32>
+  %i2 = tensor.empty () : tensor<3x1x1x2xf32>
   %in = tensor.extract_slice %arg0[0,0,0,2][2,7,5,1][1,1,1,1]: tensor<2x7x5x3xf32> to tensor<2x7x5xf32>
   %fil = tensor.extract_slice %arg1[0,0,2,0][3,1,1,2][1,1,1,1]: tensor<3x1x3x2xf32> to tensor<3x2xf32>
   %in2 = tensor.expand_shape %in [[0],[1],[2,3]] : tensor<2x7x5xf32> into tensor<2x7x5x1xf32>

--- a/tests/litmus/tosa-ops/gather-const-bad.src.mlir
+++ b/tests/litmus/tosa-ops/gather-const-bad.src.mlir
@@ -1,6 +1,6 @@
 // VERIFY-INCORRECT
 func.func @test_gather() -> tensor<2x1x1xf32> {
-  %v = linalg.init_tensor [2,2,1]: tensor<2x2x1xf32>
+  %v = tensor.empty (): tensor<2x2x1xf32>
   %zero = arith.constant 0: index
   %one = arith.constant 1: index
   %c1 = arith.constant 10.0: f32

--- a/tests/litmus/tosa-ops/gather-const.src.mlir
+++ b/tests/litmus/tosa-ops/gather-const.src.mlir
@@ -1,6 +1,6 @@
 // VERIFY
 func.func @test_gather() -> tensor<2x1x1xf32> {
-  %v = linalg.init_tensor [2,2,1]: tensor<2x2x1xf32>
+  %v = tensor.empty (): tensor<2x2x1xf32>
   %zero = arith.constant 0: index
   %one = arith.constant 1: index
   %c1 = arith.constant 10.0: f32

--- a/tests/litmus/tosa-ops/gather-oob.src.mlir
+++ b/tests/litmus/tosa-ops/gather-oob.src.mlir
@@ -1,7 +1,7 @@
 // EXPECT: "correct (source is always undefined)"
 
 func.func @test_gather() -> tensor<2x1x1xf32> {
-  %v = linalg.init_tensor [2,2,1]: tensor<2x2x1xf32>
+  %v = tensor.empty (): tensor<2x2x1xf32>
   %zero = arith.constant 0: index
   %one = arith.constant 1: index
   %c1 = arith.constant 10.0: f32

--- a/tests/litmus/tosa-ops/gather-oob.tgt.mlir
+++ b/tests/litmus/tosa-ops/gather-oob.tgt.mlir
@@ -1,4 +1,4 @@
 func.func @test_gather() -> tensor<2x1x1xf32> {
-  %v = linalg.init_tensor [2,1,1]: tensor<2x1x1xf32>
+  %v = tensor.empty (): tensor<2x1x1xf32>
   return %v: tensor<2x1x1xf32>
 }

--- a/tests/litmus/tosa-ops/gather-uninit-index.src.mlir
+++ b/tests/litmus/tosa-ops/gather-uninit-index.src.mlir
@@ -1,7 +1,7 @@
 // EXPECT: "correct (source is always undefined)"
 
 func.func @test_gather() -> tensor<2x1x1xf32> {
-  %v = linalg.init_tensor [2,2,1]: tensor<2x2x1xf32>
+  %v = tensor.empty (): tensor<2x2x1xf32>
   %zero = arith.constant 0: index
   %one = arith.constant 1: index
   %c1 = arith.constant 10.0: f32
@@ -9,7 +9,7 @@ func.func @test_gather() -> tensor<2x1x1xf32> {
   %v1 = tensor.insert %c1 into %v [%zero, %zero, %zero]: tensor<2x2x1xf32>
   %v2 = tensor.insert %c2 into %v1[%one,  %zero, %zero]: tensor<2x2x1xf32>
 
-  %indices = linalg.init_tensor [2,1]: tensor<2x1xi32>
+  %indices = tensor.empty (): tensor<2x1xi32>
 
   %0 = "tosa.gather"(%v2, %indices) : (tensor<2x2x1xf32>, tensor<2x1xi32>) -> tensor<2x1x1xf32>
   return %0 : tensor<2x1x1xf32>

--- a/tests/litmus/tosa-ops/gather-uninit-index.tgt.mlir
+++ b/tests/litmus/tosa-ops/gather-uninit-index.tgt.mlir
@@ -1,4 +1,4 @@
 func.func @test_gather() -> tensor<2x1x1xf32> {
-  %v = linalg.init_tensor [2,1,1]: tensor<2x1x1xf32>
+  %v = tensor.empty (): tensor<2x1x1xf32>
   return %v: tensor<2x1x1xf32>
 }

--- a/tests/litmus/tosa-ops/gather-uninit.src.mlir
+++ b/tests/litmus/tosa-ops/gather-uninit.src.mlir
@@ -1,7 +1,7 @@
 // EXPECT: "correct (source is always undefined)"
 
 func.func @test_gather() -> tensor<2x1x1xf32> {
-  %v = linalg.init_tensor [2,2,1]: tensor<2x2x1xf32>
+  %v = tensor.empty (): tensor<2x2x1xf32>
   %zero = arith.constant 0: index
   %one = arith.constant 1: index
   %c1 = arith.constant 10.0: f32

--- a/tests/litmus/tosa-ops/gather-uninit.tgt.mlir
+++ b/tests/litmus/tosa-ops/gather-uninit.tgt.mlir
@@ -1,4 +1,4 @@
 func.func @test_gather() -> tensor<2x1x1xf32> {
-  %v = linalg.init_tensor [2,1,1]: tensor<2x1x1xf32>
+  %v = tensor.empty (): tensor<2x1x1xf32>
   return %v: tensor<2x1x1xf32>
 }

--- a/tests/litmus/tosa-ops/maxpool2d.src.mlir
+++ b/tests/litmus/tosa-ops/maxpool2d.src.mlir
@@ -2,6 +2,6 @@
 // ARGS: --use-neg-zero
 
 func.func @maxpool(%arg0: tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32> {
-  %0 = "tosa.max_pool2d"(%arg0) {kernel = [7, 7], pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32>
+  %0 = "tosa.max_pool2d"(%arg0) {kernel = array<i64: 7, 7>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32>
   return %0 : tensor<1x1x1x1280xf32>
 }

--- a/tests/litmus/tosa-ops/maxpool2d.src.mlir
+++ b/tests/litmus/tosa-ops/maxpool2d.src.mlir
@@ -2,6 +2,6 @@
 // ARGS: --use-neg-zero
 
 func.func @maxpool(%arg0: tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32> {
-  %0 = "tosa.max_pool2d"(%arg0) {kernel = [7, 7], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32>
+  %0 = "tosa.max_pool2d"(%arg0) {kernel = [7, 7], pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32>
   return %0 : tensor<1x1x1x1280xf32>
 }

--- a/tests/litmus/tosa-ops/maxpool2d.tgt.mlir
+++ b/tests/litmus/tosa-ops/maxpool2d.tgt.mlir
@@ -1,8 +1,8 @@
 func.func @maxpool(%arg0: tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32> {
   %cst = arith.constant -3.40282347E+38 : f32
-  %0 = linalg.init_tensor [1, 1, 1, 1280] : tensor<1x1x1x1280xf32>
+  %0 = tensor.empty () : tensor<1x1x1x1280xf32>
   %1 = linalg.fill ins(%cst: f32) outs(%0: tensor<1x1x1x1280xf32>) -> tensor<1x1x1x1280xf32> 
-  %2 = linalg.init_tensor [7, 7] : tensor<7x7xf32>
+  %2 = tensor.empty () : tensor<7x7xf32>
   %3 = linalg.pooling_nhwc_max {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%arg0, %2 : tensor<1x7x7x1280xf32>, tensor<7x7xf32>) outs(%1 : tensor<1x1x1x1280xf32>) -> tensor<1x1x1x1280xf32>
   return %3 : tensor<1x1x1x1280xf32>
 }

--- a/tests/litmus/tosa-ops/maxpool2d_memref.src.mlir
+++ b/tests/litmus/tosa-ops/maxpool2d_memref.src.mlir
@@ -2,6 +2,6 @@
 // ARGS: --use-neg-zero
 
 func.func @maxpool(%arg0: tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32> {
-  %0 = "tosa.max_pool2d"(%arg0) {kernel = [7, 7], pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32>
+  %0 = "tosa.max_pool2d"(%arg0) {kernel = array<i64: 7, 7>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32>
   return %0 : tensor<1x1x1x1280xf32>
 }

--- a/tests/litmus/tosa-ops/maxpool2d_memref.src.mlir
+++ b/tests/litmus/tosa-ops/maxpool2d_memref.src.mlir
@@ -2,6 +2,6 @@
 // ARGS: --use-neg-zero
 
 func.func @maxpool(%arg0: tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32> {
-  %0 = "tosa.max_pool2d"(%arg0) {kernel = [7, 7], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32>
+  %0 = "tosa.max_pool2d"(%arg0) {kernel = [7, 7], pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x7x7x1280xf32>) -> tensor<1x1x1x1280xf32>
   return %0 : tensor<1x1x1x1280xf32>
 }

--- a/tests/litmus/tosa-ops/maxpool_noop.src.mlir
+++ b/tests/litmus/tosa-ops/maxpool_noop.src.mlir
@@ -1,6 +1,6 @@
 // VERIFY
 
 func.func @max_pool2d_is_noop(%arg0: tensor<10x1x1x3xf32>) -> tensor<10x1x1x3xf32> {
-  %0 = "tosa.max_pool2d"(%arg0) {kernel = [1, 1], pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1>} : (tensor<10x1x1x3xf32>) -> tensor<10x1x1x3xf32>
+  %0 = "tosa.max_pool2d"(%arg0) {kernel = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1>} : (tensor<10x1x1x3xf32>) -> tensor<10x1x1x3xf32>
   return %0 : tensor<10x1x1x3xf32>
 }

--- a/tests/litmus/tosa-ops/maxpool_noop.src.mlir
+++ b/tests/litmus/tosa-ops/maxpool_noop.src.mlir
@@ -1,6 +1,6 @@
 // VERIFY
 
 func.func @max_pool2d_is_noop(%arg0: tensor<10x1x1x3xf32>) -> tensor<10x1x1x3xf32> {
-  %0 = "tosa.max_pool2d"(%arg0) {kernel = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1], dilation = [1, 1]} : (tensor<10x1x1x3xf32>) -> tensor<10x1x1x3xf32>
+  %0 = "tosa.max_pool2d"(%arg0) {kernel = [1, 1], pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1>} : (tensor<10x1x1x3xf32>) -> tensor<10x1x1x3xf32>
   return %0 : tensor<10x1x1x3xf32>
 }

--- a/tests/litmus/tosa-ops/reshape.src.mlir
+++ b/tests/litmus/tosa-ops/reshape.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @f() -> (i32, i32) {
   %t = "tosa.const"() {value = dense<[1, 2, 3, 4]> : tensor<4xi32>} : () -> tensor<4xi32>
-  %t2 = "tosa.reshape"(%t) {new_shape = [2, 2]} : (tensor<4xi32>)  -> tensor<2x2xi32>
+  %t2 = "tosa.reshape"(%t) {new_shape = array<i64: 2, 2>} : (tensor<4xi32>)  -> tensor<2x2xi32>
 	%c0 = arith.constant 0: index
 	%c1 = arith.constant 1: index
 	%two = tensor.extract %t2[%c0,%c1]: tensor<2x2xi32>

--- a/tests/litmus/tosa-ops/tile-bad.src.mlir
+++ b/tests/litmus/tosa-ops/tile-bad.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @f(%x0: tensor<3x3xf32>) -> tensor<6x9xf32> {
   %x = "tosa.reverse"(%x0) {axis = 0: i64}: (tensor<3x3xf32>) -> tensor<3x3xf32>
-  %a = "tosa.tile"(%x) {multiples = [2, 1]} : (tensor<3x3xf32>)  -> (tensor<6x3xf32>)
-  %b = "tosa.tile"(%a) {multiples = [1, 3]} : (tensor<6x3xf32>)  -> (tensor<6x9xf32>)
+  %a = "tosa.tile"(%x) {multiples = array<i64: 2, 1>} : (tensor<3x3xf32>)  -> (tensor<6x3xf32>)
+  %b = "tosa.tile"(%a) {multiples = array<i64: 1, 3>} : (tensor<6x3xf32>)  -> (tensor<6x9xf32>)
   return %b: tensor<6x9xf32>
 }

--- a/tests/litmus/tosa-ops/tile-bad.tgt.mlir
+++ b/tests/litmus/tosa-ops/tile-bad.tgt.mlir
@@ -1,4 +1,4 @@
 func.func @f(%x: tensor<3x3xf32>) -> tensor<6x9xf32> {
-  %a = "tosa.tile"(%x) {multiples = [2, 3]} : (tensor<3x3xf32>)  -> (tensor<6x9xf32>)
+  %a = "tosa.tile"(%x) {multiples = array<i64: 2, 3>} : (tensor<3x3xf32>)  -> (tensor<6x9xf32>)
   return %a: tensor<6x9xf32>
 }

--- a/tests/litmus/tosa-ops/tile.src.mlir
+++ b/tests/litmus/tosa-ops/tile.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func.func @f(%x: tensor<3x3xf32>) -> tensor<6x9xf32> {
-  %a = "tosa.tile"(%x) {multiples = [2, 1]} : (tensor<3x3xf32>)  -> (tensor<6x3xf32>)
-  %b = "tosa.tile"(%a) {multiples = [1, 3]} : (tensor<6x3xf32>)  -> (tensor<6x9xf32>)
+  %a = "tosa.tile"(%x) {multiples = array<i64: 2, 1>} : (tensor<3x3xf32>)  -> (tensor<6x3xf32>)
+  %b = "tosa.tile"(%a) {multiples = array<i64: 1, 3>} : (tensor<6x3xf32>)  -> (tensor<6x9xf32>)
   return %b: tensor<6x9xf32>
 }

--- a/tests/litmus/tosa-ops/tile.tgt.mlir
+++ b/tests/litmus/tosa-ops/tile.tgt.mlir
@@ -1,4 +1,4 @@
 func.func @f(%x: tensor<3x3xf32>) -> tensor<6x9xf32> {
-  %a = "tosa.tile"(%x) {multiples = [2, 3]} : (tensor<3x3xf32>)  -> (tensor<6x9xf32>)
+  %a = "tosa.tile"(%x) {multiples = array<i64: 2, 3>} : (tensor<3x3xf32>)  -> (tensor<6x9xf32>)
   return %a: tensor<6x9xf32>
 }

--- a/tests/litmus/tosa-ops/transpose3.src.mlir
+++ b/tests/litmus/tosa-ops/transpose3.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func.func @conv(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>) -> tensor<1x14x14x16xf32> {
-    %out = linalg.init_tensor [1,14,14,16] : tensor<1x14x14x16xf32>
+    %out = tensor.empty () : tensor<1x14x14x16xf32>
     %0 = linalg.conv_2d_nhwc_hwcf
       {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
        ins(%arg0, %arg1: tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)

--- a/tests/litmus/tosa-ops/transpose3.tgt.mlir
+++ b/tests/litmus/tosa-ops/transpose3.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @conv(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>) -> tensor<1x14x14x16xf32> {
-    %out = linalg.init_tensor [1,16,14,14] : tensor<1x16x14x14xf32>
+    %out = tensor.empty () : tensor<1x16x14x14xf32>
     %inperms = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
     %filperms = "tosa.const"() {value = dense<[3, 2, 0, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
     %outperms = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>

--- a/tests/litmus/verbose/conv2d1.src.mlir
+++ b/tests/litmus/verbose/conv2d1.src.mlir
@@ -4,6 +4,6 @@
 func.func @conv(%img: tensor<1x16x16x4xf32>, %filtr: tensor<16x3x3x4xf32>) -> tensor<1x14x14x16xf32> {
     %c0 = arith.constant 0.0 : f32
     %bias = tensor.from_elements %c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0: tensor<16xf32>
-    %0 = "tosa.conv2d"(%img, %filtr, %bias) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
+    %0 = "tosa.conv2d"(%img, %filtr, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
     return %0 : tensor<1x14x14x16xf32>
 }

--- a/tests/litmus/verbose/conv2d1.src.mlir
+++ b/tests/litmus/verbose/conv2d1.src.mlir
@@ -4,6 +4,6 @@
 func.func @conv(%img: tensor<1x16x16x4xf32>, %filtr: tensor<16x3x3x4xf32>) -> tensor<1x14x14x16xf32> {
     %c0 = arith.constant 0.0 : f32
     %bias = tensor.from_elements %c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0: tensor<16xf32>
-    %0 = "tosa.conv2d"(%img, %filtr, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
+    %0 = "tosa.conv2d"(%img, %filtr, %bias) {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
     return %0 : tensor<1x14x14x16xf32>
 }

--- a/tests/litmus/verbose/conv2d1.tgt.mlir
+++ b/tests/litmus/verbose/conv2d1.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @conv(%img: tensor<1x16x16x4xf32>, %filtr: tensor<16x3x3x4xf32>) -> tensor<1x14x14x16xf32> {
     %c0 = arith.constant 0.0 : f32
     %bias = tensor.from_elements %c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0: tensor<16xf32>
-    %0 = "tosa.conv2d"(%img, %filtr, %bias) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
+    %0 = "tosa.conv2d"(%img, %filtr, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
     return %0 : tensor<1x14x14x16xf32>
 }

--- a/tests/litmus/verbose/conv2d1.tgt.mlir
+++ b/tests/litmus/verbose/conv2d1.tgt.mlir
@@ -1,6 +1,6 @@
 func.func @conv(%img: tensor<1x16x16x4xf32>, %filtr: tensor<16x3x3x4xf32>) -> tensor<1x14x14x16xf32> {
     %c0 = arith.constant 0.0 : f32
     %bias = tensor.from_elements %c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0: tensor<16xf32>
-    %0 = "tosa.conv2d"(%img, %filtr, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
+    %0 = "tosa.conv2d"(%img, %filtr, %bias) {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
     return %0 : tensor<1x14x14x16xf32>
 }

--- a/tests/long-opts/conv2d-to-img2col/nhwc_filter-bad.tgt.mlir
+++ b/tests/long-opts/conv2d-to-img2col/nhwc_filter-bad.tgt.mlir
@@ -2,7 +2,7 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>
 module  {
   func.func @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
-    %0 = linalg.init_tensor [1, 14, 14, 3, 3, 4] : tensor<1x14x14x3x3x4xf32>
+    %0 = tensor.empty () : tensor<1x14x14x3x3x4xf32>
     %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<1x16x16x4xf32>) outs(%0 : tensor<1x14x14x3x3x4xf32>) {
     ^bb0(%arg3: f32, %arg4: f32):  // no predecessors
       linalg.yield %arg3 : f32

--- a/tests/long-opts/conv2d/conv2d2.src.mlir
+++ b/tests/long-opts/conv2d/conv2d2.src.mlir
@@ -7,6 +7,6 @@ func.func @conv(%arg0: tensor<1x29x29x4xf32>, %arg1: tensor<3x3x4x16xf32>) -> te
     %bias = tensor.from_elements %c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0: tensor<16xf32>
     %filperms = "tosa.const"() {value = dense<[3, 0, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
     %arg3 = "tosa.transpose"(%arg1, %filperms) : (tensor<3x3x4x16xf32>, tensor<4xi64>) -> tensor<16x3x3x4xf32>
-    %0 = "tosa.conv2d"(%arg0, %arg3, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [2, 2]} : (tensor<1x29x29x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
+    %0 = "tosa.conv2d"(%arg0, %arg3, %bias) {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 2, 2>} : (tensor<1x29x29x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
     return %0 : tensor<1x14x14x16xf32>
 }

--- a/tests/long-opts/conv2d/conv2d2.src.mlir
+++ b/tests/long-opts/conv2d/conv2d2.src.mlir
@@ -7,6 +7,6 @@ func.func @conv(%arg0: tensor<1x29x29x4xf32>, %arg1: tensor<3x3x4x16xf32>) -> te
     %bias = tensor.from_elements %c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0: tensor<16xf32>
     %filperms = "tosa.const"() {value = dense<[3, 0, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
     %arg3 = "tosa.transpose"(%arg1, %filperms) : (tensor<3x3x4x16xf32>, tensor<4xi64>) -> tensor<16x3x3x4xf32>
-    %0 = "tosa.conv2d"(%arg0, %arg3, %bias) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [2, 2]} : (tensor<1x29x29x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
+    %0 = "tosa.conv2d"(%arg0, %arg3, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [2, 2]} : (tensor<1x29x29x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
     return %0 : tensor<1x14x14x16xf32>
 }

--- a/tests/long-opts/conv2d/conv2d2.tgt.mlir
+++ b/tests/long-opts/conv2d/conv2d2.tgt.mlir
@@ -1,5 +1,5 @@
 func.func @conv(%arg0: tensor<1x29x29x4xf32>, %arg1: tensor<3x3x4x16xf32>) -> tensor<1x14x14x16xf32> {
-    %out = linalg.init_tensor [1,14,14,16] : tensor<1x14x14x16xf32>
+    %out = tensor.empty () : tensor<1x14x14x16xf32>
     %0 = linalg.conv_2d_nhwc_hwcf
       {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64> }
        ins(%arg0, %arg1: tensor<1x29x29x4xf32>, tensor<3x3x4x16xf32>)

--- a/tests/long-opts/tosa-to-linalg/conv2d2.src.mlir
+++ b/tests/long-opts/tosa-to-linalg/conv2d2.src.mlir
@@ -7,6 +7,6 @@
 func.func @conv(%img: tensor<1x29x29x4xf32>, %filter: tensor<16x3x3x4xf32>) -> tensor<1x14x14x16xf32> {
     %c0 = arith.constant 0.0 : f32
     %bias = tensor.from_elements %c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0: tensor<16xf32>
-    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [2, 2]} : (tensor<1x29x29x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
+    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 2, 2>} : (tensor<1x29x29x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
     return %0 : tensor<1x14x14x16xf32>
 }

--- a/tests/long-opts/tosa-to-linalg/conv2d2.src.mlir
+++ b/tests/long-opts/tosa-to-linalg/conv2d2.src.mlir
@@ -7,6 +7,6 @@
 func.func @conv(%img: tensor<1x29x29x4xf32>, %filter: tensor<16x3x3x4xf32>) -> tensor<1x14x14x16xf32> {
     %c0 = arith.constant 0.0 : f32
     %bias = tensor.from_elements %c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0,%c0: tensor<16xf32>
-    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [2, 2]} : (tensor<1x29x29x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
+    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = array<i64: 1, 1>, pad = [0, 0, 0, 0], stride = [2, 2]} : (tensor<1x29x29x4xf32>, tensor<16x3x3x4xf32>, tensor<16xf32>) -> tensor<1x14x14x16xf32>
     return %0 : tensor<1x14x14x16xf32>
 }

--- a/tests/long-opts/tosa-to-linalg/conv2d2.tgt.mlir
+++ b/tests/long-opts/tosa-to-linalg/conv2d2.tgt.mlir
@@ -6,15 +6,15 @@ module  {
     %cst = arith.constant 0.000000e+00 : f32
     %0 = tensor.from_elements %cst, %cst, %cst, %cst, %cst, %cst, %cst, %cst, %cst, %cst, %cst, %cst, %cst, %cst, %cst, %cst : tensor<16xf32>
     %cst_0 = arith.constant dense<[1, 2, 3, 0]> : tensor<4xi64>
-    %1 = linalg.init_tensor [3, 3, 4, 16] : tensor<3x3x4x16xf32>
+    %1 = tensor.empty () : tensor<3x3x4x16xf32>
     %2 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg1 : tensor<16x3x3x4xf32>) outs(%1 : tensor<3x3x4x16xf32>) {
     ^bb0(%arg2: f32, %arg3: f32):  // no predecessors
       linalg.yield %arg2 : f32
     } -> tensor<3x3x4x16xf32>
-    %3 = linalg.init_tensor [1, 14, 14, 16] : tensor<1x14x14x16xf32>
+    %3 = tensor.empty () : tensor<1x14x14x16xf32>
     %cst_1 = arith.constant 0.000000e+00 : f32
     %4 = linalg.fill ins(%cst_1: f32) outs(%3: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> 
-    %5 = linalg.init_tensor [1, 14, 14, 16] : tensor<1x14x14x16xf32>
+    %5 = tensor.empty () : tensor<1x14x14x16xf32>
     %6 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %2 : tensor<1x29x29x4xf32>, tensor<3x3x4x16xf32>) outs(%4 : tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
     %7 = linalg.generic {indexing_maps = [#map2, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %6 : tensor<16xf32>, tensor<1x14x14x16xf32>) outs(%5 : tensor<1x14x14x16xf32>) {
     ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):  // no predecessors

--- a/tests/long-opts/tosa-to-linalg/conv_pad.src.mlir
+++ b/tests/long-opts/tosa-to-linalg/conv_pad.src.mlir
@@ -5,6 +5,6 @@
 // tgt is filling a non-identity value (+0.0) to the output tensor.
 
 func.func @conv(%arg0: tensor<2x4x4x3xf32>, %arg1: tensor<16x3x6x3xf32>, %arg2: tensor<16xf32>) -> tensor<2x6x9x16xf32> {
-    %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = array<i64: 1, 1>, pad = [2, 2, 5, 5], stride = [1, 1]} : (tensor<2x4x4x3xf32>, tensor<16x3x6x3xf32>, tensor<16xf32>) -> tensor<2x6x9x16xf32>
+    %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = array<i64: 1, 1>, pad = array<i64: 2, 2, 5, 5>, stride = array<i64: 1, 1>} : (tensor<2x4x4x3xf32>, tensor<16x3x6x3xf32>, tensor<16xf32>) -> tensor<2x6x9x16xf32>
     return %0 : tensor<2x6x9x16xf32>
 }

--- a/tests/long-opts/tosa-to-linalg/conv_pad.src.mlir
+++ b/tests/long-opts/tosa-to-linalg/conv_pad.src.mlir
@@ -5,6 +5,6 @@
 // tgt is filling a non-identity value (+0.0) to the output tensor.
 
 func.func @conv(%arg0: tensor<2x4x4x3xf32>, %arg1: tensor<16x3x6x3xf32>, %arg2: tensor<16xf32>) -> tensor<2x6x9x16xf32> {
-    %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [2, 2, 5, 5], stride = [1, 1]} : (tensor<2x4x4x3xf32>, tensor<16x3x6x3xf32>, tensor<16xf32>) -> tensor<2x6x9x16xf32>
+    %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = array<i64: 1, 1>, pad = [2, 2, 5, 5], stride = [1, 1]} : (tensor<2x4x4x3xf32>, tensor<16x3x6x3xf32>, tensor<16xf32>) -> tensor<2x6x9x16xf32>
     return %0 : tensor<2x6x9x16xf32>
 }

--- a/tests/long-opts/tosa-to-linalg/conv_pad.tgt.mlir
+++ b/tests/long-opts/tosa-to-linalg/conv_pad.tgt.mlir
@@ -9,15 +9,15 @@ module  {
       tensor.yield %cst : f32
     } : tensor<2x4x4x3xf32> to tensor<2x8x14x3xf32>
     %cst_0 = arith.constant dense<[1, 2, 3, 0]> : tensor<4xi64>
-    %1 = linalg.init_tensor [3, 6, 3, 16] : tensor<3x6x3x16xf32>
+    %1 = tensor.empty () : tensor<3x6x3x16xf32>
     %2 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg1 : tensor<16x3x6x3xf32>) outs(%1 : tensor<3x6x3x16xf32>) {
     ^bb0(%arg3: f32, %arg4: f32):  // no predecessors
       linalg.yield %arg3 : f32
     } -> tensor<3x6x3x16xf32>
-    %3 = linalg.init_tensor [2, 6, 9, 16] : tensor<2x6x9x16xf32>
+    %3 = tensor.empty () : tensor<2x6x9x16xf32>
     %cst_1 = arith.constant 0.000000e+00 : f32
     %4 = linalg.fill ins(%cst_1: f32) outs(%3: tensor<2x6x9x16xf32>) -> tensor<2x6x9x16xf32> 
-    %5 = linalg.init_tensor [2, 6, 9, 16] : tensor<2x6x9x16xf32>
+    %5 = tensor.empty () : tensor<2x6x9x16xf32>
     %6 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%0, %2 : tensor<2x8x14x3xf32>, tensor<3x6x3x16xf32>) outs(%4 : tensor<2x6x9x16xf32>) -> tensor<2x6x9x16xf32>
     %7 = linalg.generic {indexing_maps = [#map2, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg2, %6 : tensor<16xf32>, tensor<2x6x9x16xf32>) outs(%5 : tensor<2x6x9x16xf32>) {
     ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors

--- a/tests/long-opts/tosa-to-linalg/depthwise2.src.mlir
+++ b/tests/long-opts/tosa-to-linalg/depthwise2.src.mlir
@@ -5,6 +5,6 @@
 // filling a non-identity value (+0.0) to the output tensor.
 
 func.func @depthwise2(%arg0: tensor<2x5x5x2xf32>, %arg1: tensor<2x2x2x3xf32>, %arg2: tensor<6xf32>) -> tensor<2x6x6x6xf32> {
-  %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) {pad = [1, 1, 1, 1], stride = [1, 1], dilation = [1, 1]} : (tensor<2x5x5x2xf32>, tensor<2x2x2x3xf32>, tensor<6xf32>) -> tensor<2x6x6x6xf32>
+  %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) {pad = array<i64: 1, 1, 1, 1>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1>} : (tensor<2x5x5x2xf32>, tensor<2x2x2x3xf32>, tensor<6xf32>) -> tensor<2x6x6x6xf32>
   return %0 : tensor<2x6x6x6xf32>
 }

--- a/tests/long-opts/tosa-to-linalg/depthwise2.tgt.mlir
+++ b/tests/long-opts/tosa-to-linalg/depthwise2.tgt.mlir
@@ -7,10 +7,10 @@ module  {
     ^bb0(%arg3: index, %arg4: index, %arg5: index, %arg6: index):  // no predecessors
       tensor.yield %cst : f32
     } : tensor<2x5x5x2xf32> to tensor<2x7x7x2xf32>
-    %1 = linalg.init_tensor [2, 6, 6, 2, 3] : tensor<2x6x6x2x3xf32>
+    %1 = tensor.empty () : tensor<2x6x6x2x3xf32>
     %cst_0 = arith.constant 0.000000e+00 : f32
     %2 = linalg.fill ins(%cst_0: f32) outs(%1: tensor<2x6x6x2x3xf32>) -> tensor<2x6x6x2x3xf32> 
-    %3 = linalg.init_tensor [2, 6, 6, 6] : tensor<2x6x6x6xf32>
+    %3 = tensor.empty () : tensor<2x6x6x6xf32>
     %4 = linalg.depthwise_conv_2d_nhwc_hwcm {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%0, %arg1 : tensor<2x7x7x2xf32>, tensor<2x2x2x3xf32>) outs(%2 : tensor<2x6x6x2x3xf32>) -> tensor<2x6x6x2x3xf32>
     %5 = tensor.collapse_shape %4 [[0], [1], [2], [3, 4]] : tensor<2x6x6x2x3xf32> into tensor<2x6x6x6xf32>
     %6 = linalg.generic {indexing_maps = [#map0, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg2, %5 : tensor<6xf32>, tensor<2x6x6x6xf32>) outs(%3 : tensor<2x6x6x6xf32>) {

--- a/tests/opts/conv2d-to-img2col/nhwc_filter.tgt.mlir
+++ b/tests/opts/conv2d-to-img2col/nhwc_filter.tgt.mlir
@@ -2,7 +2,7 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>
 module  {
   func.func @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
-    %0 = linalg.init_tensor [1, 14, 14, 3, 3, 4] : tensor<1x14x14x3x3x4xf32>
+    %0 = tensor.empty () : tensor<1x14x14x3x3x4xf32>
     %1 = linalg.generic {indexing_maps = [#map0, #map1],
                          iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]}
        ins(%arg0 : tensor<1x16x16x4xf32>)

--- a/tests/opts/fusion-tensor/const-bad.src.mlir
+++ b/tests/opts/fusion-tensor/const-bad.src.mlir
@@ -10,7 +10,7 @@ func.func @generic_op_constant_fusion(%arg0 : tensor<5x?x?xf32>) -> tensor<5x?x?
   %cst = arith.constant dense<42.0> : tensor<5xf32>
   %0 = tensor.dim %arg0, %c1 : tensor<5x?x?xf32>
   %1 = tensor.dim %arg0, %c2 : tensor<5x?x?xf32>
-  %2 = linalg.init_tensor [5, %0, %1] : tensor<5x?x?xf32>
+  %2 = tensor.empty (%0, %1) : tensor<5x?x?xf32>
   %3 = linalg.generic {
     indexing_maps = [#map0, #map1, #map1],
     iterator_types = ["parallel", "parallel", "parallel"]}

--- a/tests/opts/fusion-tensor/const-bad.tgt.mlir
+++ b/tests/opts/fusion-tensor/const-bad.tgt.mlir
@@ -6,7 +6,7 @@ module  {
     %cst = arith.constant 5.200000e+01 : f32 // wrong constant
     %0 = tensor.dim %arg0, %c1 : tensor<5x?x?xf32>
     %1 = tensor.dim %arg0, %c2 : tensor<5x?x?xf32>
-    %2 = linalg.init_tensor [5, %0, %1] : tensor<5x?x?xf32>
+    %2 = tensor.empty (%0, %1) : tensor<5x?x?xf32>
     %3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0 : tensor<5x?x?xf32>) outs(%2 : tensor<5x?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
       %4 = arith.mulf %cst, %arg1 : f32

--- a/tests/opts/fusion-tensor/const.src.mlir
+++ b/tests/opts/fusion-tensor/const.src.mlir
@@ -10,7 +10,7 @@ func.func @generic_op_constant_fusion(%arg0 : tensor<5x?x?xf32>) -> tensor<5x?x?
   %cst = arith.constant dense<42.0> : tensor<5xf32>
   %0 = tensor.dim %arg0, %c1 : tensor<5x?x?xf32>
   %1 = tensor.dim %arg0, %c2 : tensor<5x?x?xf32>
-  %2 = linalg.init_tensor [5, %0, %1] : tensor<5x?x?xf32>
+  %2 = tensor.empty (%0, %1) : tensor<5x?x?xf32>
   %3 = linalg.generic {
     indexing_maps = [#map0, #map1, #map1],
     iterator_types = ["parallel", "parallel", "parallel"]}

--- a/tests/opts/fusion-tensor/const.tgt.mlir
+++ b/tests/opts/fusion-tensor/const.tgt.mlir
@@ -6,7 +6,7 @@ module  {
     %cst = arith.constant 4.200000e+01 : f32
     %0 = tensor.dim %arg0, %c1 : tensor<5x?x?xf32>
     %1 = tensor.dim %arg0, %c2 : tensor<5x?x?xf32>
-    %2 = linalg.init_tensor [5, %0, %1] : tensor<5x?x?xf32>
+    %2 = tensor.empty (%0, %1) : tensor<5x?x?xf32>
     %3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0 : tensor<5x?x?xf32>) outs(%2 : tensor<5x?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
       %4 = arith.mulf %cst, %arg1 : f32

--- a/tests/opts/fusion-tensor/i32-bad.src.mlir
+++ b/tests/opts/fusion-tensor/i32-bad.src.mlir
@@ -7,7 +7,7 @@ func.func @producer_indexed_consumer_fusion(%arg0: tensor<?x?xi32>,
   %c1 = arith.constant 1 : index
   %0 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
   %1 = tensor.dim %arg0, %c1 : tensor<?x?xi32>
-  %2 = linalg.init_tensor [%0, %1] : tensor<?x?xi32>
+  %2 = tensor.empty (%0, %1) : tensor<?x?xi32>
   %3 = linalg.generic {
     indexing_maps = [#map0, #map0, #map0],
     iterator_types = ["parallel", "parallel"] }

--- a/tests/opts/fusion-tensor/i32-bad.tgt.mlir
+++ b/tests/opts/fusion-tensor/i32-bad.tgt.mlir
@@ -5,7 +5,7 @@ module  {
     %c1 = arith.constant 1 : index
     %0 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
     %1 = tensor.dim %arg0, %c1 : tensor<?x?xi32>
-    %2 = linalg.init_tensor [%0, %1] : tensor<?x?xi32>
+    %2 = tensor.empty (%0, %1) : tensor<?x?xi32>
     %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<?x?xi32>, tensor<?x?xi32>) outs(%2 : tensor<?x?xi32>) {
     ^bb0(%arg2: i32, %arg3: i32, %arg4: i32):  // no predecessors
       %4 = arith.addi %arg2, %arg3 : i32

--- a/tests/opts/fusion-tensor/i32.src.mlir
+++ b/tests/opts/fusion-tensor/i32.src.mlir
@@ -8,7 +8,7 @@ func.func @producer_indexed_consumer_fusion(%arg0: tensor<?x?xi32>,
   %c1 = arith.constant 1 : index
   %0 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
   %1 = tensor.dim %arg0, %c1 : tensor<?x?xi32>
-  %2 = linalg.init_tensor [%0, %1] : tensor<?x?xi32>
+  %2 = tensor.empty (%0, %1) : tensor<?x?xi32>
   %3 = linalg.generic {
     indexing_maps = [#map0, #map0, #map0],
     iterator_types = ["parallel", "parallel"] }

--- a/tests/opts/fusion-tensor/i32.tgt.mlir
+++ b/tests/opts/fusion-tensor/i32.tgt.mlir
@@ -5,7 +5,7 @@ module  {
     %c1 = arith.constant 1 : index
     %0 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
     %1 = tensor.dim %arg0, %c1 : tensor<?x?xi32>
-    %2 = linalg.init_tensor [%0, %1] : tensor<?x?xi32>
+    %2 = tensor.empty (%0, %1) : tensor<?x?xi32>
     %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<?x?xi32>, tensor<?x?xi32>) outs(%2 : tensor<?x?xi32>) {
     ^bb0(%arg2: i32, %arg3: i32, %arg4: i32):  // no predecessors
       %4 = arith.addi %arg2, %arg3 : i32

--- a/tests/opts/fusion-tensor/nontensor-bad.src.mlir
+++ b/tests/opts/fusion-tensor/nontensor-bad.src.mlir
@@ -9,7 +9,7 @@ func.func @scalar_add_mul_fusion(%arg0: tensor<?x?xf32>, %arg1 : f32, %arg2 : f3
   %c1 = arith.constant 1 : index
   %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-  %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+  %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
   %3 = linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel"]}
       ins(%arg0, %arg1 : tensor<?x?xf32>, f32)
       outs(%2 : tensor<?x?xf32>) {

--- a/tests/opts/fusion-tensor/nontensor-bad.tgt.mlir
+++ b/tests/opts/fusion-tensor/nontensor-bad.tgt.mlir
@@ -7,7 +7,7 @@ module  {
     %cf1 = arith.constant 1.0 : f32
     %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-    %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+    %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
     %3 = linalg.generic {indexing_maps = [#map0, #map1, #map1, #map0], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1, %arg2 : tensor<?x?xf32>, f32, f32) outs(%2 : tensor<?x?xf32>) {
     ^bb0(%arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32):  // no predecessors
       %4 = arith.addf %arg3, %arg4 : f32

--- a/tests/opts/fusion-tensor/nontensor.src.mlir
+++ b/tests/opts/fusion-tensor/nontensor.src.mlir
@@ -10,7 +10,7 @@ func.func @scalar_add_mul_fusion(%arg0: tensor<?x?xf32>, %arg1 : f32, %arg2 : f3
   %c1 = arith.constant 1 : index
   %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-  %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+  %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
   %3 = linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel"]}
       ins(%arg0, %arg1 : tensor<?x?xf32>, f32)
       outs(%2 : tensor<?x?xf32>) {

--- a/tests/opts/fusion-tensor/nontensor.tgt.mlir
+++ b/tests/opts/fusion-tensor/nontensor.tgt.mlir
@@ -6,7 +6,7 @@ module  {
     %c1 = arith.constant 1 : index
     %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-    %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+    %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
     %3 = linalg.generic {indexing_maps = [#map0, #map1, #map1, #map0], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1, %arg2 : tensor<?x?xf32>, f32, f32) outs(%2 : tensor<?x?xf32>) {
     ^bb0(%arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32):  // no predecessors
       %4 = arith.addf %arg3, %arg4 : f32

--- a/tests/opts/fusion-tensor/simple-bad.src.mlir
+++ b/tests/opts/fusion-tensor/simple-bad.src.mlir
@@ -8,7 +8,7 @@ func.func @add_mul_fusion(%arg0: tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2
   %c1 = arith.constant 1 : index
   %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-  %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+  %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
   %3 = linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]}
       ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
       outs(%2 : tensor<?x?xf32>) {

--- a/tests/opts/fusion-tensor/simple-bad.tgt.mlir
+++ b/tests/opts/fusion-tensor/simple-bad.tgt.mlir
@@ -4,7 +4,7 @@ func.func @add_mul_fusion(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %arg2:
   %c1 = arith.constant 1 : index
   %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   %1 = tensor.dim %arg0, %c0 : tensor<?x?xf32> // wrong arith.constant
-  %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+  %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
   %3 = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1, %arg2 : tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) outs(%2 : tensor<?x?xf32>) {
   ^bb0(%arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32):  // no predecessors
     %4 = arith.addf %arg3, %arg4 : f32

--- a/tests/opts/fusion-tensor/simple.src.mlir
+++ b/tests/opts/fusion-tensor/simple.src.mlir
@@ -9,7 +9,7 @@ func.func @add_mul_fusion(%arg0: tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2
   %c1 = arith.constant 1 : index
   %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-  %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+  %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
   %3 = linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]}
       ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
       outs(%2 : tensor<?x?xf32>) {

--- a/tests/opts/fusion-tensor/simple.tgt.mlir
+++ b/tests/opts/fusion-tensor/simple.tgt.mlir
@@ -4,7 +4,7 @@ func.func @add_mul_fusion(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %arg2:
   %c1 = arith.constant 1 : index
   %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-  %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+  %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
   %3 = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1, %arg2 : tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) outs(%2 : tensor<?x?xf32>) {
   ^bb0(%arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32):  // no predecessors
     %4 = arith.addf %arg3, %arg4 : f32

--- a/tests/opts/fusion-tensor/sum.src.mlir
+++ b/tests/opts/fusion-tensor/sum.src.mlir
@@ -6,7 +6,7 @@
 func.func @consumer_with_reduction(%arg0: tensor<1x10xf32>,
                               %arg1: tensor<1x10xf32>,
                               %arg2: tensor<1xf32>) -> tensor<1xf32> {
-  %init = linalg.init_tensor [1, 10] : tensor<1x10xf32>
+  %init = tensor.empty () : tensor<1x10xf32>
   %0 = linalg.generic
     {indexing_maps = [#map0, #map0, #map0],
      iterator_types = ["parallel", "parallel"]}

--- a/tests/opts/fusion-tensor/sum_comm.src.mlir
+++ b/tests/opts/fusion-tensor/sum_comm.src.mlir
@@ -6,7 +6,7 @@
 func.func @consumer_with_reduction(%arg0: tensor<1x10xf32>,
                               %arg1: tensor<1x10xf32>,
                               %arg2: tensor<1xf32>) -> tensor<1xf32> {
-  %init = linalg.init_tensor [1, 10] : tensor<1x10xf32>
+  %init = tensor.empty () : tensor<1x10xf32>
   %0 = linalg.generic
     {indexing_maps = [#map0, #map0, #map0],
      iterator_types = ["parallel", "parallel"]}

--- a/tests/opts/fusion-tensor/tensor_extract.src.mlir
+++ b/tests/opts/fusion-tensor/tensor_extract.src.mlir
@@ -6,7 +6,7 @@ func.func @sigmoid_dynamic_dim(%0: tensor<?x1xf32>) -> tensor<?x1xf32> {
   %shape = shape.shape_of %0 : tensor<?x1xf32> -> tensor<?xindex>
   %extend = shape.to_extent_tensor %shape : tensor<?xindex> -> tensor<2xindex>
   %extracted = tensor.extract %extend[%c0] : tensor<2xindex>
-  %init0 = linalg.init_tensor [%extracted, 1] : tensor<?x1xf32>
+  %init0 = tensor.empty (%extracted) : tensor<?x1xf32>
   %1 = linalg.generic {indexing_maps = [
     affine_map<(d0, d1) -> (d0, d1)>],
     iterator_types = ["parallel", "parallel"]
@@ -16,7 +16,7 @@ func.func @sigmoid_dynamic_dim(%0: tensor<?x1xf32>) -> tensor<?x1xf32> {
       linalg.yield %cp5 : f32
   } -> tensor<?x1xf32>
   %d0 = tensor.dim %0, %c0 : tensor<?x1xf32>
-  %init1 = linalg.init_tensor [%d0, 1] : tensor<?x1xf32>
+  %init1 = tensor.empty (%d0) : tensor<?x1xf32>
   %2 = linalg.generic {indexing_maps = [
     affine_map<(d0, d1) -> (d0, d1)>,
     affine_map<(d0, d1) -> (d0, d1)>,

--- a/tests/opts/fusion-tensor/tensor_extract.tgt.mlir
+++ b/tests/opts/fusion-tensor/tensor_extract.tgt.mlir
@@ -4,7 +4,7 @@ module  {
     %cst = arith.constant 5.000000e-01 : f32
     %c0 = arith.constant 0 : index
     %0 = tensor.dim %arg0, %c0 : tensor<?x1xf32>
-    %1 = linalg.init_tensor [%0, 1] : tensor<?x1xf32>
+    %1 = tensor.empty (%0) : tensor<?x1xf32>
     %2 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<?x1xf32>) outs(%1 : tensor<?x1xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
       %3 = arith.mulf %arg1, %cst : f32

--- a/tests/opts/fusion-tensor/transpose-bad.src.mlir
+++ b/tests/opts/fusion-tensor/transpose-bad.src.mlir
@@ -9,7 +9,7 @@ func.func @transpose_add_mul_fusion(%arg0: tensor<?x?xf32>, %arg1 : tensor<?x?xf
   %c1 = arith.constant 1 : index
   %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-  %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+  %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
   %3 = linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel"]}
       ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
       outs(%2 : tensor<?x?xf32>) {

--- a/tests/opts/fusion-tensor/transpose-bad.tgt.mlir
+++ b/tests/opts/fusion-tensor/transpose-bad.tgt.mlir
@@ -6,7 +6,7 @@ module  {
     %c1 = arith.constant 1 : index
     %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-    %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+    %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
     %3 = linalg.generic {indexing_maps = [#map0, #map1, #map0, #map0],
                          iterator_types = ["parallel", "parallel"]}
         ins(%arg0, %arg1, %arg2 : tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>)

--- a/tests/opts/fusion-tensor/transpose.src.mlir
+++ b/tests/opts/fusion-tensor/transpose.src.mlir
@@ -10,7 +10,7 @@ func.func @transpose_add_mul_fusion(%arg0: tensor<?x?xf32>, %arg1 : tensor<?x?xf
   %c1 = arith.constant 1 : index
   %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-  %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+  %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
   %3 = linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel"]}
       ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
       outs(%2 : tensor<?x?xf32>) {

--- a/tests/opts/fusion-tensor/transpose.tgt.mlir
+++ b/tests/opts/fusion-tensor/transpose.tgt.mlir
@@ -6,7 +6,7 @@ module  {
     %c1 = arith.constant 1 : index
     %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-    %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+    %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
     %3 = linalg.generic {indexing_maps = [#map0, #map1, #map0, #map0], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1, %arg2 : tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) outs(%2 : tensor<?x?xf32>) {
     ^bb0(%arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32):  // no predecessors
       %4 = arith.addf %arg3, %arg4 : f32

--- a/tests/opts/fusion-tensor/zerodim.src.mlir
+++ b/tests/opts/fusion-tensor/zerodim.src.mlir
@@ -4,7 +4,7 @@
 
 func.func @add_mul_scalar_fusion(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<f32>
 {
-  %0 = linalg.init_tensor [] : tensor<f32>
+  %0 = tensor.empty () : tensor<f32>
   %1 = linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = []}
       ins(%arg0, %arg1 : tensor<f32>, tensor<f32>)
       outs(%0 : tensor<f32>) {

--- a/tests/opts/fusion-tensor/zerodim.tgt.mlir
+++ b/tests/opts/fusion-tensor/zerodim.tgt.mlir
@@ -1,7 +1,7 @@
 #map = affine_map<() -> ()>
 module  {
   func.func @add_mul_scalar_fusion(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> tensor<f32> {
-    %0 = linalg.init_tensor [] : tensor<f32>
+    %0 = tensor.empty () : tensor<f32>
     %1 = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = []} ins(%arg0, %arg1, %arg2 : tensor<f32>, tensor<f32>, tensor<f32>) outs(%0 : tensor<f32>) {
     ^bb0(%arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32):  // no predecessors
       %2 = arith.addf %arg3, %arg4 : f32

--- a/tests/opts/linalg-bufferize/depthwise1.src.mlir
+++ b/tests/opts/linalg-bufferize/depthwise1.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func.func @depthwise1(%arg0: tensor<2x5x5x2xf32>, %arg1: tensor<2x2x2x3xf32>) -> tensor<2x4x4x2x3xf32> {
-  %0 = linalg.init_tensor [2, 4, 4, 2, 3] : tensor<2x4x4x2x3xf32>
+  %0 = tensor.empty () : tensor<2x4x4x2x3xf32>
   %cst = arith.constant 0.000000e+00 : f32
   %1 = linalg.fill ins(%cst: f32) outs(%0: tensor<2x4x4x2x3xf32>) -> tensor<2x4x4x2x3xf32> 
   %2 = linalg.depthwise_conv_2d_nhwc_hwcm {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<2x5x5x2xf32>, tensor<2x2x2x3xf32>) outs(%1 : tensor<2x4x4x2x3xf32>) -> tensor<2x4x4x2x3xf32>

--- a/tests/opts/linalg-bufferize/depthwise2.src.mlir
+++ b/tests/opts/linalg-bufferize/depthwise2.src.mlir
@@ -1,7 +1,7 @@
 // VERIFY
 
 func.func @depthwise2(%arg0: tensor<1x11x9x3xf32>, %arg1: tensor<3x1x3x11xf32>) -> tensor<1x5x5x3x11xf32> {
-  %0 = linalg.init_tensor [1, 5, 5, 3, 11] : tensor<1x5x5x3x11xf32>
+  %0 = tensor.empty () : tensor<1x5x5x3x11xf32>
   %cst = arith.constant 0.000000e+00 : f32
   %1 = linalg.fill ins(%cst: f32) outs(%0: tensor<1x5x5x3x11xf32>) -> tensor<1x5x5x3x11xf32> 
   %2 = linalg.depthwise_conv_2d_nhwc_hwcm {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x11x9x3xf32>, tensor<3x1x3x11xf32>) outs(%1 : tensor<1x5x5x3x11xf32>) -> tensor<1x5x5x3x11xf32>

--- a/tests/opts/linalg-fold-unit-extent-dims/drop-unit-extent-dims.src.mlir
+++ b/tests/opts/linalg-fold-unit-extent-dims/drop-unit-extent-dims.src.mlir
@@ -2,7 +2,7 @@
 
 func.func @unit_dim_for_both_reduction(%arg0: tensor<1x?x1x1xf32>) -> tensor<1x1xf32> {
   %cst = arith.constant 1.000000e+00 : f32
-  %1 = linalg.init_tensor [1, 1] : tensor<1x1xf32>
+  %1 = tensor.empty () : tensor<1x1xf32>
   %2 = linalg.fill ins(%cst: f32) outs(%1: tensor<1x1xf32>) -> tensor<1x1xf32>
   %3 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,

--- a/tests/opts/linalg-fold-unit-extent-dims/drop-unit-extent-dims.tgt.mlir
+++ b/tests/opts/linalg-fold-unit-extent-dims/drop-unit-extent-dims.tgt.mlir
@@ -3,7 +3,7 @@ module  {
   func.func @unit_dim_for_both_reduction(%arg0: tensor<1x?x1x1xf32>) -> tensor<1x1xf32> {
     %cst = arith.constant 1.000000e+00 : f32
     %0 = tensor.collapse_shape %arg0 [[0, 1, 2, 3]] : tensor<1x?x1x1xf32> into tensor<?xf32>
-    %1 = linalg.init_tensor [1] : tensor<1xf32>
+    %1 = tensor.empty () : tensor<1xf32>
     %2 = linalg.fill ins(%cst: f32) outs(%1: tensor<1xf32>) -> tensor<1xf32> 
     %3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%0 : tensor<?xf32>) outs(%2 : tensor<1xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors

--- a/tests/opts/linalg-fold-unit-extent-dims/one-trip-loop.src.mlir
+++ b/tests/opts/linalg-fold-unit-extent-dims/one-trip-loop.src.mlir
@@ -4,7 +4,7 @@
 
 func.func @f(%arg0: tensor<1x?x1x1xi32>) -> tensor<1x1xi32> {
   %cst = arith.constant 1 : i32
-  %init_tensor = linalg.init_tensor [1, 1] : tensor<1x1xi32>
+  %init_tensor = tensor.empty () : tensor<1x1xi32>
   %filled = linalg.fill ins(%cst: i32) outs(%init_tensor: tensor<1x1xi32>) -> tensor<1x1xi32>
   %res = linalg.generic {
     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,

--- a/tests/opts/linalg-fold-unit-extent-dims/one-trip-loop.tgt.mlir
+++ b/tests/opts/linalg-fold-unit-extent-dims/one-trip-loop.tgt.mlir
@@ -3,7 +3,7 @@ module  {
   func.func @f(%arg0: tensor<1x?x1x1xi32>) -> tensor<1x1xi32> {
     %cst = arith.constant 1 : i32
     %0 = tensor.collapse_shape %arg0 [[0, 1, 2, 3]] : tensor<1x?x1x1xi32> into tensor<?xi32>
-    %1 = linalg.init_tensor [1] : tensor<1xi32>
+    %1 = tensor.empty () : tensor<1xi32>
     %2 = linalg.fill ins(%cst: i32) outs(%1: tensor<1xi32>) -> tensor<1xi32> 
     %3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%0 : tensor<?xi32>) outs(%2 : tensor<1xi32>) {
     ^bb0(%arg1: i32, %arg2: i32):  // no predecessors

--- a/tests/opts/tosa-make-broadcastable/broadcast1.tgt.mlir
+++ b/tests/opts/tosa-make-broadcastable/broadcast1.tgt.mlir
@@ -1,6 +1,6 @@
 module  {
   func.func @broadcast(%arg0: tensor<17x16x15x14xf32>, %arg1: tensor<15x1xf32>) -> tensor<17x16x15x14xf32> {
-    %0 = "tosa.reshape"(%arg1) {new_shape = [1, 1, 15, 1]} : (tensor<15x1xf32>) -> tensor<1x1x15x1xf32>
+    %0 = "tosa.reshape"(%arg1) {new_shape = array<i64: 1, 1, 15, 1>} : (tensor<15x1xf32>) -> tensor<1x1x15x1xf32>
     %1 = "tosa.add"(%arg0, %0) : (tensor<17x16x15x14xf32>, tensor<1x1x15x1xf32>) -> tensor<17x16x15x14xf32>
     return %1 : tensor<17x16x15x14xf32>
   }

--- a/tests/opts/tosa-to-linalg/abs.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/abs.tgt.mlir
@@ -3,7 +3,7 @@ module  {
   func.func @test_abs(%arg0: tensor<?xf32>) -> tensor<?xf32> {
 		%c0 = arith.constant 0: index
     %sz = tensor.dim %arg0, %c0: tensor<?xf32>
-    %0 = linalg.init_tensor [%sz] : tensor<?xf32>
+    %0 = tensor.empty (%sz) : tensor<?xf32>
     %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]}
 			ins(%arg0 : tensor<?xf32>) outs(%0 : tensor<?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors

--- a/tests/opts/tosa-to-linalg/add.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/add.tgt.mlir
@@ -5,7 +5,7 @@ module  {
     %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %c1 = arith.constant 1 : index
     %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-    %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+    %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
     %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%2 : tensor<?x?xf32>) {
     ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):  // no predecessors
       %4 = arith.addf %arg2, %arg3 : f32

--- a/tests/opts/tosa-to-linalg/clamp.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/clamp.tgt.mlir
@@ -5,7 +5,7 @@ module  {
     %0 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
     %c1 = arith.constant 1 : index
     %1 = tensor.dim %arg0, %c1 : tensor<?x?xi32>
-    %2 = linalg.init_tensor [%0, %1] : tensor<?x?xi32>
+    %2 = tensor.empty (%0, %1) : tensor<?x?xi32>
     %3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<?x?xi32>) outs(%2 : tensor<?x?xi32>) {
     ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
       %c-127_i32 = arith.constant -127 : i32
@@ -23,7 +23,7 @@ module  {
     %0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %c1 = arith.constant 1 : index
     %1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-    %2 = linalg.init_tensor [%0, %1] : tensor<?x?xf32>
+    %2 = tensor.empty (%0, %1) : tensor<?x?xf32>
     %3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<?x?xf32>) outs(%2 : tensor<?x?xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
       %cst = arith.constant 1.000000e+00 : f32

--- a/tests/opts/tosa-to-linalg/concat.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/concat.tgt.mlir
@@ -11,7 +11,7 @@ module  {
     %c4 = arith.constant 4 : index
     %c5 = arith.constant 5 : index
     %c9 = arith.constant 9 : index
-    %0 = linalg.init_tensor [9, 2] : tensor<9x2xf32>
+    %0 = tensor.empty () : tensor<9x2xf32>
     %cst = arith.constant 0.000000e+00 : f32
     %1 = linalg.fill ins(%cst: f32) outs(%0: tensor<9x2xf32>) -> tensor<9x2xf32> 
     %c1_4 = arith.constant 1 : index

--- a/tests/opts/tosa-to-linalg/conv2d1.src.mlir
+++ b/tests/opts/tosa-to-linalg/conv2d1.src.mlir
@@ -7,6 +7,6 @@
 func.func @conv(%img: tensor<1x2x2x2xf32>, %filter: tensor<1x2x2x2xf32>) -> tensor<1x1x1x1xf32> {
     %c0 = arith.constant -0.0 : f32
     %bias = tensor.from_elements %c0: tensor<1xf32>
-    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = array<i64:1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x2x2x2xf32>, tensor<1x2x2x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
+    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = array<i64:1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x2x2x2xf32>, tensor<1x2x2x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
     return %0 : tensor<1x1x1x1xf32>
 }

--- a/tests/opts/tosa-to-linalg/conv2d1.src.mlir
+++ b/tests/opts/tosa-to-linalg/conv2d1.src.mlir
@@ -7,6 +7,6 @@
 func.func @conv(%img: tensor<1x2x2x2xf32>, %filter: tensor<1x2x2x2xf32>) -> tensor<1x1x1x1xf32> {
     %c0 = arith.constant -0.0 : f32
     %bias = tensor.from_elements %c0: tensor<1xf32>
-    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x2x2x2xf32>, tensor<1x2x2x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
+    %0 = "tosa.conv2d"(%img, %filter, %bias) {dilation = array<i64:1, 1>, pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x2x2x2xf32>, tensor<1x2x2x2xf32>, tensor<1xf32>) -> tensor<1x1x1x1xf32>
     return %0 : tensor<1x1x1x1xf32>
 }

--- a/tests/opts/tosa-to-linalg/conv2d1.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/conv2d1.tgt.mlir
@@ -6,15 +6,15 @@ module  {
     %cst = arith.constant -0.000000e+00 : f32
     %0 = tensor.from_elements %cst : tensor<1xf32>
     %cst_0 = arith.constant dense<[1, 2, 3, 0]> : tensor<4xi64>
-    %1 = linalg.init_tensor [2, 2, 2, 1] : tensor<2x2x2x1xf32>
+    %1 = tensor.empty () : tensor<2x2x2x1xf32>
     %2 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg1 : tensor<1x2x2x2xf32>) outs(%1 : tensor<2x2x2x1xf32>) {
     ^bb0(%arg2: f32, %arg3: f32):  // no predecessors
       linalg.yield %arg2 : f32
     } -> tensor<2x2x2x1xf32>
-    %3 = linalg.init_tensor [1, 1, 1, 1] : tensor<1x1x1x1xf32>
+    %3 = tensor.empty () : tensor<1x1x1x1xf32>
     %cst_1 = arith.constant 0.000000e+00 : f32
     %4 = linalg.fill ins(%cst_1: f32) outs(%3: tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32> 
-    %5 = linalg.init_tensor [1, 1, 1, 1] : tensor<1x1x1x1xf32>
+    %5 = tensor.empty () : tensor<1x1x1x1xf32>
     %6 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %2 : tensor<1x2x2x2xf32>, tensor<2x2x2x1xf32>) outs(%4 : tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
     %7 = linalg.generic {indexing_maps = [#map2, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %6 : tensor<1xf32>, tensor<1x1x1x1xf32>) outs(%5 : tensor<1x1x1x1xf32>) {
     ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):  // no predecessors

--- a/tests/opts/tosa-to-linalg/depthwise1.src.mlir
+++ b/tests/opts/tosa-to-linalg/depthwise1.src.mlir
@@ -5,6 +5,6 @@
 // a non-identity value (+0.0) to the output tensor.
 
 func.func @depthwise1(%arg0: tensor<2x5x5x2xf32>, %arg1: tensor<2x2x2x3xf32>, %arg2: tensor<6xf32>) -> tensor<2x4x4x6xf32> {
-  %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) {pad = [0, 0, 0, 0], stride = [1, 1], dilation = [1, 1]} : (tensor<2x5x5x2xf32>, tensor<2x2x2x3xf32>, tensor<6xf32>) -> tensor<2x4x4x6xf32>
+  %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) {pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, dilation = array<i64: 1, 1>} : (tensor<2x5x5x2xf32>, tensor<2x2x2x3xf32>, tensor<6xf32>) -> tensor<2x4x4x6xf32>
   return %0 : tensor<2x4x4x6xf32>
 }

--- a/tests/opts/tosa-to-linalg/depthwise1.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/depthwise1.tgt.mlir
@@ -2,10 +2,10 @@
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 module  {
   func.func @depthwise1(%arg0: tensor<2x5x5x2xf32>, %arg1: tensor<2x2x2x3xf32>, %arg2: tensor<6xf32>) -> tensor<2x4x4x6xf32> {
-    %0 = linalg.init_tensor [2, 4, 4, 2, 3] : tensor<2x4x4x2x3xf32>
+    %0 = tensor.empty () : tensor<2x4x4x2x3xf32>
     %cst = arith.constant 0.000000e+00 : f32
     %1 = linalg.fill ins(%cst: f32) outs(%0: tensor<2x4x4x2x3xf32>) -> tensor<2x4x4x2x3xf32> 
-    %2 = linalg.init_tensor [2, 4, 4, 6] : tensor<2x4x4x6xf32>
+    %2 = tensor.empty () : tensor<2x4x4x6xf32>
     %3 = linalg.depthwise_conv_2d_nhwc_hwcm {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<2x5x5x2xf32>, tensor<2x2x2x3xf32>) outs(%1 : tensor<2x4x4x2x3xf32>) -> tensor<2x4x4x2x3xf32>
     %4 = tensor.collapse_shape %3 [[0], [1], [2], [3, 4]] : tensor<2x4x4x2x3xf32> into tensor<2x4x4x6xf32>
     %5 = linalg.generic {indexing_maps = [#map0, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg2, %4 : tensor<6xf32>, tensor<2x4x4x6xf32>) outs(%2 : tensor<2x4x4x6xf32>) {

--- a/tests/opts/tosa-to-linalg/depthwise3.src.mlir
+++ b/tests/opts/tosa-to-linalg/depthwise3.src.mlir
@@ -5,6 +5,6 @@
 // a non-identity value (+0.0) to the output tensor.
 
 func.func @depthwise3(%arg0 : tensor<1x11x9x3xf32>, %arg1 : tensor<3x1x3x11xf32>, %arg2 : tensor<33xf32>) -> (tensor<1x5x5x33xf32>) {
-  %2 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) { pad = [0, 0, 0, 0], stride = [2, 2], dilation = [1, 1] } : (tensor<1x11x9x3xf32>, tensor<3x1x3x11xf32>, tensor<33xf32>)  -> (tensor<1x5x5x33xf32>)
+  %2 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) { pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 2, 2>, dilation = array<i64: 1, 1> } : (tensor<1x11x9x3xf32>, tensor<3x1x3x11xf32>, tensor<33xf32>)  -> (tensor<1x5x5x33xf32>)
   return %2 : tensor<1x5x5x33xf32>
 }

--- a/tests/opts/tosa-to-linalg/depthwise3.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/depthwise3.tgt.mlir
@@ -2,10 +2,10 @@
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 module  {
   func.func @depthwise3(%arg0: tensor<1x11x9x3xf32>, %arg1: tensor<3x1x3x11xf32>, %arg2: tensor<33xf32>) -> tensor<1x5x5x33xf32> {
-    %0 = linalg.init_tensor [1, 5, 5, 3, 11] : tensor<1x5x5x3x11xf32>
+    %0 = tensor.empty () : tensor<1x5x5x3x11xf32>
     %cst = arith.constant 0.000000e+00 : f32
     %1 = linalg.fill ins(%cst: f32) outs(%0: tensor<1x5x5x3x11xf32>) -> tensor<1x5x5x3x11xf32> 
-    %2 = linalg.init_tensor [1, 5, 5, 33] : tensor<1x5x5x33xf32>
+    %2 = tensor.empty () : tensor<1x5x5x33xf32>
     %3 = linalg.depthwise_conv_2d_nhwc_hwcm {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x11x9x3xf32>, tensor<3x1x3x11xf32>) outs(%1 : tensor<1x5x5x3x11xf32>) -> tensor<1x5x5x3x11xf32>
     %4 = tensor.collapse_shape %3 [[0], [1], [2], [3, 4]] : tensor<1x5x5x3x11xf32> into tensor<1x5x5x33xf32>
     %5 = linalg.generic {indexing_maps = [#map0, #map1, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg2, %4 : tensor<33xf32>, tensor<1x5x5x33xf32>) outs(%2 : tensor<1x5x5x33xf32>) {

--- a/tests/opts/tosa-to-linalg/fully_connected.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/fully_connected.tgt.mlir
@@ -3,16 +3,16 @@
 #map2 = affine_map<(d0, d1) -> (d1)>
 module  {
   func.func @f(%arg0: tensor<10x3xf32>, %arg1: tensor<6x3xf32>, %arg2: tensor<6xf32>) -> tensor<10x6xf32> {
-    %0 = linalg.init_tensor [10, 6] : tensor<10x6xf32>
+    %0 = tensor.empty () : tensor<10x6xf32>
     %cst = arith.constant 0.000000e+00 : f32
     %1 = linalg.fill ins(%cst: f32) outs(%0: tensor<10x6xf32>) -> tensor<10x6xf32> 
     %cst_0 = arith.constant dense<[1, 0]> : tensor<2xi64>
-    %2 = linalg.init_tensor [3, 6] : tensor<3x6xf32>
+    %2 = tensor.empty () : tensor<3x6xf32>
     %3 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<6x3xf32>) outs(%2 : tensor<3x6xf32>) {
     ^bb0(%arg3: f32, %arg4: f32):  // no predecessors
       linalg.yield %arg3 : f32
     } -> tensor<3x6xf32>
-    %4 = linalg.init_tensor [10, 6] : tensor<10x6xf32>
+    %4 = tensor.empty () : tensor<10x6xf32>
     %5 = linalg.matmul ins(%arg0, %3 : tensor<10x3xf32>, tensor<3x6xf32>) outs(%1 : tensor<10x6xf32>) -> tensor<10x6xf32>
     %6 = linalg.generic {indexing_maps = [#map2, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg2, %5 : tensor<6xf32>, tensor<10x6xf32>) outs(%4 : tensor<10x6xf32>) {
     ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors

--- a/tests/opts/tosa-to-linalg/gather.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/gather.tgt.mlir
@@ -2,7 +2,7 @@
 #map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 module  {
   func.func @gather_float(%arg0: tensor<2x3x2xf32>, %arg1: tensor<2x3xi32>) {
-    %0 = linalg.init_tensor [2, 3, 2] : tensor<2x3x2xf32>
+    %0 = tensor.empty () : tensor<2x3x2xf32>
     %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg1 : tensor<2x3xi32>) outs(%0 : tensor<2x3x2xf32>) {
     ^bb0(%arg2: i32, %arg3: f32):  // no predecessors
       %2 = linalg.index 0 : index

--- a/tests/opts/tosa-to-linalg/mul.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/mul.tgt.mlir
@@ -1,7 +1,7 @@
 #map = affine_map<(d0) -> (d0)>
 module  {
   func.func @f(%arg0: tensor<8xf32>, %arg1: tensor<8xf32>) -> tensor<8xf32> {
-    %0 = linalg.init_tensor [8] : tensor<8xf32>
+    %0 = tensor.empty () : tensor<8xf32>
     %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%arg0, %arg1 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) {
     ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):  // no predecessors
       %2 = arith.mulf %arg2, %arg3 : f32

--- a/tests/opts/tosa-to-linalg/muli.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/muli.tgt.mlir
@@ -1,7 +1,7 @@
 #map = affine_map<(d0) -> (d0)>
 module  {
   func.func @f(%arg0: tensor<8xi32>, %arg1: tensor<8xi32>) -> tensor<8xi32> {
-    %0 = linalg.init_tensor [8] : tensor<8xi32>
+    %0 = tensor.empty () : tensor<8xi32>
     %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%arg0, %arg1 : tensor<8xi32>, tensor<8xi32>) outs(%0 : tensor<8xi32>) {
     ^bb0(%arg2: i32, %arg3: i32, %arg4: i32):  // no predecessors
       %2 = arith.muli %arg2, %arg3 : i32

--- a/tests/opts/tosa-to-linalg/reciprocal.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/reciprocal.tgt.mlir
@@ -1,7 +1,7 @@
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module  {
   func.func @f(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
-    %0 = linalg.init_tensor [10, 10] : tensor<10x10xf32>
+    %0 = tensor.empty () : tensor<10x10xf32>
     %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<10x10xf32>) outs(%0 : tensor<10x10xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
       %cst = arith.constant 1.000000e+00 : f32

--- a/tests/opts/tosa-to-linalg/reduce_sum.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/reduce_sum.tgt.mlir
@@ -2,7 +2,7 @@
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 module  {
   func.func @f(%arg0: tensor<3x4x5xf32>) -> tensor<1x4x5xf32> {
-    %0 = linalg.init_tensor [4, 5] : tensor<4x5xf32>
+    %0 = tensor.empty () : tensor<4x5xf32>
     %cst = arith.constant 0.000000e+00 : f32
     %1 = linalg.fill ins(%cst: f32) outs(%0: tensor<4x5xf32>) -> tensor<4x5xf32> 
     %2 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["reduction", "parallel", "parallel"]} ins(%arg0 : tensor<3x4x5xf32>) outs(%1 : tensor<4x5xf32>) {

--- a/tests/opts/tosa-to-linalg/reduce_sum2.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/reduce_sum2.tgt.mlir
@@ -2,7 +2,7 @@
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 module  {
   func.func @f(%arg0: tensor<3x4x5xf32>) -> tensor<3x1x5xf32> {
-    %0 = linalg.init_tensor [3, 5] : tensor<3x5xf32>
+    %0 = tensor.empty () : tensor<3x5xf32>
     %cst = arith.constant 0.000000e+00 : f32
     %1 = linalg.fill ins(%cst: f32) outs(%0:tensor<3x5xf32>) -> tensor<3x5xf32> 
     %2 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "reduction", "parallel"]} ins(%arg0 : tensor<3x4x5xf32>) outs(%1 : tensor<3x5xf32>) {

--- a/tests/opts/tosa-to-linalg/reduce_sum3.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/reduce_sum3.tgt.mlir
@@ -2,7 +2,7 @@
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 module  {
   func.func @f(%arg0: tensor<3x1000x5xf32>) -> tensor<3x1x5xf32> {
-    %0 = linalg.init_tensor [3, 5] : tensor<3x5xf32>
+    %0 = tensor.empty () : tensor<3x5xf32>
     %cst = arith.constant 0.000000e+00 : f32
     %1 = linalg.fill ins(%cst: f32) outs(%0:tensor<3x5xf32>) -> tensor<3x5xf32> 
     %2 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "reduction", "parallel"]} ins(%arg0 : tensor<3x1000x5xf32>) outs(%1 : tensor<3x5xf32>) {

--- a/tests/opts/tosa-to-linalg/reverse.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/reverse.tgt.mlir
@@ -9,7 +9,7 @@ module  {
     %2 = tensor.dim %arg0, %c2 : tensor<?x?x?xi32>
     %c1_0 = arith.constant 1 : index
     %3 = tensor.dim %arg0, %c1_0 : tensor<?x?x?xi32>
-    %4 = linalg.init_tensor [%0, %1, %2] : tensor<?x?x?xi32>
+    %4 = tensor.empty (%0, %1, %2) : tensor<?x?x?xi32>
     %5 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel", "parallel"]} outs(%4 : tensor<?x?x?xi32>) {
     ^bb0(%arg1: i32):  // no predecessors
       %6 = linalg.index 0 : index

--- a/tests/opts/tosa-to-linalg/tile.src.mlir
+++ b/tests/opts/tosa-to-linalg/tile.src.mlir
@@ -1,8 +1,8 @@
 // VERIFY
 
 func.func @f(%x: tensor<3x3xf32>) -> tensor<6x9xf32> {
-  %a = "tosa.tile"(%x) {multiples = [2, 1]} : (tensor<3x3xf32>)  -> (tensor<6x3xf32>)
-  %b = "tosa.tile"(%a) {multiples = [1, 3]} : (tensor<6x3xf32>)  -> (tensor<6x9xf32>)
+  %a = "tosa.tile"(%x) {multiples = array<i64: 2, 1>} : (tensor<3x3xf32>)  -> (tensor<6x3xf32>)
+  %b = "tosa.tile"(%a) {multiples = array<i64: 1, 3>} : (tensor<6x3xf32>)  -> (tensor<6x9xf32>)
   return %b: tensor<6x9xf32>
 }
 

--- a/tests/opts/tosa-to-linalg/tile.tgt.mlir
+++ b/tests/opts/tosa-to-linalg/tile.tgt.mlir
@@ -2,13 +2,13 @@
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 module  {
   func.func @f(%arg0: tensor<3x3xf32>) -> tensor<6x9xf32> {
-    %0 = linalg.init_tensor [2, 3, 1, 3] : tensor<2x3x1x3xf32>
+    %0 = tensor.empty () : tensor<2x3x1x3xf32>
     %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<3x3xf32>) outs(%0 : tensor<2x3x1x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
       linalg.yield %arg1 : f32
     } -> tensor<2x3x1x3xf32>
     %2 = tensor.collapse_shape %1 [[0, 1, 2], [3]] : tensor<2x3x1x3xf32> into tensor<6x3xf32>
-    %3 = linalg.init_tensor [1, 6, 3, 3] : tensor<1x6x3x3xf32>
+    %3 = tensor.empty () : tensor<1x6x3x3xf32>
     %4 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<6x3xf32>) outs(%3 : tensor<1x6x3x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
       linalg.yield %arg1 : f32


### PR DESCRIPTION
I tried to upgrade the project to the newest MLIR 0w0.
Now it passes complication. 
However `Linalg` dialect removed `InitTensorOp` thus all related tests should be updated.  I tried to update them but I am not quite sure about finding a substitute op. Maybe [tensor.empty](https://mlir.llvm.org/docs/Dialects/TensorOps/#tensorempty-mlirtensoremptyop) ? 

Thanks!
